### PR TITLE
Add sync setup for existing GitHub-linked projects and seed manual verify fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Imported issues stay linked to GitHub and continue to receive description, label
 - `pnpm dev:ui` starts a local Paperclip plugin UI dev server from `dist/ui` on port `4177`.
 - `pnpm test:e2e` builds the plugin, boots an isolated Paperclip instance, installs the plugin, and verifies the hosted settings page renders.
 - `pnpm verify:manual` builds the plugin, boots a Paperclip instance for manual inspection, seeds a project already mapped to `https://github.com/alvarosanchez/paperclip-github-plugin`, seeds a `CEO` agent on the Codex local adapter with model `gpt-5.4`, and opens the plugin settings page.
+- Set `PAPERCLIP_E2E_CEO_BYPASS_APPROVALS_AND_SANDBOX=true` if you want that seeded `CEO` agent to opt into Codex's bypass flag during manual verification.
 
 For fast hosted-UI iteration, run `pnpm dev` in one terminal and `pnpm dev:ui` in another.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ It is designed for teams that plan in Paperclip but still receive work through G
 - Support for multiple repository-to-project mappings.
 - When settings are opened inside a company, the repository list only shows that company’s mappings and saving it preserves mappings that belong to other companies.
 - Repository input accepts either `owner/repo` or `https://github.com/owner/repo`.
+- When a company already has Paperclip projects bound to GitHub repository workspaces, the settings page surfaces those existing projects so sync can be enabled without recreating the project.
 - Automatic creation or reuse of the target Paperclip project when a mapping is saved.
 - Automatic binding of the GitHub repository URL to the target Paperclip project workspace.
 - Configurable automatic sync cadence in whole minutes.
@@ -152,7 +153,7 @@ Notes:
 3. Save the validated token so Paperclip can store it as a secret reference.
 4. If the settings page reports that this Paperclip deployment requires board access, connect **Paperclip board access** from the same settings page and approve the new tab that opens.
 5. Add one or more repository mappings for the current company.
-6. For each mapping, enter a GitHub repository and the Paperclip project name that should receive synced issues.
+6. For each mapping, either enable sync for an existing GitHub-linked Paperclip project or enter a GitHub repository and the Paperclip project name that should receive synced issues.
 7. Choose the automatic sync interval in minutes.
 8. Save the settings.
 9. Repeat inside any other Paperclip companies that should have their own mappings or board access.
@@ -183,7 +184,7 @@ Imported issues stay linked to GitHub and continue to receive description, label
 - `pnpm dev` watches the manifest, worker, and UI bundles and rebuilds them into `dist/`.
 - `pnpm dev:ui` starts a local Paperclip plugin UI dev server from `dist/ui` on port `4177`.
 - `pnpm test:e2e` builds the plugin, boots an isolated Paperclip instance, installs the plugin, and verifies the hosted settings page renders.
-- `pnpm verify:manual` builds the plugin, boots a Paperclip instance for manual inspection, and opens the plugin settings page.
+- `pnpm verify:manual` builds the plugin, boots a Paperclip instance for manual inspection, seeds a project already mapped to `https://github.com/alvarosanchez/paperclip-github-plugin`, and opens the plugin settings page.
 
 For fast hosted-UI iteration, run `pnpm dev` in one terminal and `pnpm dev:ui` in another.
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Imported issues stay linked to GitHub and continue to receive description, label
 - `pnpm dev` watches the manifest, worker, and UI bundles and rebuilds them into `dist/`.
 - `pnpm dev:ui` starts a local Paperclip plugin UI dev server from `dist/ui` on port `4177`.
 - `pnpm test:e2e` builds the plugin, boots an isolated Paperclip instance, installs the plugin, and verifies the hosted settings page renders.
-- `pnpm verify:manual` builds the plugin, boots a Paperclip instance for manual inspection, seeds a project already mapped to `https://github.com/alvarosanchez/paperclip-github-plugin`, and opens the plugin settings page.
+- `pnpm verify:manual` builds the plugin, boots a Paperclip instance for manual inspection, seeds a project already mapped to `https://github.com/alvarosanchez/paperclip-github-plugin`, seeds a `CEO` agent on the Codex local adapter with model `gpt-5.4`, and opens the plugin settings page.
 
 For fast hosted-UI iteration, run `pnpm dev` in one terminal and `pnpm dev:ui` in another.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -11,12 +11,13 @@ The plugin MUST provide a settings page inside Paperclip where an operator can c
 - Paperclip board access, which is optional on unauthenticated deployments and required when the Paperclip deployment reports `deploymentMode: "authenticated"`
 - one or more GitHub repository mappings
 - the frequency for automatic scheduled sync runs
-- a Paperclip project name per mapping where synchronized issues should be created
+- a Paperclip project name per mapping where synchronized issues should be created, including existing Paperclip projects that are already bound to a GitHub repository workspace
 
 The settings page MUST allow saving mappings and triggering a manual sync.
 - When the settings page is opened with a Paperclip company context, it MUST only display and save repository mappings for that company, and saving one company’s mappings MUST preserve mappings that belong to other companies.
 - The settings page SHOULD clearly label company-scoped setup versus plugin-instance-wide setup when both are shown together.
 - When a company context is present, the settings page SHOULD show the active company name prominently using a human-friendly label instead of a raw identifier.
+- When a company already has Paperclip projects bound to GitHub repository workspaces, the settings page SHOULD surface those projects so an operator can enable sync without recreating the project.
 - The plugin SHOULD also expose manual sync entry points from Paperclip toolbar surfaces when the SDK supports them.
 - When a manual sync will outlive a quick action response, the worker MUST persist a `running` sync state immediately and complete the sync asynchronously.
 - The settings page, dashboard widget, and sync toolbar surfaces SHOULD detect authenticated deployments from `/api/health` and MUST require connected Paperclip board access before enabling sync for the affected company.
@@ -75,6 +76,7 @@ The plugin MUST persist repository mappings and sync state in plugin state.
 
 - Saving a mapping MUST create or reuse the target Paperclip project.
 - Saving a company-scoped mapping from the settings page MUST create or reuse the target Paperclip project in that same company.
+- Saving a mapping for a Paperclip project that is already bound to the GitHub repository MUST reuse that existing project instead of creating a duplicate workspace binding.
 - Saving a mapping MUST bind the GitHub repository URL to the Paperclip project workspace.
 - Once a project has been created and linked, its project name field SHOULD be treated as read-only in the settings UI.
 

--- a/scripts/e2e/manual-paperclip-verify.mjs
+++ b/scripts/e2e/manual-paperclip-verify.mjs
@@ -19,6 +19,7 @@ const seededProjectName = 'Paperclip Github Plugin';
 const seededRepositoryUrl = 'https://github.com/alvarosanchez/paperclip-github-plugin';
 const seededAgentName = 'CEO';
 const seededAgentModel = 'gpt-5.4';
+const seedAgentBypassApprovalsAndSandbox = process.env.PAPERCLIP_E2E_CEO_BYPASS_APPROVALS_AND_SANDBOX === 'true';
 const requestedPort = process.env.PAPERCLIP_E2E_PORT ? Number(process.env.PAPERCLIP_E2E_PORT) : 3100;
 const requestedDbPort = process.env.PAPERCLIP_E2E_DB_PORT ? Number(process.env.PAPERCLIP_E2E_DB_PORT) : 54329;
 const env = {
@@ -366,7 +367,7 @@ async function ensureSeedAgent(company) {
     adapterType: 'codex_local',
     adapterConfig: {
       model: seededAgentModel,
-      dangerouslyBypassApprovalsAndSandbox: true
+      dangerouslyBypassApprovalsAndSandbox: seedAgentBypassApprovalsAndSandbox
     }
   };
 
@@ -375,7 +376,7 @@ async function ensureSeedAgent(company) {
       method: 'PATCH',
       body: JSON.stringify(agentPayload)
     });
-    log(`Updated seeded agent ${seededAgentName} to use Codex ${seededAgentModel}.`);
+    log(`Updated seeded agent ${seededAgentName} to use Codex ${seededAgentModel}${seedAgentBypassApprovalsAndSandbox ? ' with bypass enabled' : ''}.`);
     return;
   }
 
@@ -383,7 +384,7 @@ async function ensureSeedAgent(company) {
     method: 'POST',
     body: JSON.stringify(agentPayload)
   });
-  log(`Seeded agent ${seededAgentName} using Codex ${seededAgentModel}.`);
+  log(`Seeded agent ${seededAgentName} using Codex ${seededAgentModel}${seedAgentBypassApprovalsAndSandbox ? ' with bypass enabled' : ''}.`);
 }
 
 async function waitForServerExit(timeoutMs) {

--- a/scripts/e2e/manual-paperclip-verify.mjs
+++ b/scripts/e2e/manual-paperclip-verify.mjs
@@ -15,6 +15,8 @@ const stateRoot = persistentStateRoot ?? await mkdtemp(join(tmpdir(), 'paperclip
 const paperclipHome = join(stateRoot, 'paperclip-home');
 const dataDir = join(stateRoot, 'paperclip-data');
 const instanceId = 'paperclip-github-plugin-manual';
+const seededProjectName = 'Paperclip Github Plugin';
+const seededRepositoryUrl = 'https://github.com/alvarosanchez/paperclip-github-plugin';
 const requestedPort = process.env.PAPERCLIP_E2E_PORT ? Number(process.env.PAPERCLIP_E2E_PORT) : 3100;
 const requestedDbPort = process.env.PAPERCLIP_E2E_DB_PORT ? Number(process.env.PAPERCLIP_E2E_DB_PORT) : 54329;
 const env = {
@@ -282,6 +284,59 @@ async function ensurePluginInstalled(configPath) {
   }
 }
 
+async function ensureSeedProjectMapped(company) {
+  const companyId = typeof company?.id === 'string' ? company.id : '';
+  if (!companyId) {
+    throw new Error('A seeded company id is required before creating the manual verification project.');
+  }
+
+  const projects = await fetchJson(new URL(`/api/companies/${companyId}/projects`, baseUrl).toString());
+  const existingProject =
+    Array.isArray(projects)
+      ? projects.find((entry) =>
+          entry
+          && typeof entry === 'object'
+          && typeof entry.id === 'string'
+          && typeof entry.name === 'string'
+          && entry.name.trim().toLowerCase() === seededProjectName.toLowerCase()
+        )
+      : null;
+
+  const project = existingProject ?? await fetchJson(new URL(`/api/companies/${companyId}/projects`, baseUrl).toString(), {
+    method: 'POST',
+    body: JSON.stringify({
+      name: seededProjectName,
+      status: 'planned'
+    })
+  });
+  const projectId = typeof project?.id === 'string' ? project.id : '';
+  if (!projectId) {
+    throw new Error('Paperclip did not return a usable project id for the manual verification seed project.');
+  }
+
+  const workspaces = await fetchJson(new URL(`/api/projects/${projectId}/workspaces`, baseUrl).toString());
+  const alreadyMapped =
+    Array.isArray(workspaces)
+      && workspaces.some((entry) =>
+        entry
+        && typeof entry === 'object'
+        && typeof entry.repoUrl === 'string'
+        && entry.repoUrl.trim().replace(/\.git$/, '') === seededRepositoryUrl
+      );
+  if (!alreadyMapped) {
+    await fetchJson(new URL(`/api/projects/${projectId}/workspaces`, baseUrl).toString(), {
+      method: 'POST',
+      body: JSON.stringify({
+        repoUrl: seededRepositoryUrl,
+        sourceType: 'git_repo',
+        isPrimary: true
+      })
+    });
+  }
+
+  log(`Seeded project ${seededProjectName} mapped to ${seededRepositoryUrl}.`);
+}
+
 async function waitForServerExit(timeoutMs) {
   if (!serverProcess) {
     return;
@@ -379,6 +434,7 @@ async function main() {
   log(`Paperclip server is ready at ${baseUrl}.`);
 
   const company = await ensureCompanySeeded();
+  await ensureSeedProjectMapped(company);
   await ensurePluginInstalled(configPath);
 
   const manualUrl = `${baseUrl}/settings/plugins`;

--- a/scripts/e2e/manual-paperclip-verify.mjs
+++ b/scripts/e2e/manual-paperclip-verify.mjs
@@ -17,6 +17,8 @@ const dataDir = join(stateRoot, 'paperclip-data');
 const instanceId = 'paperclip-github-plugin-manual';
 const seededProjectName = 'Paperclip Github Plugin';
 const seededRepositoryUrl = 'https://github.com/alvarosanchez/paperclip-github-plugin';
+const seededAgentName = 'CEO';
+const seededAgentModel = 'gpt-5.4';
 const requestedPort = process.env.PAPERCLIP_E2E_PORT ? Number(process.env.PAPERCLIP_E2E_PORT) : 3100;
 const requestedDbPort = process.env.PAPERCLIP_E2E_DB_PORT ? Number(process.env.PAPERCLIP_E2E_DB_PORT) : 54329;
 const env = {
@@ -337,6 +339,53 @@ async function ensureSeedProjectMapped(company) {
   log(`Seeded project ${seededProjectName} mapped to ${seededRepositoryUrl}.`);
 }
 
+async function ensureSeedAgent(company) {
+  const companyId = typeof company?.id === 'string' ? company.id : '';
+  if (!companyId) {
+    throw new Error('A seeded company id is required before creating the manual verification agent.');
+  }
+
+  const companyAgentsUrl = new URL(`/api/companies/${companyId}/agents`, baseUrl).toString();
+  const existingAgents = await fetchJson(companyAgentsUrl);
+  const existingAgent =
+    Array.isArray(existingAgents)
+      ? existingAgents.find((entry) =>
+          entry
+          && typeof entry === 'object'
+          && typeof entry.id === 'string'
+          && typeof entry.name === 'string'
+          && entry.name.trim().toLowerCase() === seededAgentName.toLowerCase()
+        )
+      : null;
+
+  const agentPayload = {
+    name: seededAgentName,
+    role: 'ceo',
+    title: seededAgentName,
+    icon: 'sparkles',
+    adapterType: 'codex_local',
+    adapterConfig: {
+      model: seededAgentModel,
+      dangerouslyBypassApprovalsAndSandbox: true
+    }
+  };
+
+  if (existingAgent) {
+    await fetchJson(new URL(`/api/agents/${existingAgent.id}`, baseUrl).toString(), {
+      method: 'PATCH',
+      body: JSON.stringify(agentPayload)
+    });
+    log(`Updated seeded agent ${seededAgentName} to use Codex ${seededAgentModel}.`);
+    return;
+  }
+
+  await fetchJson(companyAgentsUrl, {
+    method: 'POST',
+    body: JSON.stringify(agentPayload)
+  });
+  log(`Seeded agent ${seededAgentName} using Codex ${seededAgentModel}.`);
+}
+
 async function waitForServerExit(timeoutMs) {
   if (!serverProcess) {
     return;
@@ -435,6 +484,7 @@ async function main() {
 
   const company = await ensureCompanySeeded();
   await ensureSeedProjectMapped(company);
+  await ensureSeedAgent(company);
   await ensurePluginInstalled(configPath);
 
   const manualUrl = `${baseUrl}/settings/plugins`;

--- a/src/github-repo.ts
+++ b/src/github-repo.ts
@@ -1,0 +1,48 @@
+export interface ParsedRepositoryReference {
+  owner: string;
+  repo: string;
+  url: string;
+}
+
+export function parseRepositoryReference(repositoryInput: string): ParsedRepositoryReference | null {
+  const trimmed = repositoryInput.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const slugMatch = trimmed.match(/^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?$/);
+  if (slugMatch) {
+    const [, owner, repo] = slugMatch;
+    return {
+      owner,
+      repo,
+      url: `https://github.com/${owner}/${repo}`
+    };
+  }
+
+  try {
+    const url = new URL(trimmed);
+    if (url.hostname !== 'github.com' && url.hostname !== 'www.github.com') {
+      return null;
+    }
+
+    const pathSegments = url.pathname.split('/').filter(Boolean);
+    if (pathSegments.length !== 2) {
+      return null;
+    }
+
+    const [owner, rawRepo] = pathSegments;
+    const repo = rawRepo.replace(/\.git$/, '');
+    if (!owner || !repo) {
+      return null;
+    }
+
+    return {
+      owner,
+      repo,
+      url: `https://github.com/${owner}/${repo}`
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -4,6 +4,12 @@ import { useHostContext, usePluginAction, usePluginData, usePluginToast } from '
 import { requiresPaperclipBoardAccess } from '../paperclip-health.ts';
 import { buildPaperclipUrl, fetchJson, fetchPaperclipHealth, resolveCliAuthPollUrl } from './http.ts';
 import { mergePluginConfig, normalizePluginConfig } from './plugin-config.ts';
+import {
+  discoverExistingProjectSyncCandidates,
+  filterExistingProjectSyncCandidates,
+  type ExistingProjectSyncCandidate,
+  type ProjectWorkspaceSummary
+} from './project-bindings.ts';
 
 const HOST_BUTTON_BASE_CLASSNAME = [
   'inline-flex items-center justify-center whitespace-nowrap text-sm font-medium',
@@ -1282,6 +1288,40 @@ const PAGE_STYLES = `
   line-height: 1.5;
 }
 
+.ghsync__existing-projects {
+  display: grid;
+  gap: 10px;
+}
+
+.ghsync__existing-project-card {
+  display: grid;
+  gap: 10px;
+  align-items: start;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.ghsync__existing-project-meta {
+  display: grid;
+  gap: 6px;
+}
+
+.ghsync__existing-project-meta strong {
+  color: var(--ghsync-title);
+  font-size: 13px;
+}
+
+.ghsync__existing-project-meta span {
+  color: var(--ghsync-muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.ghsync__existing-project-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .ghsync__mapping-grid {
   display: grid;
   align-items: start;
@@ -1390,6 +1430,7 @@ const PAGE_STYLES = `
   .ghsync__scope-overview,
   .ghsync__layout,
   .ghsync__schedule-card,
+  .ghsync__existing-project-card,
   .ghsync__mapping-grid,
   .ghsync__stats {
     grid-template-columns: minmax(0, 1fr);
@@ -2197,7 +2238,7 @@ function useResolvedThemeMode(): ThemeMode {
 }
 
 async function resolveOrCreateProject(companyId: string, projectName: string): Promise<{ id: string; name: string }> {
-  const projects = await fetchJson<Array<{ id: string; name: string }>>(`/api/companies/${companyId}/projects`);
+  const projects = await listCompanyProjects(companyId);
   const existing = projects.find((project) => project.name.trim().toLowerCase() === projectName.trim().toLowerCase());
   if (existing) {
     return existing;
@@ -2212,11 +2253,92 @@ async function resolveOrCreateProject(companyId: string, projectName: string): P
   });
 }
 
-async function bindProjectRepo(projectId: string, repositoryUrl: string): Promise<void> {
+async function listCompanyProjects(companyId: string): Promise<Array<{ id: string; name: string }>> {
+  const response = await fetchJson<unknown>(`/api/companies/${companyId}/projects`);
+  if (!Array.isArray(response)) {
+    return [];
+  }
+
+  return response
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') {
+        return null;
+      }
+
+      const record = entry as Record<string, unknown>;
+      const id = typeof record.id === 'string' ? record.id.trim() : '';
+      const name = typeof record.name === 'string' ? record.name.trim() : '';
+      return id && name ? { id, name } : null;
+    })
+    .filter((entry): entry is { id: string; name: string } => entry !== null);
+}
+
+async function listProjectWorkspaces(projectId: string): Promise<ProjectWorkspaceSummary[]> {
+  const response = await fetchJson<unknown>(`/api/projects/${projectId}/workspaces`);
+  if (!Array.isArray(response)) {
+    return [];
+  }
+
+  const workspaces: ProjectWorkspaceSummary[] = [];
+  for (const entry of response) {
+    if (!entry || typeof entry !== 'object') {
+      continue;
+    }
+
+    const record = entry as Record<string, unknown>;
+    workspaces.push({
+      repoUrl: typeof record.repoUrl === 'string' ? record.repoUrl : null,
+      sourceType: typeof record.sourceType === 'string' ? record.sourceType : null,
+      isPrimary: record.isPrimary === true
+    });
+  }
+
+  return workspaces;
+}
+
+async function loadExistingProjectSyncCandidates(companyId: string): Promise<ExistingProjectSyncCandidate[]> {
+  const projects = await listCompanyProjects(companyId);
+  const workspacesByProjectId = Object.fromEntries(
+    await Promise.all(
+      projects.map(async (project): Promise<[string, ProjectWorkspaceSummary[]]> => [
+        project.id,
+        await listProjectWorkspaces(project.id)
+      ])
+    )
+  ) as Record<string, ProjectWorkspaceSummary[]>;
+
+  return discoverExistingProjectSyncCandidates({
+    projects,
+    workspacesByProjectId
+  });
+}
+
+async function ensureProjectRepoBinding(projectId: string, repositoryUrl: string): Promise<void> {
+  const parsedRepository = parseRepositoryReference(repositoryUrl);
+  const normalizedRepositoryUrl = parsedRepository?.url ?? repositoryUrl.trim();
+
+  try {
+    const workspaces = await listProjectWorkspaces(projectId);
+    const alreadyBound = workspaces.some((workspace) => {
+      if (typeof workspace.repoUrl !== 'string' || !workspace.repoUrl.trim()) {
+        return false;
+      }
+
+      const normalizedWorkspaceRepositoryUrl = parseRepositoryReference(workspace.repoUrl)?.url ?? workspace.repoUrl.trim();
+      return normalizedWorkspaceRepositoryUrl === normalizedRepositoryUrl;
+    });
+
+    if (alreadyBound) {
+      return;
+    }
+  } catch {
+    // Fall back to attempting the create call when workspace listing is unavailable.
+  }
+
   await fetchJson(`/api/projects/${projectId}/workspaces`, {
     method: 'POST',
     body: JSON.stringify({
-      repoUrl: repositoryUrl,
+      repoUrl: normalizedRepositoryUrl,
       sourceType: 'git_repo',
       isPrimary: true
     })
@@ -3208,6 +3330,9 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
   const [showSavedTokenHint, setShowSavedTokenHint] = useState(false);
   const [showTokenEditor, setShowTokenEditor] = useState(false);
   const [cachedSettings, setCachedSettings] = useState<GitHubSyncSettings | null>(null);
+  const [existingProjectCandidates, setExistingProjectCandidates] = useState<ExistingProjectSyncCandidate[]>([]);
+  const [existingProjectCandidatesLoading, setExistingProjectCandidatesLoading] = useState(false);
+  const [existingProjectCandidatesError, setExistingProjectCandidatesError] = useState<string | null>(null);
   const themeMode = useResolvedThemeMode();
   const boardAccessRequirement = usePaperclipBoardAccessRequirement();
   const armSyncCompletionToast = useSyncCompletionToast(form.syncState, toast);
@@ -3253,6 +3378,50 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
       setValidatedLogin(null);
     }
   }, [settings.data, showSavedTokenHint]);
+
+  useEffect(() => {
+    const companyId = hostContext.companyId;
+    if (!companyId || tokenStatusOverride === 'invalid') {
+      setExistingProjectCandidates([]);
+      setExistingProjectCandidatesLoading(false);
+      setExistingProjectCandidatesError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setExistingProjectCandidatesLoading(true);
+    setExistingProjectCandidatesError(null);
+
+    void (async () => {
+      try {
+        const candidates = await loadExistingProjectSyncCandidates(companyId);
+        if (cancelled) {
+          return;
+        }
+
+        setExistingProjectCandidates(candidates);
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+
+        setExistingProjectCandidates([]);
+        setExistingProjectCandidatesError(
+          error instanceof Error
+            ? error.message
+            : 'GitHub Sync could not inspect existing GitHub-linked projects in this company.'
+        );
+      } finally {
+        if (!cancelled) {
+          setExistingProjectCandidatesLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hostContext.companyId, settings.data?.updatedAt, tokenStatusOverride]);
 
   useEffect(() => {
     const companyId = hostContext.companyId;
@@ -3412,6 +3581,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
   const savedMappings = getComparableMappings(savedMappingsSource);
   const draftMappings = getComparableMappings(form.mappings);
   const savedMappingCount = savedMappings.length;
+  const availableExistingProjectCandidates = filterExistingProjectSyncCandidates(existingProjectCandidates, form.mappings);
   const repositoriesSectionDescription = hasCompanyContext
     ? `Only repositories mapped for ${currentCompanyName} appear here.`
     : 'Repository mappings are saved separately for each company.';
@@ -3570,6 +3740,33 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
       ...current,
       mappings: [...current.mappings, createEmptyMapping(current.mappings.length)]
     }));
+  }
+
+  function addExistingProjectCandidate(candidate: ExistingProjectSyncCandidate) {
+    setForm((current) => {
+      const emptyMappingIndex = current.mappings.findIndex((mapping) =>
+        !mapping.repositoryUrl.trim() && !mapping.paperclipProjectName.trim() && !mapping.paperclipProjectId
+      );
+      const nextMapping = {
+        ...(emptyMappingIndex === -1 ? createEmptyMapping(current.mappings.length) : current.mappings[emptyMappingIndex]),
+        repositoryUrl: candidate.repositoryUrl,
+        paperclipProjectName: candidate.projectName,
+        paperclipProjectId: candidate.projectId,
+        companyId: hostContext.companyId ?? undefined
+      };
+
+      if (emptyMappingIndex === -1) {
+        return {
+          ...current,
+          mappings: [...current.mappings, nextMapping]
+        };
+      }
+
+      return {
+        ...current,
+        mappings: current.mappings.map((mapping, index) => index === emptyMappingIndex ? nextMapping : mapping)
+      };
+    });
   }
 
   function removeMapping(mappingId: string) {
@@ -3790,7 +3987,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
           ? { id: mapping.paperclipProjectId, name: paperclipProjectName }
           : await resolveOrCreateProject(companyId, paperclipProjectName);
 
-        await bindProjectRepo(project.id, parsedRepository.url);
+        await ensureProjectRepoBinding(project.id, parsedRepository.url);
 
         resolvedMappings.push({
           ...mapping,
@@ -4155,6 +4352,42 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
             ) : (
               <div className="ghsync__stack">
                 {settingsMutationsLockReason ? <p className="ghsync__hint">{settingsMutationsLockReason}</p> : null}
+                {existingProjectCandidatesLoading ? (
+                  <p className="ghsync__hint">Checking this company for GitHub-linked projects that can be enabled for sync…</p>
+                ) : null}
+                {existingProjectCandidatesError ? (
+                  <p className="ghsync__hint ghsync__hint--error">{existingProjectCandidatesError}</p>
+                ) : null}
+                {availableExistingProjectCandidates.length > 0 ? (
+                  <div className="ghsync__existing-projects">
+                    <div className="ghsync__mapping-title">
+                      <strong>Existing GitHub-linked projects</strong>
+                      <span>Enable sync for projects that are already bound to a GitHub repository in {currentCompanyName}.</span>
+                    </div>
+                    {availableExistingProjectCandidates.map((candidate) => (
+                      <section key={`${candidate.projectId}:${candidate.repositoryUrl}`} className="ghsync__mapping-card ghsync__existing-project-card">
+                        <div className="ghsync__existing-project-meta">
+                          <strong>{candidate.projectName}</strong>
+                          <span>{candidate.repositoryUrl}</span>
+                          <div className="ghsync__existing-project-tags">
+                            <span className="ghsync__scope-pill ghsync__scope-pill--company">Existing project</span>
+                            <span className="ghsync__scope-pill ghsync__scope-pill--global">GitHub workspace</span>
+                          </div>
+                        </div>
+                        <div className="ghsync__button-row">
+                          <button
+                            type="button"
+                            className={getPluginActionClassName({ variant: 'secondary' })}
+                            disabled={settingsMutationsLocked}
+                            onClick={() => addExistingProjectCandidate(candidate)}
+                          >
+                            Enable sync
+                          </button>
+                        </div>
+                      </section>
+                    ))}
+                  </div>
+                ) : null}
                 <div className="ghsync__mapping-list">
                   {mappings.map((mapping, index) => {
                     const canRemove = mappings.length > 1 || mapping.repositoryUrl.trim() !== '' || mapping.paperclipProjectName.trim() !== '';
@@ -4164,6 +4397,9 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
                         <div className="ghsync__mapping-head">
                           <div className="ghsync__mapping-title">
                             <strong>Repository {index + 1}</strong>
+                            {mapping.paperclipProjectId ? (
+                              <span>This mapping will sync into an existing Paperclip project.</span>
+                            ) : null}
                           </div>
                           {canRemove ? (
                             <button

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useHostContext, usePluginAction, usePluginData, usePluginToast } from '@paperclipai/plugin-sdk/ui';
 
+import { parseRepositoryReference, type ParsedRepositoryReference } from '../github-repo.ts';
 import { requiresPaperclipBoardAccess } from '../paperclip-health.ts';
 import { buildPaperclipUrl, fetchJson, fetchPaperclipHealth, resolveCliAuthPollUrl } from './http.ts';
 import { mergePluginConfig, normalizePluginConfig } from './plugin-config.ts';
@@ -216,12 +217,6 @@ interface CliAuthIdentityResponse {
 
 interface PluginConfigResponse {
   configJson?: Record<string, unknown> | null;
-}
-
-interface ParsedRepositoryReference {
-  owner: string;
-  repo: string;
-  url: string;
 }
 
 type ThemeMode = 'light' | 'dark';
@@ -2060,49 +2055,6 @@ function formatScheduleFrequency(minutes: number): string {
   return `every ${normalizedMinutes} minute${normalizedMinutes === 1 ? '' : 's'}`;
 }
 
-function parseRepositoryReference(repositoryInput: string): ParsedRepositoryReference | null {
-  const trimmed = repositoryInput.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  const slugMatch = trimmed.match(/^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?$/);
-  if (slugMatch) {
-    const [, owner, repo] = slugMatch;
-    return {
-      owner,
-      repo,
-      url: `https://github.com/${owner}/${repo}`
-    };
-  }
-
-  try {
-    const url = new URL(trimmed);
-    if (url.hostname !== 'github.com' && url.hostname !== 'www.github.com') {
-      return null;
-    }
-
-    const pathSegments = url.pathname.split('/').filter(Boolean);
-    if (pathSegments.length !== 2) {
-      return null;
-    }
-
-    const [owner, rawRepo] = pathSegments;
-    const repo = rawRepo.replace(/\.git$/, '');
-    if (!owner || !repo) {
-      return null;
-    }
-
-    return {
-      owner,
-      repo,
-      url: `https://github.com/${owner}/${repo}`
-    };
-  } catch {
-    return null;
-  }
-}
-
 function formatProjectNameFromRepository(repositoryInput: string): string {
   const parsedRepository = parseRepositoryReference(repositoryInput);
   const repositoryName = parsedRepository?.repo
@@ -2256,7 +2208,7 @@ async function resolveOrCreateProject(companyId: string, projectName: string): P
 async function listCompanyProjects(companyId: string): Promise<Array<{ id: string; name: string }>> {
   const response = await fetchJson<unknown>(`/api/companies/${companyId}/projects`);
   if (!Array.isArray(response)) {
-    return [];
+    throw new Error(`Unexpected projects response for company ${companyId}: expected an array.`);
   }
 
   return response
@@ -2276,7 +2228,7 @@ async function listCompanyProjects(companyId: string): Promise<Array<{ id: strin
 async function listProjectWorkspaces(projectId: string): Promise<ProjectWorkspaceSummary[]> {
   const response = await fetchJson<unknown>(`/api/projects/${projectId}/workspaces`);
   if (!Array.isArray(response)) {
-    return [];
+    throw new Error(`Unexpected project workspaces response for project ${projectId}: expected an array.`);
   }
 
   const workspaces: ProjectWorkspaceSummary[] = [];

--- a/src/ui/project-bindings.ts
+++ b/src/ui/project-bindings.ts
@@ -1,0 +1,129 @@
+export interface RepositoryMappingSnapshot {
+  repositoryUrl: string;
+  paperclipProjectId?: string;
+}
+
+export interface CompanyProjectSummary {
+  id: string;
+  name: string;
+}
+
+export interface ProjectWorkspaceSummary {
+  repoUrl?: string | null;
+  sourceType?: string | null;
+  isPrimary?: boolean | null;
+}
+
+export interface ExistingProjectSyncCandidate {
+  projectId: string;
+  projectName: string;
+  repositoryUrl: string;
+  sourceType?: string;
+  isPrimary: boolean;
+}
+
+function parseGitHubRepositoryReference(repositoryInput: string): string | null {
+  const trimmed = repositoryInput.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const slugMatch = trimmed.match(/^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?$/);
+  if (slugMatch) {
+    const [, owner, repo] = slugMatch;
+    return `https://github.com/${owner}/${repo}`;
+  }
+
+  try {
+    const url = new URL(trimmed);
+    if (url.hostname !== 'github.com' && url.hostname !== 'www.github.com') {
+      return null;
+    }
+
+    const pathSegments = url.pathname.split('/').filter(Boolean);
+    if (pathSegments.length !== 2) {
+      return null;
+    }
+
+    const [owner, rawRepo] = pathSegments;
+    const repo = rawRepo.replace(/\.git$/, '');
+    if (!owner || !repo) {
+      return null;
+    }
+
+    return `https://github.com/${owner}/${repo}`;
+  } catch {
+    return null;
+  }
+}
+
+function compareByProjectName(left: ExistingProjectSyncCandidate, right: ExistingProjectSyncCandidate): number {
+  const projectNameComparison = left.projectName.localeCompare(right.projectName, undefined, { sensitivity: 'base' });
+  if (projectNameComparison !== 0) {
+    return projectNameComparison;
+  }
+
+  return left.repositoryUrl.localeCompare(right.repositoryUrl, undefined, { sensitivity: 'base' });
+}
+
+export function discoverExistingProjectSyncCandidates(params: {
+  projects: CompanyProjectSummary[];
+  workspacesByProjectId: Record<string, ProjectWorkspaceSummary[] | undefined>;
+}): ExistingProjectSyncCandidate[] {
+  const discoveredCandidates: ExistingProjectSyncCandidate[] = [];
+  const seenCandidates = new Set<string>();
+
+  for (const project of params.projects) {
+    const projectId = project.id.trim();
+    const projectName = project.name.trim();
+    if (!projectId || !projectName) {
+      continue;
+    }
+
+    const workspaces = params.workspacesByProjectId[projectId] ?? [];
+    for (const workspace of workspaces) {
+      const repositoryUrl = parseGitHubRepositoryReference(workspace.repoUrl ?? '');
+      if (!repositoryUrl) {
+        continue;
+      }
+
+      const candidateKey = `${projectId}:${repositoryUrl}`;
+      if (seenCandidates.has(candidateKey)) {
+        continue;
+      }
+      seenCandidates.add(candidateKey);
+
+      discoveredCandidates.push({
+        projectId,
+        projectName,
+        repositoryUrl,
+        sourceType: typeof workspace.sourceType === 'string' && workspace.sourceType.trim()
+          ? workspace.sourceType.trim()
+          : undefined,
+        isPrimary: workspace.isPrimary === true
+      });
+    }
+  }
+
+  return discoveredCandidates.sort(compareByProjectName);
+}
+
+export function filterExistingProjectSyncCandidates(
+  candidates: ExistingProjectSyncCandidate[],
+  mappings: RepositoryMappingSnapshot[]
+): ExistingProjectSyncCandidate[] {
+  const mappedProjectIds = new Set(
+    mappings
+      .map((mapping) => mapping.paperclipProjectId?.trim())
+      .filter((value): value is string => Boolean(value))
+  );
+  const mappedRepositoryUrls = new Set(
+    mappings
+      .map((mapping) => parseGitHubRepositoryReference(mapping.repositoryUrl))
+      .filter((value): value is string => Boolean(value))
+  );
+
+  return candidates.filter((candidate) =>
+    !mappedProjectIds.has(candidate.projectId) && !mappedRepositoryUrls.has(candidate.repositoryUrl)
+  );
+}

--- a/src/ui/project-bindings.ts
+++ b/src/ui/project-bindings.ts
@@ -1,3 +1,5 @@
+import { parseRepositoryReference } from '../github-repo.ts';
+
 export interface RepositoryMappingSnapshot {
   repositoryUrl: string;
   paperclipProjectId?: string;
@@ -22,41 +24,6 @@ export interface ExistingProjectSyncCandidate {
   isPrimary: boolean;
 }
 
-function parseGitHubRepositoryReference(repositoryInput: string): string | null {
-  const trimmed = repositoryInput.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  const slugMatch = trimmed.match(/^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?$/);
-  if (slugMatch) {
-    const [, owner, repo] = slugMatch;
-    return `https://github.com/${owner}/${repo}`;
-  }
-
-  try {
-    const url = new URL(trimmed);
-    if (url.hostname !== 'github.com' && url.hostname !== 'www.github.com') {
-      return null;
-    }
-
-    const pathSegments = url.pathname.split('/').filter(Boolean);
-    if (pathSegments.length !== 2) {
-      return null;
-    }
-
-    const [owner, rawRepo] = pathSegments;
-    const repo = rawRepo.replace(/\.git$/, '');
-    if (!owner || !repo) {
-      return null;
-    }
-
-    return `https://github.com/${owner}/${repo}`;
-  } catch {
-    return null;
-  }
-}
-
 function compareByProjectName(left: ExistingProjectSyncCandidate, right: ExistingProjectSyncCandidate): number {
   const projectNameComparison = left.projectName.localeCompare(right.projectName, undefined, { sensitivity: 'base' });
   if (projectNameComparison !== 0) {
@@ -70,8 +37,7 @@ export function discoverExistingProjectSyncCandidates(params: {
   projects: CompanyProjectSummary[];
   workspacesByProjectId: Record<string, ProjectWorkspaceSummary[] | undefined>;
 }): ExistingProjectSyncCandidate[] {
-  const discoveredCandidates: ExistingProjectSyncCandidate[] = [];
-  const seenCandidates = new Set<string>();
+  const discoveredCandidates = new Map<string, ExistingProjectSyncCandidate>();
 
   for (const project of params.projects) {
     const projectId = project.id.trim();
@@ -82,30 +48,39 @@ export function discoverExistingProjectSyncCandidates(params: {
 
     const workspaces = params.workspacesByProjectId[projectId] ?? [];
     for (const workspace of workspaces) {
-      const repositoryUrl = parseGitHubRepositoryReference(workspace.repoUrl ?? '');
-      if (!repositoryUrl) {
+      const parsedRepository = parseRepositoryReference(workspace.repoUrl ?? '');
+      if (!parsedRepository) {
         continue;
       }
 
+      const repositoryUrl = parsedRepository.url;
       const candidateKey = `${projectId}:${repositoryUrl}`;
-      if (seenCandidates.has(candidateKey)) {
+      const sourceType =
+        typeof workspace.sourceType === 'string' && workspace.sourceType.trim()
+          ? workspace.sourceType.trim()
+          : undefined;
+      const isPrimary = workspace.isPrimary === true;
+      const existingCandidate = discoveredCandidates.get(candidateKey);
+      if (existingCandidate) {
+        discoveredCandidates.set(candidateKey, {
+          ...existingCandidate,
+          sourceType: existingCandidate.sourceType ?? sourceType,
+          isPrimary: existingCandidate.isPrimary || isPrimary
+        });
         continue;
       }
-      seenCandidates.add(candidateKey);
 
-      discoveredCandidates.push({
+      discoveredCandidates.set(candidateKey, {
         projectId,
         projectName,
         repositoryUrl,
-        sourceType: typeof workspace.sourceType === 'string' && workspace.sourceType.trim()
-          ? workspace.sourceType.trim()
-          : undefined,
-        isPrimary: workspace.isPrimary === true
+        sourceType,
+        isPrimary
       });
     }
   }
 
-  return discoveredCandidates.sort(compareByProjectName);
+  return [...discoveredCandidates.values()].sort(compareByProjectName);
 }
 
 export function filterExistingProjectSyncCandidates(
@@ -119,7 +94,7 @@ export function filterExistingProjectSyncCandidates(
   );
   const mappedRepositoryUrls = new Set(
     mappings
-      .map((mapping) => parseGitHubRepositoryReference(mapping.repositoryUrl))
+      .map((mapping) => parseRepositoryReference(mapping.repositoryUrl)?.url)
       .filter((value): value is string => Boolean(value))
   );
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { Octokit } from '@octokit/rest';
 import { definePlugin, runWorker, type Issue } from '@paperclipai/plugin-sdk';
 
+import { parseRepositoryReference, type ParsedRepositoryReference } from './github-repo.ts';
 import { normalizePaperclipHealthResponse, requiresPaperclipBoardAccess } from './paperclip-health.ts';
 
 const SETTINGS_SCOPE = {
@@ -347,12 +348,6 @@ interface GitHubIssueLabelRecord {
 
 interface TokenValidationResult {
   login: string;
-}
-
-interface ParsedRepositoryReference {
-  owner: string;
-  repo: string;
-  url: string;
 }
 
 interface ParsedGitHubIssueReference {
@@ -2430,49 +2425,6 @@ function normalizeImportRegistry(value: unknown): ImportedIssueRecord[] {
       };
     })
     .filter((entry): entry is ImportedIssueRecord => entry !== null);
-}
-
-function parseRepositoryReference(repositoryInput: string): ParsedRepositoryReference | null {
-  const trimmed = repositoryInput.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  const slugMatch = trimmed.match(/^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?$/);
-  if (slugMatch) {
-    const [, owner, repo] = slugMatch;
-    return {
-      owner,
-      repo,
-      url: `https://github.com/${owner}/${repo}`
-    };
-  }
-
-  try {
-    const url = new URL(trimmed);
-    if (url.hostname !== 'github.com' && url.hostname !== 'www.github.com') {
-      return null;
-    }
-
-    const pathSegments = url.pathname.split('/').filter(Boolean);
-    if (pathSegments.length !== 2) {
-      return null;
-    }
-
-    const [owner, rawRepo] = pathSegments;
-    const repo = rawRepo.replace(/\.git$/, '');
-    if (!owner || !repo) {
-      return null;
-    }
-
-    return {
-      owner,
-      repo,
-      url: `https://github.com/${owner}/${repo}`
-    };
-  } catch {
-    return null;
-  }
 }
 
 function requireRepositoryReference(repositoryInput: string): ParsedRepositoryReference {

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -10,6 +10,10 @@ import manifest from '../src/manifest.ts';
 import { requiresPaperclipBoardAccess } from '../src/paperclip-health.ts';
 import { fetchJson, fetchPaperclipHealth, resolveCliAuthPollUrl } from '../src/ui/http.ts';
 import { mergePluginConfig } from '../src/ui/plugin-config.ts';
+import {
+  discoverExistingProjectSyncCandidates,
+  filterExistingProjectSyncCandidates
+} from '../src/ui/project-bindings.ts';
 import plugin from '../src/worker.ts';
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -150,6 +154,79 @@ function delay(ms: number): Promise<void> {
     globalThis.setTimeout(resolve, ms);
   });
 }
+
+test('discoverExistingProjectSyncCandidates normalizes GitHub workspaces and ignores non-GitHub links', () => {
+  const candidates = discoverExistingProjectSyncCandidates({
+    projects: [
+      { id: 'project-2', name: 'Beta' },
+      { id: 'project-1', name: 'Alpha' }
+    ],
+    workspacesByProjectId: {
+      'project-1': [
+        { repoUrl: 'https://github.com/example/alpha' },
+        { repoUrl: 'https://github.com/example/alpha.git', isPrimary: true },
+        { repoUrl: 'https://gitlab.com/example/alpha' }
+      ],
+      'project-2': [
+        { repoUrl: 'example/beta', sourceType: 'git_repo' }
+      ]
+    }
+  });
+
+  assert.deepEqual(candidates, [
+    {
+      projectId: 'project-1',
+      projectName: 'Alpha',
+      repositoryUrl: 'https://github.com/example/alpha',
+      isPrimary: false,
+      sourceType: undefined
+    },
+    {
+      projectId: 'project-2',
+      projectName: 'Beta',
+      repositoryUrl: 'https://github.com/example/beta',
+      isPrimary: false,
+      sourceType: 'git_repo'
+    }
+  ]);
+});
+
+test('filterExistingProjectSyncCandidates hides projects already enabled in plugin mappings', () => {
+  const availableCandidates = filterExistingProjectSyncCandidates(
+    [
+      {
+        projectId: 'project-1',
+        projectName: 'Alpha',
+        repositoryUrl: 'https://github.com/example/alpha',
+        isPrimary: true,
+        sourceType: 'git_repo'
+      },
+      {
+        projectId: 'project-2',
+        projectName: 'Beta',
+        repositoryUrl: 'https://github.com/example/beta',
+        isPrimary: false,
+        sourceType: 'git_repo'
+      }
+    ],
+    [
+      {
+        repositoryUrl: 'example/alpha',
+        paperclipProjectId: 'project-1'
+      }
+    ]
+  );
+
+  assert.deepEqual(availableCandidates, [
+    {
+      projectId: 'project-2',
+      projectName: 'Beta',
+      repositoryUrl: 'https://github.com/example/beta',
+      isPrimary: false,
+      sourceType: 'git_repo'
+    }
+  ]);
+});
 
 async function withExternalPluginConfig<T>(
   config: Record<string, unknown>,
@@ -5956,16 +6033,18 @@ test('worker stores repository and issue diagnostics when a sync fails mid-run',
 });
 
 test('worker reports sync error when configuration is incomplete', async () => {
-  const harness = createTestHarness({ manifest });
-  await plugin.definition.setup(harness.ctx);
+  await withExternalPluginConfig({}, async () => {
+    const harness = createTestHarness({ manifest });
+    await plugin.definition.setup(harness.ctx);
 
-  const result = await harness.performAction('sync.runNow', {}) as {
-    syncState: { status: string; message?: string; lastRunTrigger?: string };
-  };
+    const result = await harness.performAction('sync.runNow', {}) as {
+      syncState: { status: string; message?: string; lastRunTrigger?: string };
+    };
 
-  assert.equal(result.syncState.status, 'error');
-  assert.equal(result.syncState.message, 'Configure a GitHub token before running sync.');
-  assert.equal(result.syncState.lastRunTrigger, 'manual');
+    assert.equal(result.syncState.status, 'error');
+    assert.equal(result.syncState.message, 'Configure a GitHub token before running sync.');
+    assert.equal(result.syncState.lastRunTrigger, 'manual');
+  });
 });
 
 test('sync.runNow falls back to the saved githubTokenRef when config has not propagated yet', async () => {

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -178,7 +178,7 @@ test('discoverExistingProjectSyncCandidates normalizes GitHub workspaces and ign
       projectId: 'project-1',
       projectName: 'Alpha',
       repositoryUrl: 'https://github.com/example/alpha',
-      isPrimary: false,
+      isPrimary: true,
       sourceType: undefined
     },
     {
@@ -186,6 +186,30 @@ test('discoverExistingProjectSyncCandidates normalizes GitHub workspaces and ign
       projectName: 'Beta',
       repositoryUrl: 'https://github.com/example/beta',
       isPrimary: false,
+      sourceType: 'git_repo'
+    }
+  ]);
+});
+
+test('discoverExistingProjectSyncCandidates merges duplicate repo workspaces and keeps primary metadata', () => {
+  const candidates = discoverExistingProjectSyncCandidates({
+    projects: [
+      { id: 'project-1', name: 'Alpha' }
+    ],
+    workspacesByProjectId: {
+      'project-1': [
+        { repoUrl: 'https://github.com/example/alpha', isPrimary: false },
+        { repoUrl: 'example/alpha', sourceType: 'git_repo', isPrimary: true }
+      ]
+    }
+  });
+
+  assert.deepEqual(candidates, [
+    {
+      projectId: 'project-1',
+      projectName: 'Alpha',
+      repositoryUrl: 'https://github.com/example/alpha',
+      isPrimary: true,
       sourceType: 'git_repo'
     }
   ]);


### PR DESCRIPTION
## Summary
- surface existing company projects that are already bound to GitHub repos and let operators enable sync without recreating the project
- make repo workspace binding idempotent so saving a mapping reuses an existing GitHub-linked project binding instead of duplicating it
- seed `pnpm verify:manual` with a mapped project and a `CEO` agent on `codex_local` using model `gpt-5.4`
- update the spec, README, and tests to cover the new setup flow

## Testing
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `node --check scripts/e2e/manual-paperclip-verify.mjs`

## Model Used
- OpenAI Codex via API; exact runtime model ID/version was not exposed in this session
- Context window size was not exposed in this session
- Capability details: tool-assisted code editing, shell verification, and targeted reasoning