### PR TITLE
Support external plugin config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 GitHub Sync is a Paperclip plugin that connects GitHub repositories to Paperclip projects and keeps GitHub issues synchronized into your Paperclip workspace.
 
-It is designed for teams that plan in Paperclip but still receive work through GitHub issues. The plugin gives you a Paperclip-native setup flow, secure GitHub token handling through Paperclip secrets, authenticated-deployment detection with required board-access connection when needed, manual sync controls, automatic background sync, and GitHub context directly on synced Paperclip issues.
+It is designed for teams that plan in Paperclip but still receive work through GitHub issues. The plugin gives you a Paperclip-native setup flow, secure GitHub token handling through Paperclip secrets or an optional local worker config file, authenticated-deployment detection with required board-access connection when needed, manual sync controls, automatic background sync, and GitHub context directly on synced Paperclip issues.
 
 ## What the plugin does
 
@@ -10,6 +10,7 @@ It is designed for teams that plan in Paperclip but still receive work through G
 - Imports GitHub issues as top-level Paperclip issues.
 - Keeps already imported issues updated instead of recreating them.
 - Stores the GitHub token as a Paperclip secret reference instead of persisting the raw token in plugin state.
+- Supports an optional worker-local config file at `~/.paperclip/plugins/github-sync/config.json` for a raw `githubToken` fallback when Paperclip-managed secrets are not available.
 - Can store a per-company Paperclip board API token for worker-side REST calls when Paperclip board access requires sign-in.
 - Adds Paperclip UI surfaces for setup, sync status, manual sync actions, issue details, and GitHub link annotations.
 
@@ -20,6 +21,7 @@ It is designed for teams that plan in Paperclip but still receive work through G
 - Hosted settings page inside Paperclip.
 - GitHub token validation before saving.
 - GitHub token saved through Paperclip company secrets; the plugin stores only the secret reference.
+- Optional worker-local config file support at `~/.paperclip/plugins/github-sync/config.json` with a `githubToken` field for global runtime fallback.
 - GitHub token and automatic sync cadence stay shared across the plugin instance, while repository mappings and Paperclip board access are managed per company from the same hosted settings flow.
 - The hosted settings page calls out the current company by name and separates company-scoped setup from shared plugin-wide settings.
 - Automatic detection of authenticated Paperclip deployments through `/api/health`.
@@ -89,6 +91,7 @@ It is designed for teams that plan in Paperclip but still receive work through G
 ### Resilience and safety
 
 - Raw GitHub tokens are never persisted in plugin state.
+- Raw GitHub tokens loaded from `~/.paperclip/plugins/github-sync/config.json` stay worker-local and are never returned by public data endpoints.
 - Raw Paperclip board tokens are never persisted in plugin state or plugin config.
 - Scheduled sync skips runs that are not due yet.
 - Incomplete setup is surfaced as configuration guidance instead of silently failing.
@@ -124,6 +127,24 @@ npx paperclip plugin install --local "$PWD"
 
 If you are installing into an isolated local Paperclip instance for testing, include the Paperclip CLI flags you normally use for `--data-dir` and `--config`.
 
+## Optional external worker config
+
+If the Paperclip host cannot provide the GitHub token through environment variables or plugin config, the worker can also read an optional local file:
+
+```json
+{
+  "githubToken": "ghp_your_token_here"
+}
+```
+
+Save it at `~/.paperclip/plugins/github-sync/config.json`.
+
+Notes:
+
+- This file is read by the worker only.
+- The raw token is not persisted into plugin state or plugin config.
+- A GitHub token secret saved through the Paperclip settings UI still takes precedence over the external file.
+
 ## First-time setup in Paperclip
 
 1. Open Paperclip instance settings and go to the plugin settings for **GitHub Sync** from inside the company you want to configure.
@@ -146,7 +167,7 @@ Imported issues stay linked to GitHub and continue to receive description, label
 ## Troubleshooting notes
 
 - If one company’s mappings disappear after saving another company’s setup, reopen plugin settings inside the affected company and confirm each company’s mappings separately; the settings page now keeps those mapping lists isolated per company.
-- If sync says setup is incomplete, confirm that a validated token has been saved, at least one repository mapping has a created Paperclip project, and authenticated deployments have connected Paperclip board access for the current company.
+- If sync says setup is incomplete, confirm that either a validated token secret has been saved or `~/.paperclip/plugins/github-sync/config.json` contains `githubToken`, at least one repository mapping has a created Paperclip project, and authenticated deployments have connected Paperclip board access for the current company.
 - If token validation fails, confirm the token is still valid and can access the target repositories through the GitHub API.
 - If the dashboard, toolbar, or settings page says board access is required, open plugin settings inside the target company and complete the Paperclip board access approval flow before retrying sync.
 - If sync reports that the Paperclip API returned an authenticated HTML page instead of JSON, the worker is reaching a board URL that requires the browser login session. Connect Paperclip board access from plugin settings for that company, or set `PAPERCLIP_API_URL` for the Paperclip worker to a worker-accessible Paperclip API origin, then rerun sync.

--- a/SPEC.md
+++ b/SPEC.md
@@ -7,6 +7,7 @@ GitHub Sync is a Paperclip plugin for registering one or more GitHub repositorie
 The plugin MUST provide a settings page inside Paperclip where an operator can configure:
 
 - a GitHub token stored as a Paperclip secret reference
+- an optional external config file at `~/.paperclip/plugins/github-sync/config.json` for worker-only global values such as a raw `githubToken`
 - Paperclip board access, which is optional on unauthenticated deployments and required when the Paperclip deployment reports `deploymentMode: "authenticated"`
 - one or more GitHub repository mappings
 - the frequency for automatic scheduled sync runs
@@ -26,6 +27,7 @@ The settings page MUST allow saving mappings and triggering a manual sync.
 - Saving a token from the settings UI MUST create or reuse a company secret through the Paperclip host API.
 - The plugin MUST persist only the resulting secret UUID in plugin instance config.
 - The worker MUST resolve that secret UUID at runtime via `ctx.secrets.resolve(...)`.
+- If `~/.paperclip/plugins/github-sync/config.json` exists and contains a string `githubToken`, the worker MUST treat it as a worker-only fallback source for the GitHub token without persisting or returning that raw token.
 - The raw Paperclip board API token MUST NOT be persisted in plugin state.
 - Connecting Paperclip board access from the settings UI MUST create or reuse a company secret through the Paperclip host API and MUST persist only the resulting secret UUID, keyed by company in plugin state and mirrored into plugin instance config so the worker can resolve it.
 - The worker MUST resolve the saved Paperclip board token secret at runtime via `ctx.secrets.resolve(...)` before making direct Paperclip REST calls for that company, and MUST treat plugin config as the worker-readable source of truth for those secret refs.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,3 +1,6 @@
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { Octokit } from '@octokit/rest';
 import { definePlugin, runWorker, type Issue } from '@paperclipai/plugin-sdk';
 
@@ -26,8 +29,9 @@ const MANUAL_SYNC_RESPONSE_GRACE_PERIOD_MS = 500;
 const RUNNING_SYNC_MESSAGE = 'GitHub sync is running in the background. This page will update when it finishes.';
 const SYNC_PROGRESS_PERSIST_INTERVAL_MS = 250;
 const GITHUB_SECONDARY_RATE_LIMIT_FALLBACK_MS = 60_000;
-const MISSING_GITHUB_TOKEN_SYNC_MESSAGE = 'Configure a GitHub token secret before running sync.';
-const MISSING_GITHUB_TOKEN_SYNC_ACTION = 'Open settings, add a GitHub token secret, validate it, and then run sync again.';
+const MISSING_GITHUB_TOKEN_SYNC_MESSAGE = 'Configure a GitHub token before running sync.';
+const MISSING_GITHUB_TOKEN_SYNC_ACTION =
+  'Open settings and save a GitHub token secret, or create ~/.paperclip/plugins/github-sync/config.json with a "githubToken" value, and then run sync again.';
 const MISSING_MAPPING_SYNC_MESSAGE = 'Save at least one mapping with a created Paperclip project before running sync.';
 const MISSING_MAPPING_SYNC_ACTION =
   'Open settings, add a repository mapping, let Paperclip create the target project, and then retry sync.';
@@ -37,6 +41,7 @@ const MISSING_BOARD_ACCESS_SYNC_ACTION =
   'Open plugin settings for each mapped company that sync will touch, connect Paperclip board access, approve the flow, and then run sync again.';
 const ISSUE_LINK_ENTITY_TYPE = 'paperclip-github-plugin.issue-link';
 const COMMENT_ANNOTATION_ENTITY_TYPE = 'paperclip-github-plugin.comment-annotation';
+const EXTERNAL_CONFIG_FILE_PATH_SEGMENTS = ['.paperclip', 'plugins', 'github-sync', 'config.json'] as const;
 
 type PluginSetupContext = Parameters<Parameters<typeof definePlugin>[0]['setup']>[0];
 type PaperclipIssueStatus = Issue['status'];
@@ -248,7 +253,13 @@ interface GitHubSyncSettings {
 
 interface GitHubSyncConfig {
   githubTokenRef?: string;
+  githubToken?: string;
   paperclipBoardApiTokenRefs?: PaperclipBoardApiTokenRefs;
+}
+
+interface ResolvedGitHubTokenSource {
+  secretRef?: string;
+  token?: string;
 }
 
 function normalizeCompanyId(value: unknown): string | undefined {
@@ -258,6 +269,7 @@ function normalizeCompanyId(value: unknown): string | undefined {
 let activeSyncPromise: Promise<GitHubSyncSettings> | null = null;
 let activeRunningSyncState: GitHubSyncSettings | null = null;
 let activePaperclipApiAuthTokensByCompanyId: Map<string, string> | null = null;
+let activeExternalConfigWarningKey: string | null = null;
 
 class PaperclipLabelSyncError extends Error {
   readonly name = 'PaperclipLabelSyncError';
@@ -2120,10 +2132,99 @@ function normalizeConfig(value: unknown): GitHubSyncConfig {
   }
 
   const record = value as Record<string, unknown>;
+  const githubTokenRef = normalizeGitHubTokenRef(record.githubTokenRef);
+  const githubToken = normalizeGitHubToken(record.githubToken);
+  const paperclipBoardApiTokenRefs = normalizePaperclipBoardApiTokenRefs(record.paperclipBoardApiTokenRefs);
+
   return {
-    githubTokenRef: typeof record.githubTokenRef === 'string' ? record.githubTokenRef : undefined,
-    paperclipBoardApiTokenRefs: normalizePaperclipBoardApiTokenRefs(record.paperclipBoardApiTokenRefs)
+    ...(githubTokenRef ? { githubTokenRef } : {}),
+    ...(githubToken ? { githubToken } : {}),
+    ...(paperclipBoardApiTokenRefs ? { paperclipBoardApiTokenRefs } : {})
   };
+}
+
+function normalizeGitHubToken(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function getExternalConfigFilePath(): string | undefined {
+  const homeDirectory = getHomeDirectory();
+  return homeDirectory ? join(homeDirectory, ...EXTERNAL_CONFIG_FILE_PATH_SEGMENTS) : undefined;
+}
+
+function getHomeDirectory(): string | undefined {
+  try {
+    const resolvedHomeDirectory = homedir();
+    return typeof resolvedHomeDirectory === 'string' && resolvedHomeDirectory.trim()
+      ? resolvedHomeDirectory
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function warnOnceAboutExternalConfig(
+  ctx: PluginSetupContext,
+  warningKey: string,
+  message: string,
+  metadata: Record<string, unknown>
+): void {
+  if (activeExternalConfigWarningKey === warningKey) {
+    return;
+  }
+
+  activeExternalConfigWarningKey = warningKey;
+  ctx.logger.warn(message, metadata);
+}
+
+async function readExternalConfig(ctx: PluginSetupContext): Promise<GitHubSyncConfig> {
+  const externalConfigFilePath = getExternalConfigFilePath();
+  if (!externalConfigFilePath) {
+    activeExternalConfigWarningKey = null;
+    return {};
+  }
+
+  try {
+    const rawConfig = await readFile(externalConfigFilePath, 'utf8');
+    const parsedConfig = JSON.parse(rawConfig) as unknown;
+    activeExternalConfigWarningKey = null;
+    return normalizeConfig(parsedConfig);
+  } catch (error) {
+    const errorCode = error && typeof error === 'object' && 'code' in error ? (error as { code?: unknown }).code : undefined;
+    if (errorCode === 'ENOENT') {
+      activeExternalConfigWarningKey = null;
+      return {};
+    }
+
+    if (error instanceof SyntaxError) {
+      warnOnceAboutExternalConfig(
+        ctx,
+        `syntax:${externalConfigFilePath}`,
+        'Ignoring the GitHub Sync external config file because it is not valid JSON.',
+        {
+          filePath: externalConfigFilePath,
+          error: error.message
+        }
+      );
+      return {};
+    }
+
+    warnOnceAboutExternalConfig(
+      ctx,
+      `read:${externalConfigFilePath}:${String(errorCode ?? 'unknown')}`,
+      'Ignoring the GitHub Sync external config file because it could not be read.',
+      {
+        filePath: externalConfigFilePath,
+        error: getErrorMessage(error)
+      }
+    );
+    return {};
+  }
 }
 
 function normalizePaperclipBoardApiTokenRefs(value: unknown): PaperclipBoardApiTokenRefs | undefined {
@@ -5570,21 +5671,43 @@ async function synchronizePaperclipIssueStatuses(
 }
 
 async function getResolvedConfig(ctx: PluginSetupContext): Promise<GitHubSyncConfig> {
-  return normalizeConfig(await ctx.config.get());
+  const [savedConfig, externalConfig] = await Promise.all([
+    ctx.config.get(),
+    readExternalConfig(ctx)
+  ]);
+
+  return {
+    ...externalConfig,
+    ...normalizeConfig(savedConfig)
+  };
+}
+
+function getConfiguredGithubTokenSource(
+  settings: Pick<GitHubSyncSettings, 'githubTokenRef'> | null | undefined,
+  config: GitHubSyncConfig
+): ResolvedGitHubTokenSource {
+  const secretRef = normalizeGitHubTokenRef(config.githubTokenRef) ?? normalizeGitHubTokenRef(settings?.githubTokenRef);
+  if (secretRef) {
+    return { secretRef };
+  }
+
+  const token = normalizeGitHubToken(config.githubToken);
+  return token ? { token } : {};
 }
 
 function getConfiguredGithubTokenRef(
   settings: Pick<GitHubSyncSettings, 'githubTokenRef'> | null | undefined,
   config: GitHubSyncConfig
 ): string | undefined {
-  return normalizeGitHubTokenRef(config.githubTokenRef) ?? normalizeGitHubTokenRef(settings?.githubTokenRef);
+  return getConfiguredGithubTokenSource(settings, config).secretRef;
 }
 
 function hasConfiguredGithubToken(
   settings: Pick<GitHubSyncSettings, 'githubTokenRef'> | null | undefined,
   config: GitHubSyncConfig
 ): boolean {
-  return Boolean(getConfiguredGithubTokenRef(settings, config));
+  const configuredTokenSource = getConfiguredGithubTokenSource(settings, config);
+  return Boolean(configuredTokenSource.secretRef ?? configuredTokenSource.token);
 }
 
 function getSavedPaperclipBoardApiTokenRef(
@@ -5712,12 +5835,12 @@ async function resolvePaperclipApiAuthTokens(
 async function resolveGithubToken(ctx: PluginSetupContext): Promise<string> {
   const settings = normalizeSettings(await ctx.state.get(SETTINGS_SCOPE));
   const config = await getResolvedConfig(ctx);
-  const secretRef = getConfiguredGithubTokenRef(settings, config) ?? '';
-  if (!secretRef) {
-    return '';
+  const configuredTokenSource = getConfiguredGithubTokenSource(settings, config);
+  if (configuredTokenSource.secretRef) {
+    return ctx.secrets.resolve(configuredTokenSource.secretRef);
   }
 
-  return ctx.secrets.resolve(secretRef);
+  return configuredTokenSource.token ?? '';
 }
 
 async function validateGithubToken(token: string): Promise<TokenValidationResult> {
@@ -6419,6 +6542,7 @@ const plugin = definePlugin({
       const normalizedSettings = normalizeSettings(saved);
       const config = await getResolvedConfig(ctx);
       const githubTokenRef = getConfiguredGithubTokenRef(normalizedSettings, config);
+      const githubTokenConfigured = hasConfiguredGithubToken(normalizedSettings, config);
       const configuredBoardTokenRef = getConfiguredPaperclipBoardApiTokenRef(config, requestedCompanyId);
       const savedBoardTokenRef = getSavedPaperclipBoardApiTokenRef(normalizedSettings, requestedCompanyId);
       const settingsWithResolvedToken = githubTokenRef === normalizedSettings.githubTokenRef
@@ -6427,7 +6551,6 @@ const plugin = definePlugin({
             ...normalizedSettings,
             ...(githubTokenRef ? { githubTokenRef } : {})
           };
-      const githubTokenConfigured = Boolean(githubTokenRef);
       const settingsForResponse = sanitizeSettingsForCurrentSetup(settingsWithResolvedToken, {
         hasToken: githubTokenConfigured,
         hasMappings: getSyncableMappings(settingsWithResolvedToken.mappings).length > 0
@@ -6516,7 +6639,7 @@ const plugin = definePlugin({
         ...(githubTokenRef ? { githubTokenRef } : {}),
         updatedAt: new Date().toISOString()
       }, {
-        hasToken: Boolean(normalizeGitHubTokenRef(config.githubTokenRef) ?? githubTokenRef),
+        hasToken: hasConfiguredGithubToken({ githubTokenRef }, config),
         hasMappings: getSyncableMappings(nextMappings).length > 0
       });
 

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -1,4 +1,7 @@
 import { strict as assert } from 'node:assert';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import test from 'node:test';
 
 import { createTestHarness } from '@paperclipai/plugin-sdk/testing';
@@ -146,6 +149,33 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => {
     globalThis.setTimeout(resolve, ms);
   });
+}
+
+async function withExternalPluginConfig<T>(
+  config: Record<string, unknown>,
+  run: () => Promise<T>
+): Promise<T> {
+  const temporaryHomeDirectory = await mkdtemp(join(tmpdir(), 'paperclip-github-plugin-'));
+  const configDirectory = join(temporaryHomeDirectory, '.paperclip', 'plugins', 'github-sync');
+  const configFilePath = join(configDirectory, 'config.json');
+  const previousHome = process.env.HOME;
+
+  await mkdir(configDirectory, { recursive: true });
+  await writeFile(configFilePath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+
+  process.env.HOME = temporaryHomeDirectory;
+
+  try {
+    return await run();
+  } finally {
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
+
+    await rm(temporaryHomeDirectory, { recursive: true, force: true });
+  }
 }
 
 interface PublicGitHubIssueFixture {
@@ -1166,6 +1196,33 @@ test('settings.registration reports a configured token without resolving the sav
   assert.equal(result.githubTokenConfigured, true);
   assert.equal(result.syncState?.status, 'idle');
   assert.equal(resolveCount, 0);
+});
+
+test('settings.registration reports a configured token from the external config file without resolving secrets', { concurrency: false }, async () => {
+  await withExternalPluginConfig(
+    {
+      githubToken: 'ghp_external_token'
+    },
+    async () => {
+      const harness = createTestHarness({ manifest });
+      await plugin.definition.setup(harness.ctx);
+
+      let resolveCount = 0;
+      harness.ctx.secrets.resolve = async () => {
+        resolveCount += 1;
+        throw new Error('Secret resolution should not happen for settings data.');
+      };
+
+      const result = await harness.getData<{
+        githubTokenConfigured?: boolean;
+        syncState?: { status?: string };
+      }>('settings.registration');
+
+      assert.equal(result.githubTokenConfigured, true);
+      assert.equal(result.syncState?.status, 'idle');
+      assert.equal(resolveCount, 0);
+    }
+  );
 });
 
 test('settings.registration reports company-specific board access without resolving the saved secret', async () => {
@@ -5907,7 +5964,7 @@ test('worker reports sync error when configuration is incomplete', async () => {
   };
 
   assert.equal(result.syncState.status, 'error');
-  assert.equal(result.syncState.message, 'Configure a GitHub token secret before running sync.');
+  assert.equal(result.syncState.message, 'Configure a GitHub token before running sync.');
   assert.equal(result.syncState.lastRunTrigger, 'manual');
 });
 
@@ -5933,6 +5990,33 @@ test('sync.runNow falls back to the saved githubTokenRef when config has not pro
   assert.equal(result.syncState.status, 'error');
   assert.equal(result.syncState.message, 'Save at least one mapping with a created Paperclip project before running sync.');
   assert.equal(result.syncState.lastRunTrigger, 'manual');
+});
+
+test('sync.runNow falls back to the external config file token when no secret ref is configured', { concurrency: false }, async () => {
+  await withExternalPluginConfig(
+    {
+      githubToken: 'ghp_external_token'
+    },
+    async () => {
+      const harness = createTestHarness({ manifest });
+      await plugin.definition.setup(harness.ctx);
+
+      let resolveCount = 0;
+      harness.ctx.secrets.resolve = async () => {
+        resolveCount += 1;
+        throw new Error('Secret resolution should not happen when using the external config file token.');
+      };
+
+      const result = await harness.performAction('sync.runNow', {}) as {
+        syncState: { status: string; message?: string; lastRunTrigger?: string };
+      };
+
+      assert.equal(resolveCount, 0);
+      assert.equal(result.syncState.status, 'error');
+      assert.equal(result.syncState.message, 'Save at least one mapping with a created Paperclip project before running sync.');
+      assert.equal(result.syncState.lastRunTrigger, 'manual');
+    }
+  );
 });
 
 test('sync.runNow scopes a company-level manual sync to the requested company', async () => {
@@ -6079,12 +6163,13 @@ test('settings registration clears legacy setup errors once the missing token is
       mappings: [],
       syncState: {
         status: 'error',
-        message: 'Configure a GitHub token secret before running sync.',
+        message: 'Configure a GitHub token before running sync.',
         checkedAt: '2026-04-10T10:58:17.000Z',
         lastRunTrigger: 'schedule',
         errorDetails: {
           phase: 'configuration',
-          suggestedAction: 'Open settings, add a GitHub token secret, validate it, and then run sync again.'
+          suggestedAction:
+            'Open settings and save a GitHub token secret, or create ~/.paperclip/plugins/github-sync/config.json with a "githubToken" value, and then run sync again.'
         }
       },
       scheduleFrequencyMinutes: 15
@@ -6146,12 +6231,13 @@ test('saving setup clears stale setup errors instead of resaving them from the U
       mappings: [],
       syncState: {
         status: 'error',
-        message: 'Configure a GitHub token secret before running sync.',
+        message: 'Configure a GitHub token before running sync.',
         checkedAt: '2026-04-10T10:58:17.000Z',
         lastRunTrigger: 'schedule',
         errorDetails: {
           phase: 'configuration',
-          suggestedAction: 'Open settings, add a GitHub token secret, validate it, and then run sync again.'
+          suggestedAction:
+            'Open settings and save a GitHub token secret, or create ~/.paperclip/plugins/github-sync/config.json with a "githubToken" value, and then run sync again.'
         }
       },
       scheduleFrequencyMinutes: 15
@@ -6170,12 +6256,13 @@ test('saving setup clears stale setup errors instead of resaving them from the U
     ],
     syncState: {
       status: 'error',
-      message: 'Configure a GitHub token secret before running sync.',
+      message: 'Configure a GitHub token before running sync.',
       checkedAt: '2026-04-10T10:58:17.000Z',
       lastRunTrigger: 'schedule',
       errorDetails: {
         phase: 'configuration',
-        suggestedAction: 'Open settings, add a GitHub token secret, validate it, and then run sync again.'
+        suggestedAction:
+          'Open settings and save a GitHub token secret, or create ~/.paperclip/plugins/github-sync/config.json with a "githubToken" value, and then run sync again.'
       }
     }
   }) as {


### PR DESCRIPTION
## Summary
- add a worker-only fallback config file at `~/.paperclip/plugins/github-sync/config.json`
- use a raw `githubToken` from that file when no Paperclip secret ref is configured
- document and test the new fallback behavior

## Testing
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Model Used
- OpenAI Codex desktop agent, GPT-5-based coding model; the exact internal model ID/version is not exposed in this runtime.
- Context window size is not exposed in this runtime.
- Relevant capabilities: repository-aware code editing, terminal tool use, test execution, and iterative debugging.
