### PR TITLE
Limit Renovate Node updates below 24

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,15 @@
       "matchManagers": [
         "github-actions"
       ],
+      "matchPackageNames": [
+        "node"
+      ],
+      "allowedVersions": "<24"
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
       "groupName": "github-actions"
     },
     {


### PR DESCRIPTION
## Summary
- add a Renovate package rule that limits GitHub Actions `node` updates to versions below 24
- keep Renovate aligned with the plugin's intended Node 20+ support policy
- prevent follow-up PRs like the workflow-only Node 24 bump from reopening

## Why
The repo should stay compatible with Node 20+ rather than drift into Node 24-only workflow updates by default. Encoding that in Renovate keeps future dependency automation aligned with the policy we actually want.

## Impact
Renovate can still propose supported Node updates for GitHub Actions, but it will stop proposing Node 24 workflow bumps.

## Validation
- `jq . renovate.json`

## Model Used
- Model: Codex desktop agent (GPT-5-based; exact internal model ID/version not exposed in this session)
- Context window: not exposed in this session
- Capabilities: tool-assisted code editing, git, and GitHub CLI workflow
