### PR TITLE
Add GitHub agent tools for issue, PR, CI, and review workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It is designed for teams that plan in Paperclip but still receive work through G
 - Supports an optional worker-local config file at `~/.paperclip/plugins/github-sync/config.json` for a raw `githubToken` fallback when Paperclip-managed secrets are not available.
 - Can store a per-company Paperclip board API token for worker-side REST calls when Paperclip board access requires sign-in.
 - Adds Paperclip UI surfaces for setup, sync status, manual sync actions, issue details, and GitHub link annotations.
+- Exposes agent tools so Paperclip agents can search GitHub for duplicates, read and update issues, open pull requests, inspect CI, work through review threads, and request reviewers without leaving the plugin surface.
 
 ## User-facing features
 
@@ -46,6 +47,14 @@ It is designed for teams that plan in Paperclip but still receive work through G
 - Background completion for long-running manual or scheduled syncs so the host request can return promptly.
 - Live sync progress and troubleshooting details in the Paperclip UI.
 - Cumulative sync counts and last-run status in plugin state.
+
+### Agent tools
+
+- Repository-scoped search for issues and pull requests to support deduplication during triage.
+- GitHub issue read, comment-read, comment-write, and metadata update tools for agent implementation work.
+- Pull request creation, read, update, changed-file, CI-check, review-thread, and reviewer-request tools for agent delivery work.
+- Review-thread reply plus resolve and unresolve tools so agents can respond to automated review feedback directly from Paperclip.
+- Comment-posting tools automatically append a footer disclosing that a Paperclip AI agent authored the message and which LLM was used; callers must provide the LLM name when posting those messages.
 
 ### Issue import and update behavior
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -41,6 +41,8 @@ The plugin MUST persist repository mappings and sync state in plugin state.
 - A manual sync requested from a company-scoped settings or dashboard view MUST only sync repository mappings for that company.
 - The worker SHOULD support targeted manual sync requests for a specific mapped Paperclip project or imported Paperclip issue.
 - The plugin MUST declare a scheduled job that ticks every minute and only performs a scheduled sync when the saved frequency is due.
+- The plugin MUST expose agent tools for the GitHub issue and pull request workflow around synced work, including repository-item search, issue reads and updates, issue comment reads and writes, pull request creation and updates, pull request file and CI inspection, review-thread reads and replies, review-thread resolution changes, and pull request reviewer requests.
+- Agent tools that post GitHub comments or review-thread replies MUST require the caller to identify the LLM used and MUST append a footer that discloses that a Paperclip AI agent created the message and which LLM was used.
 - The sync flow MUST fetch open GitHub issues from every configured repository.
 - The sync flow MUST create one top-level Paperclip issue per imported GitHub issue when the target mapping has a resolved Paperclip project identifier.
 - Imported Paperclip issues MUST keep the original GitHub issue title without adding a `[GitHub]` prefix.

--- a/src/github-agent-tools.ts
+++ b/src/github-agent-tools.ts
@@ -27,6 +27,28 @@ const llmModelProperty = {
   description: 'Exact LLM name used to draft the comment. Required so the plugin can append the mandatory AI-authorship footer.'
 } as const;
 
+const issueTargetSchema = {
+  anyOf: [
+    {
+      required: ['paperclipIssueId']
+    },
+    {
+      required: ['issueNumber']
+    }
+  ]
+} as const;
+
+const pullRequestTargetSchema = {
+  anyOf: [
+    {
+      required: ['paperclipIssueId']
+    },
+    {
+      required: ['pullRequestNumber']
+    }
+  ]
+} as const;
+
 export const GITHUB_AGENT_TOOLS: PluginToolDeclaration[] = [
   {
     name: 'search_repository_items',
@@ -83,6 +105,7 @@ export const GITHUB_AGENT_TOOLS: PluginToolDeclaration[] = [
     parametersSchema: {
       type: 'object',
       additionalProperties: false,
+      ...issueTargetSchema,
       properties: {
         repository: repositoryProperty,
         issueNumber: issueNumberProperty,
@@ -97,6 +120,7 @@ export const GITHUB_AGENT_TOOLS: PluginToolDeclaration[] = [
     parametersSchema: {
       type: 'object',
       additionalProperties: false,
+      ...issueTargetSchema,
       properties: {
         repository: repositoryProperty,
         issueNumber: issueNumberProperty,
@@ -111,6 +135,7 @@ export const GITHUB_AGENT_TOOLS: PluginToolDeclaration[] = [
     parametersSchema: {
       type: 'object',
       additionalProperties: false,
+      ...issueTargetSchema,
       properties: {
         repository: repositoryProperty,
         issueNumber: issueNumberProperty,
@@ -177,6 +202,7 @@ export const GITHUB_AGENT_TOOLS: PluginToolDeclaration[] = [
       type: 'object',
       additionalProperties: false,
       required: ['body', 'llmModel'],
+      ...issueTargetSchema,
       properties: {
         repository: repositoryProperty,
         issueNumber: issueNumberProperty,
@@ -226,6 +252,7 @@ export const GITHUB_AGENT_TOOLS: PluginToolDeclaration[] = [
     parametersSchema: {
       type: 'object',
       additionalProperties: false,
+      ...pullRequestTargetSchema,
       properties: {
         repository: repositoryProperty,
         pullRequestNumber: pullRequestNumberProperty,
@@ -240,6 +267,7 @@ export const GITHUB_AGENT_TOOLS: PluginToolDeclaration[] = [
     parametersSchema: {
       type: 'object',
       additionalProperties: false,
+      ...pullRequestTargetSchema,
       properties: {
         repository: repositoryProperty,
         pullRequestNumber: pullRequestNumberProperty,
@@ -271,6 +299,7 @@ export const GITHUB_AGENT_TOOLS: PluginToolDeclaration[] = [
     parametersSchema: {
       type: 'object',
       additionalProperties: false,
+      ...pullRequestTargetSchema,
       properties: {
         repository: repositoryProperty,
         pullRequestNumber: pullRequestNumberProperty,
@@ -285,6 +314,7 @@ export const GITHUB_AGENT_TOOLS: PluginToolDeclaration[] = [
     parametersSchema: {
       type: 'object',
       additionalProperties: false,
+      ...pullRequestTargetSchema,
       properties: {
         repository: repositoryProperty,
         pullRequestNumber: pullRequestNumberProperty,
@@ -299,6 +329,7 @@ export const GITHUB_AGENT_TOOLS: PluginToolDeclaration[] = [
     parametersSchema: {
       type: 'object',
       additionalProperties: false,
+      ...pullRequestTargetSchema,
       properties: {
         repository: repositoryProperty,
         pullRequestNumber: pullRequestNumberProperty,
@@ -366,23 +397,40 @@ export const GITHUB_AGENT_TOOLS: PluginToolDeclaration[] = [
     parametersSchema: {
       type: 'object',
       additionalProperties: false,
+      ...pullRequestTargetSchema,
       properties: {
         repository: repositoryProperty,
         pullRequestNumber: pullRequestNumberProperty,
         paperclipIssueId: paperclipIssueIdProperty,
         userReviewers: {
           type: 'array',
+          minItems: 1,
           items: {
             type: 'string'
           }
         },
         teamReviewers: {
           type: 'array',
+          minItems: 1,
           items: {
             type: 'string'
           }
         }
-      }
+      },
+      anyOf: [
+        {
+          required: ['paperclipIssueId', 'userReviewers']
+        },
+        {
+          required: ['paperclipIssueId', 'teamReviewers']
+        },
+        {
+          required: ['pullRequestNumber', 'userReviewers']
+        },
+        {
+          required: ['pullRequestNumber', 'teamReviewers']
+        }
+      ]
     }
   }
 ];

--- a/src/github-agent-tools.ts
+++ b/src/github-agent-tools.ts
@@ -1,0 +1,397 @@
+import type { PluginToolDeclaration } from '@paperclipai/plugin-sdk';
+
+const repositoryProperty = {
+  type: 'string',
+  description: 'GitHub repository as owner/repo or https://github.com/owner/repo. Omit when the current Paperclip project has exactly one mapped repository.'
+} as const;
+
+const paperclipIssueIdProperty = {
+  type: 'string',
+  description: 'Paperclip issue id used to infer the linked GitHub issue and repository when available.'
+} as const;
+
+const issueNumberProperty = {
+  type: 'integer',
+  minimum: 1,
+  description: 'GitHub issue number.'
+} as const;
+
+const pullRequestNumberProperty = {
+  type: 'integer',
+  minimum: 1,
+  description: 'GitHub pull request number.'
+} as const;
+
+const llmModelProperty = {
+  type: 'string',
+  description: 'Exact LLM name used to draft the comment. Required so the plugin can append the mandatory AI-authorship footer.'
+} as const;
+
+export const GITHUB_AGENT_TOOLS: PluginToolDeclaration[] = [
+  {
+    name: 'search_repository_items',
+    displayName: 'Search Repository Items',
+    description: 'Search issues and pull requests in a GitHub repository for triage and deduplication.',
+    parametersSchema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['query'],
+      properties: {
+        repository: repositoryProperty,
+        query: {
+          type: 'string',
+          description: 'Free-text search query.'
+        },
+        type: {
+          type: 'string',
+          enum: ['issue', 'pull_request', 'all'],
+          description: 'Which item type to search.'
+        },
+        state: {
+          type: 'string',
+          enum: ['open', 'closed', 'all'],
+          description: 'State filter.'
+        },
+        author: {
+          type: 'string',
+          description: 'GitHub login that authored the item.'
+        },
+        assignee: {
+          type: 'string',
+          description: 'GitHub login assigned to the item.'
+        },
+        labels: {
+          type: 'array',
+          items: {
+            type: 'string'
+          },
+          description: 'Label names that must be present on the item.'
+        },
+        limit: {
+          type: 'integer',
+          minimum: 1,
+          maximum: 50,
+          description: 'Maximum number of results to return.'
+        }
+      }
+    }
+  },
+  {
+    name: 'get_issue',
+    displayName: 'Get Issue',
+    description: 'Read one GitHub issue with its metadata, assignees, labels, milestone, and linked pull requests.',
+    parametersSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        repository: repositoryProperty,
+        issueNumber: issueNumberProperty,
+        paperclipIssueId: paperclipIssueIdProperty
+      }
+    }
+  },
+  {
+    name: 'list_issue_comments',
+    displayName: 'List Issue Comments',
+    description: 'Read all comments on a GitHub issue so the agent has the full implementation context.',
+    parametersSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        repository: repositoryProperty,
+        issueNumber: issueNumberProperty,
+        paperclipIssueId: paperclipIssueIdProperty
+      }
+    }
+  },
+  {
+    name: 'update_issue',
+    displayName: 'Update Issue',
+    description: 'Update GitHub issue fields such as title, body, state, labels, assignees, or milestone.',
+    parametersSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        repository: repositoryProperty,
+        issueNumber: issueNumberProperty,
+        paperclipIssueId: paperclipIssueIdProperty,
+        title: {
+          type: 'string'
+        },
+        body: {
+          type: 'string'
+        },
+        state: {
+          type: 'string',
+          enum: ['open', 'closed']
+        },
+        setLabels: {
+          type: 'array',
+          items: {
+            type: 'string'
+          }
+        },
+        addLabels: {
+          type: 'array',
+          items: {
+            type: 'string'
+          }
+        },
+        removeLabels: {
+          type: 'array',
+          items: {
+            type: 'string'
+          }
+        },
+        setAssignees: {
+          type: 'array',
+          items: {
+            type: 'string'
+          }
+        },
+        addAssignees: {
+          type: 'array',
+          items: {
+            type: 'string'
+          }
+        },
+        removeAssignees: {
+          type: 'array',
+          items: {
+            type: 'string'
+          }
+        },
+        milestoneNumber: {
+          type: ['integer', 'null'],
+          minimum: 1,
+          description: 'Milestone number to set, or null to clear the milestone.'
+        }
+      }
+    }
+  },
+  {
+    name: 'add_issue_comment',
+    displayName: 'Add Issue Comment',
+    description: 'Post a comment on a GitHub issue or pull request. Provide only the human-facing message body; include llmModel so the plugin can append the required AI-authorship footer.',
+    parametersSchema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['body', 'llmModel'],
+      properties: {
+        repository: repositoryProperty,
+        issueNumber: issueNumberProperty,
+        paperclipIssueId: paperclipIssueIdProperty,
+        body: {
+          type: 'string',
+          description: 'Human-facing comment body without the AI footer.'
+        },
+        llmModel: llmModelProperty
+      }
+    }
+  },
+  {
+    name: 'create_pull_request',
+    displayName: 'Create Pull Request',
+    description: 'Open a GitHub pull request once the implementation branch is pushed.',
+    parametersSchema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['head', 'base', 'title'],
+      properties: {
+        repository: repositoryProperty,
+        head: {
+          type: 'string',
+          description: 'Head branch name or owner:branch.'
+        },
+        base: {
+          type: 'string',
+          description: 'Base branch name.'
+        },
+        title: {
+          type: 'string'
+        },
+        body: {
+          type: 'string'
+        },
+        draft: {
+          type: 'boolean'
+        }
+      }
+    }
+  },
+  {
+    name: 'get_pull_request',
+    displayName: 'Get Pull Request',
+    description: 'Read one pull request with branch metadata, review summary, and merge readiness.',
+    parametersSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        repository: repositoryProperty,
+        pullRequestNumber: pullRequestNumberProperty,
+        paperclipIssueId: paperclipIssueIdProperty
+      }
+    }
+  },
+  {
+    name: 'update_pull_request',
+    displayName: 'Update Pull Request',
+    description: 'Edit pull request title, body, base branch, open or close it, or convert between draft and ready for review.',
+    parametersSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        repository: repositoryProperty,
+        pullRequestNumber: pullRequestNumberProperty,
+        paperclipIssueId: paperclipIssueIdProperty,
+        title: {
+          type: 'string'
+        },
+        body: {
+          type: 'string'
+        },
+        base: {
+          type: 'string'
+        },
+        state: {
+          type: 'string',
+          enum: ['open', 'closed']
+        },
+        isDraft: {
+          type: 'boolean',
+          description: 'True converts the pull request to draft. False marks it ready for review.'
+        }
+      }
+    }
+  },
+  {
+    name: 'list_pull_request_files',
+    displayName: 'List Pull Request Files',
+    description: 'List the changed files in a pull request, including additions, deletions, and patches when available.',
+    parametersSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        repository: repositoryProperty,
+        pullRequestNumber: pullRequestNumberProperty,
+        paperclipIssueId: paperclipIssueIdProperty
+      }
+    }
+  },
+  {
+    name: 'get_pull_request_checks',
+    displayName: 'Get Pull Request Checks',
+    description: 'Read CI status for a pull request, including workflow runs, check runs, and commit status contexts.',
+    parametersSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        repository: repositoryProperty,
+        pullRequestNumber: pullRequestNumberProperty,
+        paperclipIssueId: paperclipIssueIdProperty
+      }
+    }
+  },
+  {
+    name: 'list_pull_request_review_threads',
+    displayName: 'List Pull Request Review Threads',
+    description: 'Read review threads on a pull request, including file paths, comments, and resolution state.',
+    parametersSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        repository: repositoryProperty,
+        pullRequestNumber: pullRequestNumberProperty,
+        paperclipIssueId: paperclipIssueIdProperty
+      }
+    }
+  },
+  {
+    name: 'reply_to_review_thread',
+    displayName: 'Reply To Review Thread',
+    description: 'Reply to an existing pull request review thread. Provide only the human-facing body; include llmModel so the plugin can append the required AI-authorship footer.',
+    parametersSchema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['threadId', 'body', 'llmModel'],
+      properties: {
+        threadId: {
+          type: 'string',
+          description: 'GitHub pull request review thread node id.'
+        },
+        body: {
+          type: 'string',
+          description: 'Human-facing reply body without the AI footer.'
+        },
+        llmModel: llmModelProperty
+      }
+    }
+  },
+  {
+    name: 'resolve_review_thread',
+    displayName: 'Resolve Review Thread',
+    description: 'Mark a pull request review thread as resolved after addressing the feedback.',
+    parametersSchema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['threadId'],
+      properties: {
+        threadId: {
+          type: 'string',
+          description: 'GitHub pull request review thread node id.'
+        }
+      }
+    }
+  },
+  {
+    name: 'unresolve_review_thread',
+    displayName: 'Unresolve Review Thread',
+    description: 'Reopen a previously resolved pull request review thread.',
+    parametersSchema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['threadId'],
+      properties: {
+        threadId: {
+          type: 'string',
+          description: 'GitHub pull request review thread node id.'
+        }
+      }
+    }
+  },
+  {
+    name: 'request_pull_request_reviewers',
+    displayName: 'Request Pull Request Reviewers',
+    description: 'Request users or teams to review a pull request.',
+    parametersSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        repository: repositoryProperty,
+        pullRequestNumber: pullRequestNumberProperty,
+        paperclipIssueId: paperclipIssueIdProperty,
+        userReviewers: {
+          type: 'array',
+          items: {
+            type: 'string'
+          }
+        },
+        teamReviewers: {
+          type: 'array',
+          items: {
+            type: 'string'
+          }
+        }
+      }
+    }
+  }
+];
+
+export function getGitHubAgentToolDeclaration(name: string): PluginToolDeclaration {
+  const declaration = GITHUB_AGENT_TOOLS.find((entry) => entry.name === name);
+  if (!declaration) {
+    throw new Error(`Unknown GitHub agent tool declaration: ${name}`);
+  }
+
+  return declaration;
+}

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,6 +1,8 @@
 import { createRequire } from 'node:module';
 import type { PaperclipPluginManifestV1 } from '@paperclipai/plugin-sdk';
 
+import { GITHUB_AGENT_TOOLS } from './github-agent-tools.ts';
+
 const require = createRequire(import.meta.url);
 const packageJson = require('../package.json') as { version?: unknown };
 const DASHBOARD_WIDGET_CAPABILITY = 'ui.dashboardWidget.register' as unknown as PaperclipPluginManifestV1['capabilities'][number];
@@ -35,7 +37,8 @@ export const manifest: PaperclipPluginManifestV1 = {
     'issue.comments.create',
     'jobs.schedule',
     'http.outbound',
-    'secrets.read-ref'
+    'secrets.read-ref',
+    'agent.tools.register'
   ],
   instanceConfigSchema: {
     type: 'object',
@@ -61,6 +64,7 @@ export const manifest: PaperclipPluginManifestV1 = {
       schedule: SCHEDULE_TICK_CRON
     }
   ],
+  tools: GITHUB_AGENT_TOOLS,
   entrypoints: {
     worker: './dist/worker.js',
     ui: './dist/ui/'

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2,8 +2,9 @@ import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { Octokit } from '@octokit/rest';
-import { definePlugin, runWorker, type Issue } from '@paperclipai/plugin-sdk';
+import { definePlugin, runWorker, type Issue, type ToolResult, type ToolRunContext } from '@paperclipai/plugin-sdk';
 
+import { getGitHubAgentToolDeclaration } from './github-agent-tools.ts';
 import { normalizePaperclipHealthResponse, requiresPaperclipBoardAccess } from './paperclip-health.ts';
 
 const SETTINGS_SCOPE = {
@@ -42,6 +43,7 @@ const MISSING_BOARD_ACCESS_SYNC_ACTION =
 const ISSUE_LINK_ENTITY_TYPE = 'paperclip-github-plugin.issue-link';
 const COMMENT_ANNOTATION_ENTITY_TYPE = 'paperclip-github-plugin.comment-annotation';
 const EXTERNAL_CONFIG_FILE_PATH_SEGMENTS = ['.paperclip', 'plugins', 'github-sync', 'config.json'] as const;
+const AI_AUTHORED_COMMENT_FOOTER_PREFIX = 'Created by a Paperclip AI agent using ';
 
 type PluginSetupContext = Parameters<Parameters<typeof definePlugin>[0]['setup']>[0];
 type PaperclipIssueStatus = Issue['status'];
@@ -531,11 +533,124 @@ interface GitHubRepositoryOpenPullRequestStatusesQueryResult {
   } | null;
 }
 
+interface GitHubPullRequestReviewThreadsDetailedQueryResult {
+  repository?: {
+    pullRequest?: {
+      reviewThreads?: {
+        pageInfo?: GitHubPageInfo | null;
+        nodes?: Array<{
+          id?: string | null;
+          isResolved?: boolean | null;
+          isOutdated?: boolean | null;
+          path?: string | null;
+          line?: number | null;
+          originalLine?: number | null;
+          startLine?: number | null;
+          originalStartLine?: number | null;
+          comments?: {
+            totalCount?: number | null;
+            nodes?: Array<{
+              id?: string | null;
+              databaseId?: number | null;
+              body?: string | null;
+              url?: string | null;
+              createdAt?: string | null;
+              author?: {
+                login?: string | null;
+              } | null;
+              replyTo?: {
+                id?: string | null;
+              } | null;
+            } | null> | null;
+          } | null;
+        } | null> | null;
+      } | null;
+    } | null;
+  } | null;
+}
+
+interface GitHubAddPullRequestReviewThreadReplyMutationResult {
+  addPullRequestReviewThreadReply?: {
+    comment?: {
+      id?: string | null;
+      body?: string | null;
+      url?: string | null;
+      createdAt?: string | null;
+      author?: {
+        login?: string | null;
+      } | null;
+    } | null;
+  } | null;
+}
+
+interface GitHubResolveReviewThreadMutationResult {
+  resolveReviewThread?: {
+    thread?: {
+      id?: string | null;
+      isResolved?: boolean | null;
+    } | null;
+  } | null;
+}
+
+interface GitHubUnresolveReviewThreadMutationResult {
+  unresolveReviewThread?: {
+    thread?: {
+      id?: string | null;
+      isResolved?: boolean | null;
+    } | null;
+  } | null;
+}
+
+interface GitHubConvertPullRequestToDraftMutationResult {
+  convertPullRequestToDraft?: {
+    pullRequest?: {
+      id?: string | null;
+      number?: number | null;
+      isDraft?: boolean | null;
+      url?: string | null;
+    } | null;
+  } | null;
+}
+
+interface GitHubMarkPullRequestReadyForReviewMutationResult {
+  markPullRequestReadyForReview?: {
+    pullRequest?: {
+      id?: string | null;
+      number?: number | null;
+      isDraft?: boolean | null;
+      url?: string | null;
+    } | null;
+  } | null;
+}
+
 interface GitHubCiContextRecord {
   type: 'checkRun' | 'statusContext';
   status?: string;
   conclusion?: string;
   state?: string;
+}
+
+interface GitHubReviewThreadCommentRecord {
+  id: string;
+  databaseId?: number;
+  body: string;
+  url?: string;
+  createdAt?: string;
+  authorLogin?: string;
+  replyToId?: string;
+}
+
+interface GitHubReviewThreadRecord {
+  id: string;
+  isResolved: boolean;
+  isOutdated: boolean;
+  path?: string;
+  line?: number;
+  originalLine?: number;
+  startLine?: number;
+  originalStartLine?: number;
+  comments: GitHubReviewThreadCommentRecord[];
+  totalCommentCount?: number;
 }
 
 interface SyncProcessingFailure {
@@ -702,6 +817,122 @@ const GITHUB_REPOSITORY_OPEN_PULL_REQUEST_STATUSES_QUERY = `
             }
           }
         }
+      }
+    }
+  }
+`;
+
+const GITHUB_PULL_REQUEST_REVIEW_THREADS_DETAILED_QUERY = `
+  query GitHubPullRequestReviewThreadsDetailed($owner: String!, $repo: String!, $pullRequestNumber: Int!, $after: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pullRequestNumber) {
+        reviewThreads(first: 100, after: $after) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          nodes {
+            id
+            isResolved
+            isOutdated
+            path
+            line
+            originalLine
+            startLine
+            originalStartLine
+            comments(first: 100) {
+              totalCount
+              nodes {
+                id
+                databaseId
+                body
+                url
+                createdAt
+                author {
+                  login
+                }
+                replyTo {
+                  id
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const GITHUB_ADD_PULL_REQUEST_REVIEW_THREAD_REPLY_MUTATION = `
+  mutation GitHubAddPullRequestReviewThreadReply($pullRequestReviewThreadId: ID!, $body: String!) {
+    addPullRequestReviewThreadReply(input: {
+      pullRequestReviewThreadId: $pullRequestReviewThreadId
+      body: $body
+    }) {
+      comment {
+        id
+        body
+        url
+        createdAt
+        author {
+          login
+        }
+      }
+    }
+  }
+`;
+
+const GITHUB_RESOLVE_REVIEW_THREAD_MUTATION = `
+  mutation GitHubResolveReviewThread($threadId: ID!) {
+    resolveReviewThread(input: {
+      threadId: $threadId
+    }) {
+      thread {
+        id
+        isResolved
+      }
+    }
+  }
+`;
+
+const GITHUB_UNRESOLVE_REVIEW_THREAD_MUTATION = `
+  mutation GitHubUnresolveReviewThread($threadId: ID!) {
+    unresolveReviewThread(input: {
+      threadId: $threadId
+    }) {
+      thread {
+        id
+        isResolved
+      }
+    }
+  }
+`;
+
+const GITHUB_CONVERT_PULL_REQUEST_TO_DRAFT_MUTATION = `
+  mutation GitHubConvertPullRequestToDraft($pullRequestId: ID!) {
+    convertPullRequestToDraft(input: {
+      pullRequestId: $pullRequestId
+    }) {
+      pullRequest {
+        id
+        number
+        isDraft
+        url
+      }
+    }
+  }
+`;
+
+const GITHUB_MARK_PULL_REQUEST_READY_FOR_REVIEW_MUTATION = `
+  mutation GitHubMarkPullRequestReadyForReview($pullRequestId: ID!) {
+    markPullRequestReadyForReview(input: {
+      pullRequestId: $pullRequestId
+    }) {
+      pullRequest {
+        id
+        number
+        isDraft
+        url
       }
     }
   }
@@ -5843,6 +6074,530 @@ async function resolveGithubToken(ctx: PluginSetupContext): Promise<string> {
   return configuredTokenSource.token ?? '';
 }
 
+function getToolInputRecord(params: unknown): Record<string, unknown> {
+  return params && typeof params === 'object' ? params as Record<string, unknown> : {};
+}
+
+function normalizeOptionalToolString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function normalizeToolPositiveInteger(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
+function normalizeToolStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const normalizedValues: string[] = [];
+
+  for (const entry of value) {
+    if (typeof entry !== 'string') {
+      continue;
+    }
+
+    const trimmed = entry.trim();
+    const key = trimmed.toLowerCase();
+    if (!trimmed || seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    normalizedValues.push(trimmed);
+  }
+
+  return normalizedValues;
+}
+
+function formatRepositoryLabel(repository: Pick<ParsedRepositoryReference, 'owner' | 'repo'>): string {
+  return `${repository.owner}/${repository.repo}`;
+}
+
+function buildToolSuccessResult(content: string, data: unknown): ToolResult {
+  return {
+    content,
+    data
+  };
+}
+
+function buildToolErrorResult(error: unknown): ToolResult {
+  const rateLimitPause = getGitHubRateLimitPauseDetails(error);
+  if (rateLimitPause) {
+    const resourceLabel = formatGitHubRateLimitResource(rateLimitPause.resource) ?? 'GitHub API';
+    return {
+      error: `${resourceLabel} rate limit reached. Wait until ${formatUtcTimestamp(rateLimitPause.resetAt)} before retrying.`
+    };
+  }
+
+  return {
+    error: getErrorMessage(error)
+  };
+}
+
+async function executeGitHubTool(
+  fn: () => Promise<ToolResult>
+): Promise<ToolResult> {
+  try {
+    return await fn();
+  } catch (error) {
+    return buildToolErrorResult(error);
+  }
+}
+
+async function createGitHubToolOctokit(ctx: PluginSetupContext): Promise<Octokit> {
+  const token = (await resolveGithubToken(ctx)).trim();
+  if (!token) {
+    throw new Error(MISSING_GITHUB_TOKEN_SYNC_MESSAGE);
+  }
+
+  return new Octokit({ auth: token });
+}
+
+async function resolveRepositoryFromRunContext(
+  ctx: PluginSetupContext,
+  runCtx: ToolRunContext
+): Promise<ParsedRepositoryReference> {
+  const settings = normalizeSettings(await ctx.state.get(SETTINGS_SCOPE));
+  const mappings = getSyncableMappingsForTarget(settings.mappings, {
+    kind: 'project',
+    companyId: runCtx.companyId,
+    projectId: runCtx.projectId,
+    displayLabel: 'project'
+  });
+  const repositories = [
+    ...new Map(
+      mappings
+        .map((mapping) => {
+          const repository = parseRepositoryReference(mapping.repositoryUrl);
+          return repository ? [repository.url, repository] as const : null;
+        })
+        .filter((entry): entry is readonly [string, ParsedRepositoryReference] => entry !== null)
+    ).values()
+  ];
+
+  if (repositories.length === 1) {
+    return repositories[0];
+  }
+
+  if (repositories.length === 0) {
+    throw new Error('No GitHub repository is mapped to the current Paperclip project. Pass repository explicitly.');
+  }
+
+  throw new Error('Multiple GitHub repositories are mapped to the current Paperclip project. Pass repository explicitly.');
+}
+
+async function resolveGitHubToolRepository(
+  ctx: PluginSetupContext,
+  runCtx: ToolRunContext,
+  input: Record<string, unknown>
+): Promise<ParsedRepositoryReference> {
+  const explicitRepository = normalizeOptionalToolString(input.repository);
+  if (explicitRepository) {
+    return requireRepositoryReference(explicitRepository);
+  }
+
+  const paperclipIssueId = normalizeOptionalToolString(input.paperclipIssueId);
+  if (paperclipIssueId) {
+    const link = await resolvePaperclipIssueGitHubLink(ctx, paperclipIssueId, runCtx.companyId);
+    if (!link) {
+      throw new Error('This Paperclip issue is not linked to a GitHub issue yet. Pass repository explicitly.');
+    }
+
+    return requireRepositoryReference(link.repositoryUrl);
+  }
+
+  return resolveRepositoryFromRunContext(ctx, runCtx);
+}
+
+async function resolveGitHubIssueToolTarget(
+  ctx: PluginSetupContext,
+  runCtx: ToolRunContext,
+  input: Record<string, unknown>
+): Promise<{
+  repository: ParsedRepositoryReference;
+  issueNumber: number;
+  paperclipIssueId?: string;
+  githubIssueId?: number;
+  githubIssueUrl?: string;
+}> {
+  const paperclipIssueId = normalizeOptionalToolString(input.paperclipIssueId);
+  if (paperclipIssueId) {
+    const link = await resolvePaperclipIssueGitHubLink(ctx, paperclipIssueId, runCtx.companyId);
+    if (!link) {
+      throw new Error('This Paperclip issue is not linked to a GitHub issue yet.');
+    }
+
+    const repository = normalizeOptionalToolString(input.repository)
+      ? requireRepositoryReference(String(input.repository))
+      : requireRepositoryReference(link.repositoryUrl);
+    const explicitIssueNumber = normalizeToolPositiveInteger(input.issueNumber);
+    if (explicitIssueNumber !== undefined && explicitIssueNumber !== link.githubIssueNumber) {
+      throw new Error('The provided issue number does not match the linked GitHub issue for this Paperclip issue.');
+    }
+
+    return {
+      repository,
+      issueNumber: link.githubIssueNumber,
+      paperclipIssueId,
+      githubIssueId: link.githubIssueId,
+      githubIssueUrl: link.githubIssueUrl
+    };
+  }
+
+  const repository = await resolveGitHubToolRepository(ctx, runCtx, input);
+  const issueNumber = normalizeToolPositiveInteger(input.issueNumber);
+  if (issueNumber === undefined) {
+    throw new Error('issueNumber is required when paperclipIssueId is not provided.');
+  }
+
+  return {
+    repository,
+    issueNumber
+  };
+}
+
+async function resolveGitHubPullRequestToolTarget(
+  ctx: PluginSetupContext,
+  runCtx: ToolRunContext,
+  input: Record<string, unknown>
+): Promise<{
+  repository: ParsedRepositoryReference;
+  pullRequestNumber: number;
+  paperclipIssueId?: string;
+}> {
+  const paperclipIssueId = normalizeOptionalToolString(input.paperclipIssueId);
+  if (paperclipIssueId) {
+    const link = await resolvePaperclipIssueGitHubLink(ctx, paperclipIssueId, runCtx.companyId);
+    if (!link) {
+      throw new Error('This Paperclip issue is not linked to GitHub yet.');
+    }
+
+    const repository = normalizeOptionalToolString(input.repository)
+      ? requireRepositoryReference(String(input.repository))
+      : requireRepositoryReference(link.repositoryUrl);
+    const explicitPullRequestNumber = normalizeToolPositiveInteger(input.pullRequestNumber);
+    if (explicitPullRequestNumber !== undefined) {
+      return {
+        repository,
+        pullRequestNumber: explicitPullRequestNumber,
+        paperclipIssueId
+      };
+    }
+
+    if (link.linkedPullRequestNumbers.length === 1) {
+      return {
+        repository,
+        pullRequestNumber: link.linkedPullRequestNumbers[0],
+        paperclipIssueId
+      };
+    }
+
+    throw new Error('pullRequestNumber is required unless the linked Paperclip issue has exactly one linked pull request.');
+  }
+
+  const repository = await resolveGitHubToolRepository(ctx, runCtx, input);
+  const pullRequestNumber = normalizeToolPositiveInteger(input.pullRequestNumber);
+  if (pullRequestNumber === undefined) {
+    throw new Error('pullRequestNumber is required when paperclipIssueId is not provided.');
+  }
+
+  return {
+    repository,
+    pullRequestNumber
+  };
+}
+
+function formatAiAuthorshipFooter(llmModel: string): string {
+  return `\n\n---\n${AI_AUTHORED_COMMENT_FOOTER_PREFIX}${llmModel.trim()}.`;
+}
+
+function appendAiAuthorshipFooter(body: string, llmModel: string): string {
+  const trimmedBody = body.trim();
+  if (!trimmedBody) {
+    throw new Error('Comment body cannot be empty.');
+  }
+
+  const trimmedModel = llmModel.trim();
+  if (!trimmedModel) {
+    throw new Error('llmModel is required when posting a GitHub comment.');
+  }
+
+  return `${trimmedBody}${formatAiAuthorshipFooter(trimmedModel)}`;
+}
+
+async function fetchGitHubIssue(
+  octokit: Octokit,
+  repository: ParsedRepositoryReference,
+  issueNumber: number
+): Promise<GitHubIssueRecord> {
+  const response = await octokit.rest.issues.get({
+    owner: repository.owner,
+    repo: repository.repo,
+    issue_number: issueNumber,
+    headers: {
+      'X-GitHub-Api-Version': GITHUB_API_VERSION
+    }
+  });
+
+  return normalizeGitHubIssueRecord(response.data as GitHubApiIssueRecord);
+}
+
+async function listAllGitHubIssueComments(
+  octokit: Octokit,
+  repository: ParsedRepositoryReference,
+  issueNumber: number
+): Promise<Array<{
+  id: number;
+  body: string;
+  url?: string;
+  authorLogin?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}>> {
+  const comments: Array<{
+    id: number;
+    body: string;
+    url?: string;
+    authorLogin?: string;
+    createdAt?: string;
+    updatedAt?: string;
+  }> = [];
+
+  for await (const response of octokit.paginate.iterator(octokit.rest.issues.listComments, {
+    owner: repository.owner,
+    repo: repository.repo,
+    issue_number: issueNumber,
+    per_page: 100,
+    headers: {
+      'X-GitHub-Api-Version': GITHUB_API_VERSION
+    }
+  })) {
+    for (const comment of response.data) {
+      comments.push({
+        id: comment.id,
+        body: comment.body ?? '',
+        url: comment.html_url ?? undefined,
+        authorLogin: comment.user?.login ?? undefined,
+        createdAt: comment.created_at ?? undefined,
+        updatedAt: comment.updated_at ?? undefined
+      });
+    }
+  }
+
+  return comments;
+}
+
+async function listAllPullRequestFiles(
+  octokit: Octokit,
+  repository: ParsedRepositoryReference,
+  pullRequestNumber: number
+): Promise<Array<{
+  filename: string;
+  status?: string;
+  additions: number;
+  deletions: number;
+  changes: number;
+  patch?: string;
+  blobUrl?: string;
+}>> {
+  const files: Array<{
+    filename: string;
+    status?: string;
+    additions: number;
+    deletions: number;
+    changes: number;
+    patch?: string;
+    blobUrl?: string;
+  }> = [];
+
+  for await (const response of octokit.paginate.iterator(octokit.rest.pulls.listFiles, {
+    owner: repository.owner,
+    repo: repository.repo,
+    pull_number: pullRequestNumber,
+    per_page: 100,
+    headers: {
+      'X-GitHub-Api-Version': GITHUB_API_VERSION
+    }
+  })) {
+    for (const file of response.data) {
+      files.push({
+        filename: file.filename,
+        status: file.status ?? undefined,
+        additions: file.additions,
+        deletions: file.deletions,
+        changes: file.changes,
+        patch: file.patch ?? undefined,
+        blobUrl: file.blob_url ?? undefined
+      });
+    }
+  }
+
+  return files;
+}
+
+function normalizeGitHubReviewThreadComment(
+  value: {
+    id?: string | null;
+    databaseId?: number | null;
+    body?: string | null;
+    url?: string | null;
+    createdAt?: string | null;
+    author?: {
+      login?: string | null;
+    } | null;
+    replyTo?: {
+      id?: string | null;
+    } | null;
+  } | null | undefined
+): GitHubReviewThreadCommentRecord | null {
+  if (!value?.id) {
+    return null;
+  }
+
+  return {
+    id: value.id,
+    ...(typeof value.databaseId === 'number' ? { databaseId: value.databaseId } : {}),
+    body: value.body ?? '',
+    ...(value.url ? { url: value.url } : {}),
+    ...(value.createdAt ? { createdAt: value.createdAt } : {}),
+    ...(value.author?.login ? { authorLogin: value.author.login } : {}),
+    ...(value.replyTo?.id ? { replyToId: value.replyTo.id } : {})
+  };
+}
+
+function normalizeGitHubReviewThread(
+  value: {
+    id?: string | null;
+    isResolved?: boolean | null;
+    isOutdated?: boolean | null;
+    path?: string | null;
+    line?: number | null;
+    originalLine?: number | null;
+    startLine?: number | null;
+    originalStartLine?: number | null;
+    comments?: {
+      totalCount?: number | null;
+      nodes?: Array<{
+        id?: string | null;
+        databaseId?: number | null;
+        body?: string | null;
+        url?: string | null;
+        createdAt?: string | null;
+        author?: {
+          login?: string | null;
+        } | null;
+        replyTo?: {
+          id?: string | null;
+        } | null;
+      } | null> | null;
+    } | null;
+  } | null | undefined
+): GitHubReviewThreadRecord | null {
+  if (!value?.id) {
+    return null;
+  }
+
+  const comments = (value.comments?.nodes ?? [])
+    .map((comment) => normalizeGitHubReviewThreadComment(comment))
+    .filter((comment): comment is GitHubReviewThreadCommentRecord => comment !== null);
+
+  return {
+    id: value.id,
+    isResolved: value.isResolved === true,
+    isOutdated: value.isOutdated === true,
+    ...(value.path ? { path: value.path } : {}),
+    ...(typeof value.line === 'number' ? { line: value.line } : {}),
+    ...(typeof value.originalLine === 'number' ? { originalLine: value.originalLine } : {}),
+    ...(typeof value.startLine === 'number' ? { startLine: value.startLine } : {}),
+    ...(typeof value.originalStartLine === 'number' ? { originalStartLine: value.originalStartLine } : {}),
+    comments,
+    ...(typeof value.comments?.totalCount === 'number' ? { totalCommentCount: value.comments.totalCount } : {})
+  };
+}
+
+async function listDetailedPullRequestReviewThreads(
+  octokit: Octokit,
+  repository: ParsedRepositoryReference,
+  pullRequestNumber: number
+): Promise<GitHubReviewThreadRecord[]> {
+  const threads: GitHubReviewThreadRecord[] = [];
+  let after: string | undefined;
+
+  do {
+    const response = await octokit.graphql<GitHubPullRequestReviewThreadsDetailedQueryResult>(
+      GITHUB_PULL_REQUEST_REVIEW_THREADS_DETAILED_QUERY,
+      {
+        owner: repository.owner,
+        repo: repository.repo,
+        pullRequestNumber,
+        after
+      }
+    );
+
+    const connection = response.repository?.pullRequest?.reviewThreads;
+    for (const node of connection?.nodes ?? []) {
+      const thread = normalizeGitHubReviewThread(node);
+      if (thread) {
+        threads.push(thread);
+      }
+    }
+
+    after = getPageCursor(connection?.pageInfo);
+  } while (after);
+
+  return threads;
+}
+
+async function updatePullRequestDraftState(
+  octokit: Octokit,
+  pullRequestNodeId: string,
+  isDraft: boolean
+): Promise<void> {
+  if (isDraft) {
+    await octokit.graphql<GitHubConvertPullRequestToDraftMutationResult>(
+      GITHUB_CONVERT_PULL_REQUEST_TO_DRAFT_MUTATION,
+      {
+        pullRequestId: pullRequestNodeId
+      }
+    );
+    return;
+  }
+
+  await octokit.graphql<GitHubMarkPullRequestReadyForReviewMutationResult>(
+    GITHUB_MARK_PULL_REQUEST_READY_FOR_REVIEW_MUTATION,
+    {
+      pullRequestId: pullRequestNodeId
+    }
+  );
+}
+
+function mergeNamedValues(
+  currentValues: string[],
+  params: {
+    setValues: string[];
+    addValues: string[];
+    removeValues: string[];
+  }
+): string[] {
+  if (params.setValues.length > 0) {
+    return params.setValues;
+  }
+
+  const values = new Map(currentValues.map((value) => [value.toLowerCase(), value] as const));
+  for (const value of params.addValues) {
+    values.set(value.toLowerCase(), value);
+  }
+
+  for (const value of params.removeValues) {
+    values.delete(value.toLowerCase());
+  }
+
+  return [...values.values()];
+}
+
 async function validateGithubToken(token: string): Promise<TokenValidationResult> {
   const octokit = new Octokit({ auth: token.trim() });
 
@@ -6532,6 +7287,751 @@ async function startSync(
   }
 }
 
+function registerGitHubAgentTools(ctx: PluginSetupContext): void {
+  ctx.tools.register(
+    'search_repository_items',
+    getGitHubAgentToolDeclaration('search_repository_items'),
+    async (params, runCtx) => executeGitHubTool(async () => {
+      const input = getToolInputRecord(params);
+      const octokit = await createGitHubToolOctokit(ctx);
+      const repository = await resolveGitHubToolRepository(ctx, runCtx, input);
+      const query = normalizeOptionalToolString(input.query);
+      if (!query) {
+        throw new Error('query is required.');
+      }
+
+      const type = input.type === 'issue' || input.type === 'pull_request' || input.type === 'all'
+        ? input.type
+        : 'all';
+      const state = input.state === 'open' || input.state === 'closed' || input.state === 'all'
+        ? input.state
+        : 'all';
+      const labels = normalizeToolStringArray(input.labels);
+      const limit = normalizeToolPositiveInteger(input.limit) ?? 10;
+      const searchTerms = [
+        `repo:${formatRepositoryLabel(repository)}`,
+        query.trim(),
+        type === 'issue' ? 'is:issue' : type === 'pull_request' ? 'is:pr' : '',
+        state === 'open' ? 'is:open' : state === 'closed' ? 'is:closed' : '',
+        normalizeOptionalToolString(input.author) ? `author:${normalizeOptionalToolString(input.author)}` : '',
+        normalizeOptionalToolString(input.assignee) ? `assignee:${normalizeOptionalToolString(input.assignee)}` : '',
+        ...labels.map((label) => `label:"${label.replace(/"/g, '\\"')}"`)
+      ].filter(Boolean);
+      const response = await octokit.rest.search.issuesAndPullRequests({
+        q: searchTerms.join(' '),
+        per_page: Math.min(limit, 50),
+        headers: {
+          'X-GitHub-Api-Version': GITHUB_API_VERSION
+        }
+      });
+      const items = response.data.items.map((item) => ({
+        number: item.number,
+        title: item.title,
+        kind: item.pull_request ? 'pull_request' as const : 'issue' as const,
+        state: item.state,
+        url: item.html_url,
+        createdAt: item.created_at,
+        updatedAt: item.updated_at,
+        authorLogin: item.user?.login ?? undefined,
+        labels: (item.labels ?? []).map((label) => {
+          if (typeof label === 'string') {
+            return {
+              name: label
+            };
+          }
+
+          return {
+            name: label.name ?? '',
+            color: label.color ?? undefined
+          };
+        }).filter((label) => label.name)
+      }));
+
+      return buildToolSuccessResult(
+        `Found ${items.length} matching GitHub ${items.length === 1 ? 'item' : 'items'} in ${formatRepositoryLabel(repository)}.`,
+        {
+          repository: repository.url,
+          query,
+          type,
+          state,
+          items
+        }
+      );
+    })
+  );
+
+  ctx.tools.register(
+    'get_issue',
+    getGitHubAgentToolDeclaration('get_issue'),
+    async (params, runCtx) => executeGitHubTool(async () => {
+      const input = getToolInputRecord(params);
+      const target = await resolveGitHubIssueToolTarget(ctx, runCtx, input);
+      const octokit = await createGitHubToolOctokit(ctx);
+      const response = await octokit.rest.issues.get({
+        owner: target.repository.owner,
+        repo: target.repository.repo,
+        issue_number: target.issueNumber,
+        headers: {
+          'X-GitHub-Api-Version': GITHUB_API_VERSION
+        }
+      });
+      const issue = normalizeGitHubIssueRecord(response.data as GitHubApiIssueRecord);
+      const linkedPullRequests = await listLinkedPullRequestsForIssue(octokit, target.repository, target.issueNumber);
+      const assignees = (response.data.assignees ?? [])
+        .map((assignee) => assignee?.login ?? '')
+        .filter(Boolean);
+      const milestone = response.data.milestone
+        ? {
+            number: response.data.milestone.number,
+            title: response.data.milestone.title,
+            state: response.data.milestone.state,
+            description: response.data.milestone.description ?? undefined,
+            dueOn: response.data.milestone.due_on ?? undefined,
+            url: response.data.milestone.html_url ?? undefined
+          }
+        : null;
+
+      return buildToolSuccessResult(
+        `Loaded GitHub issue #${issue.number} from ${formatRepositoryLabel(target.repository)}.`,
+        {
+          repository: target.repository.url,
+          issue: {
+            number: issue.number,
+            title: issue.title,
+            body: issue.body,
+            url: issue.htmlUrl,
+            state: issue.state,
+            stateReason: issue.stateReason,
+            labels: issue.labels,
+            assignees,
+            milestone,
+            commentsCount: issue.commentsCount,
+            linkedPullRequests
+          }
+        }
+      );
+    })
+  );
+
+  ctx.tools.register(
+    'list_issue_comments',
+    getGitHubAgentToolDeclaration('list_issue_comments'),
+    async (params, runCtx) => executeGitHubTool(async () => {
+      const input = getToolInputRecord(params);
+      const target = await resolveGitHubIssueToolTarget(ctx, runCtx, input);
+      const octokit = await createGitHubToolOctokit(ctx);
+      const comments = await listAllGitHubIssueComments(octokit, target.repository, target.issueNumber);
+
+      return buildToolSuccessResult(
+        `Loaded ${comments.length} GitHub ${comments.length === 1 ? 'comment' : 'comments'} from issue #${target.issueNumber}.`,
+        {
+          repository: target.repository.url,
+          issueNumber: target.issueNumber,
+          comments
+        }
+      );
+    })
+  );
+
+  ctx.tools.register(
+    'update_issue',
+    getGitHubAgentToolDeclaration('update_issue'),
+    async (params, runCtx) => executeGitHubTool(async () => {
+      const input = getToolInputRecord(params);
+      const target = await resolveGitHubIssueToolTarget(ctx, runCtx, input);
+      const octokit = await createGitHubToolOctokit(ctx);
+      const currentResponse = await octokit.rest.issues.get({
+        owner: target.repository.owner,
+        repo: target.repository.repo,
+        issue_number: target.issueNumber,
+        headers: {
+          'X-GitHub-Api-Version': GITHUB_API_VERSION
+        }
+      });
+      const currentIssue = currentResponse.data;
+      const currentLabels = normalizeGitHubIssueLabels((currentIssue as GitHubApiIssueRecord).labels).map((label) => label.name);
+      const currentAssignees = (currentIssue.assignees ?? [])
+        .map((assignee) => assignee?.login ?? '')
+        .filter(Boolean);
+      const nextLabels = mergeNamedValues(currentLabels, {
+        setValues: normalizeToolStringArray(input.setLabels),
+        addValues: normalizeToolStringArray(input.addLabels),
+        removeValues: normalizeToolStringArray(input.removeLabels)
+      });
+      const nextAssignees = mergeNamedValues(currentAssignees, {
+        setValues: normalizeToolStringArray(input.setAssignees),
+        addValues: normalizeToolStringArray(input.addAssignees),
+        removeValues: normalizeToolStringArray(input.removeAssignees)
+      });
+      const title = Object.prototype.hasOwnProperty.call(input, 'title') && typeof input.title === 'string'
+        ? input.title
+        : undefined;
+      const body = Object.prototype.hasOwnProperty.call(input, 'body') && typeof input.body === 'string'
+        ? input.body
+        : undefined;
+      const state = input.state === 'open' || input.state === 'closed' ? input.state : undefined;
+      const milestoneNumber = Object.prototype.hasOwnProperty.call(input, 'milestoneNumber')
+        ? input.milestoneNumber === null
+          ? null
+          : normalizeToolPositiveInteger(input.milestoneNumber)
+        : undefined;
+
+      const hasChanges =
+        title !== undefined ||
+        body !== undefined ||
+        state !== undefined ||
+        Object.prototype.hasOwnProperty.call(input, 'milestoneNumber') ||
+        normalizeToolStringArray(input.setLabels).length > 0 ||
+        normalizeToolStringArray(input.addLabels).length > 0 ||
+        normalizeToolStringArray(input.removeLabels).length > 0 ||
+        normalizeToolStringArray(input.setAssignees).length > 0 ||
+        normalizeToolStringArray(input.addAssignees).length > 0 ||
+        normalizeToolStringArray(input.removeAssignees).length > 0;
+
+      const updatedResponse = hasChanges
+        ? await octokit.rest.issues.update({
+            owner: target.repository.owner,
+            repo: target.repository.repo,
+            issue_number: target.issueNumber,
+            ...(title !== undefined ? { title } : {}),
+            ...(body !== undefined ? { body } : {}),
+            ...(state ? { state } : {}),
+            ...(Object.prototype.hasOwnProperty.call(input, 'milestoneNumber') ? { milestone: milestoneNumber } : {}),
+            labels: nextLabels,
+            assignees: nextAssignees,
+            headers: {
+              'X-GitHub-Api-Version': GITHUB_API_VERSION
+            }
+          })
+        : currentResponse;
+      const updatedIssue = normalizeGitHubIssueRecord(updatedResponse.data as GitHubApiIssueRecord);
+
+      return buildToolSuccessResult(
+        hasChanges
+          ? `Updated GitHub issue #${updatedIssue.number} in ${formatRepositoryLabel(target.repository)}.`
+          : `No GitHub issue changes were requested for #${updatedIssue.number}.`,
+        {
+          repository: target.repository.url,
+          issue: {
+            number: updatedIssue.number,
+            title: updatedIssue.title,
+            body: updatedIssue.body,
+            url: updatedIssue.htmlUrl,
+            state: updatedIssue.state,
+            stateReason: updatedIssue.stateReason,
+            labels: normalizeGitHubIssueLabels((updatedResponse.data as GitHubApiIssueRecord).labels),
+            assignees: (updatedResponse.data.assignees ?? []).map((assignee) => assignee?.login ?? '').filter(Boolean),
+            milestone: updatedResponse.data.milestone
+              ? {
+                  number: updatedResponse.data.milestone.number,
+                  title: updatedResponse.data.milestone.title,
+                  state: updatedResponse.data.milestone.state,
+                  url: updatedResponse.data.milestone.html_url ?? undefined
+                }
+              : null
+          }
+        }
+      );
+    })
+  );
+
+  ctx.tools.register(
+    'add_issue_comment',
+    getGitHubAgentToolDeclaration('add_issue_comment'),
+    async (params, runCtx) => executeGitHubTool(async () => {
+      const input = getToolInputRecord(params);
+      const target = await resolveGitHubIssueToolTarget(ctx, runCtx, input);
+      const octokit = await createGitHubToolOctokit(ctx);
+      const body = appendAiAuthorshipFooter(String(input.body ?? ''), normalizeOptionalToolString(input.llmModel) ?? '');
+      const response = await octokit.rest.issues.createComment({
+        owner: target.repository.owner,
+        repo: target.repository.repo,
+        issue_number: target.issueNumber,
+        body,
+        headers: {
+          'X-GitHub-Api-Version': GITHUB_API_VERSION
+        }
+      });
+
+      return buildToolSuccessResult(
+        `Posted a GitHub comment on issue #${target.issueNumber}.`,
+        {
+          repository: target.repository.url,
+          issueNumber: target.issueNumber,
+          comment: {
+            id: response.data.id,
+            url: response.data.html_url ?? undefined,
+            body: response.data.body ?? '',
+            authorLogin: response.data.user?.login ?? undefined,
+            createdAt: response.data.created_at ?? undefined
+          }
+        }
+      );
+    })
+  );
+
+  ctx.tools.register(
+    'create_pull_request',
+    getGitHubAgentToolDeclaration('create_pull_request'),
+    async (params, runCtx) => executeGitHubTool(async () => {
+      const input = getToolInputRecord(params);
+      const repository = await resolveGitHubToolRepository(ctx, runCtx, input);
+      const head = normalizeOptionalToolString(input.head);
+      const base = normalizeOptionalToolString(input.base);
+      const title = normalizeOptionalToolString(input.title);
+      if (!head || !base || !title) {
+        throw new Error('head, base, and title are required.');
+      }
+
+      const octokit = await createGitHubToolOctokit(ctx);
+      const response = await octokit.rest.pulls.create({
+        owner: repository.owner,
+        repo: repository.repo,
+        head,
+        base,
+        title,
+        ...(typeof input.body === 'string' ? { body: input.body } : {}),
+        ...(typeof input.draft === 'boolean' ? { draft: input.draft } : {}),
+        headers: {
+          'X-GitHub-Api-Version': GITHUB_API_VERSION
+        }
+      });
+
+      return buildToolSuccessResult(
+        `Created pull request #${response.data.number} in ${formatRepositoryLabel(repository)}.`,
+        {
+          repository: repository.url,
+          pullRequest: {
+            number: response.data.number,
+            title: response.data.title,
+            body: response.data.body ?? '',
+            url: response.data.html_url,
+            state: response.data.state,
+            isDraft: response.data.draft,
+            headRefName: response.data.head.ref,
+            baseRefName: response.data.base.ref
+          }
+        }
+      );
+    })
+  );
+
+  ctx.tools.register(
+    'get_pull_request',
+    getGitHubAgentToolDeclaration('get_pull_request'),
+    async (params, runCtx) => executeGitHubTool(async () => {
+      const input = getToolInputRecord(params);
+      const target = await resolveGitHubPullRequestToolTarget(ctx, runCtx, input);
+      const octokit = await createGitHubToolOctokit(ctx);
+      const response = await octokit.rest.pulls.get({
+        owner: target.repository.owner,
+        repo: target.repository.repo,
+        pull_number: target.pullRequestNumber,
+        headers: {
+          'X-GitHub-Api-Version': GITHUB_API_VERSION
+        }
+      });
+      const snapshot = await getGitHubPullRequestStatusSnapshot(
+        octokit,
+        target.repository,
+        target.pullRequestNumber,
+        new Map()
+      );
+
+      return buildToolSuccessResult(
+        `Loaded pull request #${response.data.number} from ${formatRepositoryLabel(target.repository)}.`,
+        {
+          repository: target.repository.url,
+          pullRequest: {
+            number: response.data.number,
+            title: response.data.title,
+            body: response.data.body ?? '',
+            url: response.data.html_url,
+            state: response.data.state,
+            isDraft: response.data.draft,
+            merged: response.data.merged,
+            mergeable: response.data.mergeable,
+            mergeableState: response.data.mergeable_state,
+            headRefName: response.data.head.ref,
+            headSha: response.data.head.sha,
+            baseRefName: response.data.base.ref,
+            authorLogin: response.data.user?.login ?? undefined,
+            requestedReviewers: (response.data.requested_reviewers ?? []).map((reviewer) => reviewer?.login ?? '').filter(Boolean),
+            requestedTeams: (response.data.requested_teams ?? []).map((team) => team?.slug ?? '').filter(Boolean),
+            ciState: snapshot.ciState,
+            hasUnresolvedReviewThreads: snapshot.hasUnresolvedReviewThreads
+          }
+        }
+      );
+    })
+  );
+
+  ctx.tools.register(
+    'update_pull_request',
+    getGitHubAgentToolDeclaration('update_pull_request'),
+    async (params, runCtx) => executeGitHubTool(async () => {
+      const input = getToolInputRecord(params);
+      const target = await resolveGitHubPullRequestToolTarget(ctx, runCtx, input);
+      const octokit = await createGitHubToolOctokit(ctx);
+      let currentResponse = await octokit.rest.pulls.get({
+        owner: target.repository.owner,
+        repo: target.repository.repo,
+        pull_number: target.pullRequestNumber,
+        headers: {
+          'X-GitHub-Api-Version': GITHUB_API_VERSION
+        }
+      });
+      const title = Object.prototype.hasOwnProperty.call(input, 'title') && typeof input.title === 'string'
+        ? input.title
+        : undefined;
+      const body = Object.prototype.hasOwnProperty.call(input, 'body') && typeof input.body === 'string'
+        ? input.body
+        : undefined;
+      const base = normalizeOptionalToolString(input.base);
+      const state = input.state === 'open' || input.state === 'closed' ? input.state : undefined;
+      const isDraft = typeof input.isDraft === 'boolean' ? input.isDraft : undefined;
+
+      if (title !== undefined || body !== undefined || base !== undefined || state !== undefined) {
+        currentResponse = await octokit.rest.pulls.update({
+          owner: target.repository.owner,
+          repo: target.repository.repo,
+          pull_number: target.pullRequestNumber,
+          ...(title !== undefined ? { title } : {}),
+          ...(body !== undefined ? { body } : {}),
+          ...(base !== undefined ? { base } : {}),
+          ...(state !== undefined ? { state } : {}),
+          headers: {
+            'X-GitHub-Api-Version': GITHUB_API_VERSION
+          }
+        });
+      }
+
+      if (isDraft !== undefined && currentResponse.data.draft !== isDraft) {
+        if (!currentResponse.data.node_id) {
+          throw new Error('GitHub did not return a pull request node id, so draft state cannot be updated.');
+        }
+
+        await updatePullRequestDraftState(octokit, currentResponse.data.node_id, isDraft);
+        currentResponse = await octokit.rest.pulls.get({
+          owner: target.repository.owner,
+          repo: target.repository.repo,
+          pull_number: target.pullRequestNumber,
+          headers: {
+            'X-GitHub-Api-Version': GITHUB_API_VERSION
+          }
+        });
+      }
+
+      return buildToolSuccessResult(
+        `Updated pull request #${currentResponse.data.number} in ${formatRepositoryLabel(target.repository)}.`,
+        {
+          repository: target.repository.url,
+          pullRequest: {
+            number: currentResponse.data.number,
+            title: currentResponse.data.title,
+            body: currentResponse.data.body ?? '',
+            url: currentResponse.data.html_url,
+            state: currentResponse.data.state,
+            isDraft: currentResponse.data.draft,
+            baseRefName: currentResponse.data.base.ref
+          }
+        }
+      );
+    })
+  );
+
+  ctx.tools.register(
+    'list_pull_request_files',
+    getGitHubAgentToolDeclaration('list_pull_request_files'),
+    async (params, runCtx) => executeGitHubTool(async () => {
+      const input = getToolInputRecord(params);
+      const target = await resolveGitHubPullRequestToolTarget(ctx, runCtx, input);
+      const octokit = await createGitHubToolOctokit(ctx);
+      const files = await listAllPullRequestFiles(octokit, target.repository, target.pullRequestNumber);
+
+      return buildToolSuccessResult(
+        `Loaded ${files.length} changed ${files.length === 1 ? 'file' : 'files'} from pull request #${target.pullRequestNumber}.`,
+        {
+          repository: target.repository.url,
+          pullRequestNumber: target.pullRequestNumber,
+          files
+        }
+      );
+    })
+  );
+
+  ctx.tools.register(
+    'get_pull_request_checks',
+    getGitHubAgentToolDeclaration('get_pull_request_checks'),
+    async (params, runCtx) => executeGitHubTool(async () => {
+      const input = getToolInputRecord(params);
+      const target = await resolveGitHubPullRequestToolTarget(ctx, runCtx, input);
+      const octokit = await createGitHubToolOctokit(ctx);
+      const pullRequestResponse = await octokit.rest.pulls.get({
+        owner: target.repository.owner,
+        repo: target.repository.repo,
+        pull_number: target.pullRequestNumber,
+        headers: {
+          'X-GitHub-Api-Version': GITHUB_API_VERSION
+        }
+      });
+      const headSha = pullRequestResponse.data.head.sha;
+      const [snapshotResult, checksResult, statusResult, workflowRunsResult] = await Promise.allSettled([
+        getGitHubPullRequestStatusSnapshot(octokit, target.repository, target.pullRequestNumber, new Map()),
+        octokit.rest.checks.listForRef({
+          owner: target.repository.owner,
+          repo: target.repository.repo,
+          ref: headSha,
+          per_page: 100,
+          headers: {
+            'X-GitHub-Api-Version': GITHUB_API_VERSION
+          }
+        }),
+        octokit.rest.repos.getCombinedStatusForRef({
+          owner: target.repository.owner,
+          repo: target.repository.repo,
+          ref: headSha,
+          per_page: 100,
+          headers: {
+            'X-GitHub-Api-Version': GITHUB_API_VERSION
+          }
+        }),
+        octokit.rest.actions.listWorkflowRunsForRepo({
+          owner: target.repository.owner,
+          repo: target.repository.repo,
+          head_sha: headSha,
+          per_page: 20,
+          headers: {
+            'X-GitHub-Api-Version': GITHUB_API_VERSION
+          }
+        })
+      ]);
+      const warnings = [
+        checksResult.status === 'rejected' ? `check_runs_unavailable: ${getErrorMessage(checksResult.reason)}` : null,
+        statusResult.status === 'rejected' ? `status_contexts_unavailable: ${getErrorMessage(statusResult.reason)}` : null,
+        workflowRunsResult.status === 'rejected' ? `workflow_runs_unavailable: ${getErrorMessage(workflowRunsResult.reason)}` : null
+      ].filter((warning): warning is string => warning !== null);
+      const snapshot = snapshotResult.status === 'fulfilled'
+        ? snapshotResult.value
+        : {
+            number: target.pullRequestNumber,
+            hasUnresolvedReviewThreads: false,
+            ciState: 'unfinished' as const
+          };
+
+      return buildToolSuccessResult(
+        `Loaded CI status for pull request #${target.pullRequestNumber} in ${formatRepositoryLabel(target.repository)}.`,
+        {
+          repository: target.repository.url,
+          pullRequestNumber: target.pullRequestNumber,
+          headSha,
+          ciState: snapshot.ciState,
+          hasUnresolvedReviewThreads: snapshot.hasUnresolvedReviewThreads,
+          checkRuns: checksResult.status === 'fulfilled'
+            ? checksResult.value.data.check_runs.map((checkRun) => ({
+                id: checkRun.id,
+                name: checkRun.name,
+                status: checkRun.status,
+                conclusion: checkRun.conclusion ?? undefined,
+                detailsUrl: checkRun.details_url ?? undefined,
+                startedAt: checkRun.started_at ?? undefined,
+                completedAt: checkRun.completed_at ?? undefined,
+                appName: checkRun.app?.name ?? undefined
+              }))
+            : [],
+          statusContexts: statusResult.status === 'fulfilled'
+            ? statusResult.value.data.statuses.map((statusEntry) => ({
+                context: statusEntry.context,
+                state: statusEntry.state,
+                description: statusEntry.description ?? undefined,
+                targetUrl: statusEntry.target_url ?? undefined,
+                createdAt: statusEntry.created_at ?? undefined,
+                updatedAt: statusEntry.updated_at ?? undefined
+              }))
+            : [],
+          workflowRuns: workflowRunsResult.status === 'fulfilled'
+            ? workflowRunsResult.value.data.workflow_runs.map((workflowRun) => ({
+                id: workflowRun.id,
+                name: workflowRun.name,
+                displayTitle: workflowRun.display_title ?? undefined,
+                status: workflowRun.status,
+                conclusion: workflowRun.conclusion ?? undefined,
+                event: workflowRun.event,
+                url: workflowRun.html_url,
+                headBranch: workflowRun.head_branch,
+                runNumber: workflowRun.run_number
+              }))
+            : [],
+          warnings
+        }
+      );
+    })
+  );
+
+  ctx.tools.register(
+    'list_pull_request_review_threads',
+    getGitHubAgentToolDeclaration('list_pull_request_review_threads'),
+    async (params, runCtx) => executeGitHubTool(async () => {
+      const input = getToolInputRecord(params);
+      const target = await resolveGitHubPullRequestToolTarget(ctx, runCtx, input);
+      const octokit = await createGitHubToolOctokit(ctx);
+      const threads = await listDetailedPullRequestReviewThreads(octokit, target.repository, target.pullRequestNumber);
+
+      return buildToolSuccessResult(
+        `Loaded ${threads.length} review ${threads.length === 1 ? 'thread' : 'threads'} from pull request #${target.pullRequestNumber}.`,
+        {
+          repository: target.repository.url,
+          pullRequestNumber: target.pullRequestNumber,
+          threads
+        }
+      );
+    })
+  );
+
+  ctx.tools.register(
+    'reply_to_review_thread',
+    getGitHubAgentToolDeclaration('reply_to_review_thread'),
+    async (params) => executeGitHubTool(async () => {
+      const input = getToolInputRecord(params);
+      const threadId = normalizeOptionalToolString(input.threadId);
+      if (!threadId) {
+        throw new Error('threadId is required.');
+      }
+
+      const body = appendAiAuthorshipFooter(String(input.body ?? ''), normalizeOptionalToolString(input.llmModel) ?? '');
+      const octokit = await createGitHubToolOctokit(ctx);
+      const response = await octokit.graphql<GitHubAddPullRequestReviewThreadReplyMutationResult>(
+        GITHUB_ADD_PULL_REQUEST_REVIEW_THREAD_REPLY_MUTATION,
+        {
+          pullRequestReviewThreadId: threadId,
+          body
+        }
+      );
+      const comment = response.addPullRequestReviewThreadReply?.comment;
+      if (!comment?.id) {
+        throw new Error('GitHub did not return the created review-thread reply.');
+      }
+
+      return buildToolSuccessResult(
+        'Posted a reply to the GitHub review thread.',
+        {
+          comment: {
+            id: comment.id,
+            body: comment.body ?? '',
+            url: comment.url ?? undefined,
+            createdAt: comment.createdAt ?? undefined,
+            authorLogin: comment.author?.login ?? undefined
+          }
+        }
+      );
+    })
+  );
+
+  ctx.tools.register(
+    'resolve_review_thread',
+    getGitHubAgentToolDeclaration('resolve_review_thread'),
+    async (params) => executeGitHubTool(async () => {
+      const input = getToolInputRecord(params);
+      const threadId = normalizeOptionalToolString(input.threadId);
+      if (!threadId) {
+        throw new Error('threadId is required.');
+      }
+
+      const octokit = await createGitHubToolOctokit(ctx);
+      const response = await octokit.graphql<GitHubResolveReviewThreadMutationResult>(
+        GITHUB_RESOLVE_REVIEW_THREAD_MUTATION,
+        {
+          threadId
+        }
+      );
+      const thread = response.resolveReviewThread?.thread;
+      if (!thread?.id) {
+        throw new Error('GitHub did not return the updated review thread.');
+      }
+
+      return buildToolSuccessResult(
+        'Resolved the GitHub review thread.',
+        {
+          thread: {
+            id: thread.id,
+            isResolved: thread.isResolved === true
+          }
+        }
+      );
+    })
+  );
+
+  ctx.tools.register(
+    'unresolve_review_thread',
+    getGitHubAgentToolDeclaration('unresolve_review_thread'),
+    async (params) => executeGitHubTool(async () => {
+      const input = getToolInputRecord(params);
+      const threadId = normalizeOptionalToolString(input.threadId);
+      if (!threadId) {
+        throw new Error('threadId is required.');
+      }
+
+      const octokit = await createGitHubToolOctokit(ctx);
+      const response = await octokit.graphql<GitHubUnresolveReviewThreadMutationResult>(
+        GITHUB_UNRESOLVE_REVIEW_THREAD_MUTATION,
+        {
+          threadId
+        }
+      );
+      const thread = response.unresolveReviewThread?.thread;
+      if (!thread?.id) {
+        throw new Error('GitHub did not return the updated review thread.');
+      }
+
+      return buildToolSuccessResult(
+        'Reopened the GitHub review thread.',
+        {
+          thread: {
+            id: thread.id,
+            isResolved: thread.isResolved === true
+          }
+        }
+      );
+    })
+  );
+
+  ctx.tools.register(
+    'request_pull_request_reviewers',
+    getGitHubAgentToolDeclaration('request_pull_request_reviewers'),
+    async (params, runCtx) => executeGitHubTool(async () => {
+      const input = getToolInputRecord(params);
+      const target = await resolveGitHubPullRequestToolTarget(ctx, runCtx, input);
+      const userReviewers = normalizeToolStringArray(input.userReviewers);
+      const teamReviewers = normalizeToolStringArray(input.teamReviewers);
+      if (userReviewers.length === 0 && teamReviewers.length === 0) {
+        throw new Error('Provide at least one user reviewer or team reviewer.');
+      }
+
+      const octokit = await createGitHubToolOctokit(ctx);
+      const response = await octokit.rest.pulls.requestReviewers({
+        owner: target.repository.owner,
+        repo: target.repository.repo,
+        pull_number: target.pullRequestNumber,
+        reviewers: userReviewers,
+        team_reviewers: teamReviewers,
+        headers: {
+          'X-GitHub-Api-Version': GITHUB_API_VERSION
+        }
+      });
+
+      return buildToolSuccessResult(
+        `Requested reviewers for pull request #${target.pullRequestNumber}.`,
+        {
+          repository: target.repository.url,
+          pullRequestNumber: target.pullRequestNumber,
+          requestedReviewers: (response.data.requested_reviewers ?? []).map((reviewer) => reviewer?.login ?? '').filter(Boolean),
+          requestedTeams: (response.data.requested_teams ?? []).map((team) => team?.slug ?? '').filter(Boolean)
+        }
+      );
+    })
+  );
+}
+
 const plugin = definePlugin({
   async setup(ctx) {
     ctx.data.register('settings.registration', async (input) => {
@@ -6737,6 +8237,8 @@ const plugin = definePlugin({
         ...(target ? { target } : {})
       });
     });
+
+    registerGitHubAgentTools(ctx);
 
     ctx.jobs.register('sync.github-issues', async (job) => {
       const settings = normalizeSettings(await ctx.state.get(SETTINGS_SCOPE));

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -6116,6 +6116,32 @@ function formatRepositoryLabel(repository: Pick<ParsedRepositoryReference, 'owne
   return `${repository.owner}/${repository.repo}`;
 }
 
+function assertExplicitRepositoryMatchesLinkedRepository(
+  explicitRepositoryInput: unknown,
+  linkedRepositoryUrl: string,
+  mismatchMessage: string
+): ParsedRepositoryReference {
+  const linkedRepository = requireRepositoryReference(linkedRepositoryUrl);
+  const explicitRepository = normalizeOptionalToolString(explicitRepositoryInput);
+  if (!explicitRepository) {
+    return linkedRepository;
+  }
+
+  const requestedRepository = requireRepositoryReference(explicitRepository);
+  if (!areRepositoriesEqual(requestedRepository, linkedRepository)) {
+    throw new Error(mismatchMessage);
+  }
+
+  return linkedRepository;
+}
+
+function sanitizeRepositoryScopedSearchQuery(query: string): string {
+  return query
+    .replace(/(^|\s)(?:repo|org|user):(?:"[^"]+"|\S+)/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 function buildToolSuccessResult(content: string, data: unknown): ToolResult {
   return {
     content,
@@ -6230,9 +6256,11 @@ async function resolveGitHubIssueToolTarget(
       throw new Error('This Paperclip issue is not linked to a GitHub issue yet.');
     }
 
-    const repository = normalizeOptionalToolString(input.repository)
-      ? requireRepositoryReference(String(input.repository))
-      : requireRepositoryReference(link.repositoryUrl);
+    const repository = assertExplicitRepositoryMatchesLinkedRepository(
+      input.repository,
+      link.repositoryUrl,
+      'The provided repository does not match the linked GitHub repository for this Paperclip issue.'
+    );
     const explicitIssueNumber = normalizeToolPositiveInteger(input.issueNumber);
     if (explicitIssueNumber !== undefined && explicitIssueNumber !== link.githubIssueNumber) {
       throw new Error('The provided issue number does not match the linked GitHub issue for this Paperclip issue.');
@@ -6275,9 +6303,11 @@ async function resolveGitHubPullRequestToolTarget(
       throw new Error('This Paperclip issue is not linked to GitHub yet.');
     }
 
-    const repository = normalizeOptionalToolString(input.repository)
-      ? requireRepositoryReference(String(input.repository))
-      : requireRepositoryReference(link.repositoryUrl);
+    const repository = assertExplicitRepositoryMatchesLinkedRepository(
+      input.repository,
+      link.repositoryUrl,
+      'repository must match the GitHub repository linked to the provided Paperclip issue.'
+    );
     const explicitPullRequestNumber = normalizeToolPositiveInteger(input.pullRequestNumber);
     if (explicitPullRequestNumber !== undefined) {
       return {
@@ -7295,9 +7325,13 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
       const input = getToolInputRecord(params);
       const octokit = await createGitHubToolOctokit(ctx);
       const repository = await resolveGitHubToolRepository(ctx, runCtx, input);
-      const query = normalizeOptionalToolString(input.query);
-      if (!query) {
+      const rawQuery = normalizeOptionalToolString(input.query);
+      if (!rawQuery) {
         throw new Error('query is required.');
+      }
+      const query = sanitizeRepositoryScopedSearchQuery(rawQuery);
+      if (!query) {
+        throw new Error('query must include free-text search terms after removing repository or org qualifiers.');
       }
 
       const type = input.type === 'issue' || input.type === 'pull_request' || input.type === 'all'

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -151,6 +151,32 @@ function delay(ms: number): Promise<void> {
   });
 }
 
+async function createGitHubAgentToolHarness() {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubToken: 'ghp_test_token'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+  await harness.performAction('settings.saveRegistration', {
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  return harness;
+}
+
 async function withExternalPluginConfig<T>(
   config: Record<string, unknown>,
   run: () => Promise<T>
@@ -325,6 +351,482 @@ test('fetchJson reports HTML API responses without throwing a raw JSON parse err
         return true;
       }
     );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('manifest declares the GitHub agent tools and capability', () => {
+  assert.ok(manifest.capabilities.includes('agent.tools.register'));
+  assert.ok(Array.isArray(manifest.tools));
+  assert.deepEqual(
+    manifest.tools?.map((tool) => tool.name),
+    [
+      'search_repository_items',
+      'get_issue',
+      'list_issue_comments',
+      'update_issue',
+      'add_issue_comment',
+      'create_pull_request',
+      'get_pull_request',
+      'update_pull_request',
+      'list_pull_request_files',
+      'get_pull_request_checks',
+      'list_pull_request_review_threads',
+      'reply_to_review_thread',
+      'resolve_review_thread',
+      'unresolve_review_thread',
+      'request_pull_request_reviewers'
+    ]
+  );
+  assert.match(
+    manifest.tools?.find((tool) => tool.name === 'add_issue_comment')?.description ?? '',
+    /AI-authorship footer/
+  );
+});
+
+test('search_repository_items infers the mapped repository from the tool run context', async () => {
+  const harness = await createGitHubAgentToolHarness();
+  const originalFetch = globalThis.fetch;
+  let capturedQuery = '';
+
+  globalThis.fetch = async (input) => {
+    const url = new URL(getRequestUrl(input));
+    if (url.pathname === '/search/issues') {
+      capturedQuery = url.searchParams.get('q') ?? '';
+      return jsonResponse({
+        total_count: 1,
+        incomplete_results: false,
+        items: [
+          {
+            number: 17,
+            title: 'Existing duplicate candidate',
+            state: 'open',
+            html_url: 'https://github.com/paperclipai/example-repo/issues/17',
+            created_at: '2026-04-10T10:00:00Z',
+            updated_at: '2026-04-11T10:00:00Z',
+            user: {
+              login: 'octocat'
+            },
+            labels: [
+              {
+                name: 'bug',
+                color: 'ff0000'
+              }
+            ]
+          }
+        ]
+      });
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    const result = await harness.executeTool('search_repository_items', {
+      query: 'duplicate crash'
+    }, {
+      companyId: 'company-1',
+      projectId: 'project-1'
+    });
+
+    assert.ok(!result.error);
+    assert.match(capturedQuery, /repo:paperclipai\/example-repo/);
+    assert.match(capturedQuery, /duplicate crash/);
+    assert.equal((result.data as { items: Array<{ number: number }> }).items[0]?.number, 17);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('add_issue_comment appends the required AI footer with the llm model', async () => {
+  const harness = await createGitHubAgentToolHarness();
+  const originalFetch = globalThis.fetch;
+  let postedBody = '';
+
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(getRequestUrl(input));
+    if (url.pathname === '/repos/paperclipai/example-repo/issues/12/comments') {
+      const requestBody = getJsonRequestBody(init);
+      postedBody = typeof requestBody?.body === 'string' ? requestBody.body : '';
+      return jsonResponse({
+        id: 9001,
+        html_url: 'https://github.com/paperclipai/example-repo/issues/12#issuecomment-9001',
+        body: postedBody,
+        created_at: '2026-04-12T10:00:00Z',
+        user: {
+          login: 'paperclip-bot'
+        }
+      }, 201);
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    const result = await harness.executeTool('add_issue_comment', {
+      issueNumber: 12,
+      body: 'I am investigating this now.',
+      llmModel: 'gpt-5.4'
+    }, {
+      companyId: 'company-1',
+      projectId: 'project-1'
+    });
+
+    assert.ok(!result.error);
+    assert.match(postedBody, /^I am investigating this now\./);
+    assert.match(postedBody, /Created by a Paperclip AI agent using gpt-5\.4\./);
+    assert.match((result.data as { comment: { body: string } }).comment.body, /gpt-5\.4/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('get_pull_request_checks returns CI jobs, status contexts, and workflow runs', async () => {
+  const harness = await createGitHubAgentToolHarness();
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(getRequestUrl(input));
+
+    if (url.pathname === '/repos/paperclipai/example-repo/pulls/7') {
+      return jsonResponse({
+        number: 7,
+        title: 'Fix the importer',
+        html_url: 'https://github.com/paperclipai/example-repo/pull/7',
+        state: 'open',
+        draft: false,
+        merged: false,
+        mergeable: true,
+        mergeable_state: 'clean',
+        head: {
+          ref: 'feature/fix-importer',
+          sha: 'abc123'
+        },
+        base: {
+          ref: 'main'
+        },
+        user: {
+          login: 'paperclip-bot'
+        },
+        requested_reviewers: [],
+        requested_teams: []
+      });
+    }
+
+    if (url.pathname === '/repos/paperclipai/example-repo/commits/abc123/check-runs') {
+      return jsonResponse({
+        total_count: 1,
+        check_runs: [
+          {
+            id: 301,
+            name: 'test',
+            status: 'completed',
+            conclusion: 'failure',
+            details_url: 'https://github.com/paperclipai/example-repo/actions/runs/301',
+            started_at: '2026-04-12T09:00:00Z',
+            completed_at: '2026-04-12T09:10:00Z',
+            app: {
+              name: 'GitHub Actions'
+            }
+          }
+        ]
+      });
+    }
+
+    if (url.pathname === '/repos/paperclipai/example-repo/commits/abc123/status') {
+      return jsonResponse({
+        state: 'failure',
+        statuses: [
+          {
+            context: 'lint',
+            state: 'failure',
+            description: 'lint failed',
+            target_url: 'https://github.com/paperclipai/example-repo/actions/runs/302',
+            created_at: '2026-04-12T09:00:00Z',
+            updated_at: '2026-04-12T09:05:00Z'
+          }
+        ]
+      });
+    }
+
+    if (url.pathname === '/repos/paperclipai/example-repo/actions/runs') {
+      assert.equal(url.searchParams.get('head_sha'), 'abc123');
+      return jsonResponse({
+        total_count: 1,
+        workflow_runs: [
+          {
+            id: 401,
+            name: 'CI',
+            display_title: 'CI',
+            status: 'completed',
+            conclusion: 'failure',
+            event: 'pull_request',
+            html_url: 'https://github.com/paperclipai/example-repo/actions/runs/401',
+            head_branch: 'feature/fix-importer',
+            run_number: 55
+          }
+        ]
+      });
+    }
+
+    if (url.pathname === '/graphql') {
+      const { query } = getGraphqlRequest(init);
+      if (query.includes('query GitHubPullRequestReviewThreads')) {
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: [
+                  {
+                    isResolved: false
+                  }
+                ]
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubPullRequestCiContexts')) {
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              statusCheckRollup: {
+                contexts: {
+                  pageInfo: {
+                    hasNextPage: false,
+                    endCursor: null
+                  },
+                  nodes: [
+                    {
+                      __typename: 'CheckRun',
+                      status: 'COMPLETED',
+                      conclusion: 'FAILURE'
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    const result = await harness.executeTool('get_pull_request_checks', {
+      pullRequestNumber: 7
+    }, {
+      companyId: 'company-1',
+      projectId: 'project-1'
+    });
+
+    assert.ok(!result.error);
+    const data = result.data as {
+      ciState: string;
+      hasUnresolvedReviewThreads: boolean;
+      checkRuns: Array<{ id: number }>;
+      statusContexts: Array<{ context: string }>;
+      workflowRuns: Array<{ id: number }>;
+    };
+    assert.equal(data.ciState, 'red');
+    assert.equal(data.hasUnresolvedReviewThreads, true);
+    assert.equal(data.checkRuns[0]?.id, 301);
+    assert.equal(data.statusContexts[0]?.context, 'lint');
+    assert.equal(data.workflowRuns[0]?.id, 401);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('review-thread tools list, reply to, resolve, and unresolve GitHub review threads', async () => {
+  const harness = await createGitHubAgentToolHarness();
+  const originalFetch = globalThis.fetch;
+  let repliedBody = '';
+
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(getRequestUrl(input));
+
+    if (url.pathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      if (query.includes('query GitHubPullRequestReviewThreadsDetailed')) {
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: [
+                  {
+                    id: 'THREAD_1',
+                    isResolved: false,
+                    isOutdated: false,
+                    path: 'src/worker.ts',
+                    line: 42,
+                    originalLine: 42,
+                    startLine: null,
+                    originalStartLine: null,
+                    comments: {
+                      totalCount: 1,
+                      nodes: [
+                        {
+                          id: 'COMMENT_1',
+                          databaseId: 77,
+                          body: 'Please tighten this condition.',
+                          url: 'https://github.com/paperclipai/example-repo/pull/7#discussion_r77',
+                          createdAt: '2026-04-12T10:00:00Z',
+                          author: {
+                            login: 'copilot-pull-request-reviewer'
+                          },
+                          replyTo: null
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('mutation GitHubAddPullRequestReviewThreadReply')) {
+        repliedBody = String(variables.body ?? '');
+        assert.equal(variables.pullRequestReviewThreadId, 'THREAD_1');
+        return graphqlResponse({
+          addPullRequestReviewThreadReply: {
+            comment: {
+              id: 'COMMENT_2',
+              body: repliedBody,
+              url: 'https://github.com/paperclipai/example-repo/pull/7#discussion_r78',
+              createdAt: '2026-04-12T10:05:00Z',
+              author: {
+                login: 'paperclip-bot'
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('mutation GitHubResolveReviewThread')) {
+        return graphqlResponse({
+          resolveReviewThread: {
+            thread: {
+              id: 'THREAD_1',
+              isResolved: true
+            }
+          }
+        });
+      }
+
+      if (query.includes('mutation GitHubUnresolveReviewThread')) {
+        return graphqlResponse({
+          unresolveReviewThread: {
+            thread: {
+              id: 'THREAD_1',
+              isResolved: false
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    const listResult = await harness.executeTool('list_pull_request_review_threads', {
+      repository: 'paperclipai/example-repo',
+      pullRequestNumber: 7
+    }, {
+      companyId: 'company-1',
+      projectId: 'project-1'
+    });
+    assert.ok(!listResult.error);
+    assert.equal((listResult.data as { threads: Array<{ id: string }> }).threads[0]?.id, 'THREAD_1');
+
+    const replyResult = await harness.executeTool('reply_to_review_thread', {
+      threadId: 'THREAD_1',
+      body: 'Updated the condition and added a guard.',
+      llmModel: 'gpt-5.4'
+    }, {
+      companyId: 'company-1',
+      projectId: 'project-1'
+    });
+    assert.ok(!replyResult.error);
+    assert.match(repliedBody, /Created by a Paperclip AI agent using gpt-5\.4\./);
+
+    const resolveResult = await harness.executeTool('resolve_review_thread', {
+      threadId: 'THREAD_1'
+    }, {
+      companyId: 'company-1',
+      projectId: 'project-1'
+    });
+    assert.equal((resolveResult.data as { thread: { isResolved: boolean } }).thread.isResolved, true);
+
+    const unresolveResult = await harness.executeTool('unresolve_review_thread', {
+      threadId: 'THREAD_1'
+    }, {
+      companyId: 'company-1',
+      projectId: 'project-1'
+    });
+    assert.equal((unresolveResult.data as { thread: { isResolved: boolean } }).thread.isResolved, false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('request_pull_request_reviewers sends user and team reviewers to GitHub', async () => {
+  const harness = await createGitHubAgentToolHarness();
+  const originalFetch = globalThis.fetch;
+  let reviewersRequestBody: Record<string, unknown> | null = null;
+
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(getRequestUrl(input));
+    if (url.pathname === '/repos/paperclipai/example-repo/pulls/7/requested_reviewers') {
+      reviewersRequestBody = getJsonRequestBody(init);
+      return jsonResponse({
+        requested_reviewers: [
+          {
+            login: 'octocat'
+          }
+        ],
+        requested_teams: [
+          {
+            slug: 'platform'
+          }
+        ]
+      });
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    const result = await harness.executeTool('request_pull_request_reviewers', {
+      pullRequestNumber: 7,
+      userReviewers: ['octocat'],
+      teamReviewers: ['platform']
+    }, {
+      companyId: 'company-1',
+      projectId: 'project-1'
+    });
+
+    assert.ok(!result.error);
+    assert.deepEqual(reviewersRequestBody, {
+      reviewers: ['octocat'],
+      team_reviewers: ['platform']
+    });
+    assert.equal((result.data as { requestedReviewers: string[] }).requestedReviewers[0], 'octocat');
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -5956,16 +6458,18 @@ test('worker stores repository and issue diagnostics when a sync fails mid-run',
 });
 
 test('worker reports sync error when configuration is incomplete', async () => {
-  const harness = createTestHarness({ manifest });
-  await plugin.definition.setup(harness.ctx);
+  await withExternalPluginConfig({}, async () => {
+    const harness = createTestHarness({ manifest });
+    await plugin.definition.setup(harness.ctx);
 
-  const result = await harness.performAction('sync.runNow', {}) as {
-    syncState: { status: string; message?: string; lastRunTrigger?: string };
-  };
+    const result = await harness.performAction('sync.runNow', {}) as {
+      syncState: { status: string; message?: string; lastRunTrigger?: string };
+    };
 
-  assert.equal(result.syncState.status, 'error');
-  assert.equal(result.syncState.message, 'Configure a GitHub token before running sync.');
-  assert.equal(result.syncState.lastRunTrigger, 'manual');
+    assert.equal(result.syncState.status, 'error');
+    assert.equal(result.syncState.message, 'Configure a GitHub token before running sync.');
+    assert.equal(result.syncState.lastRunTrigger, 'manual');
+  });
 });
 
 test('sync.runNow falls back to the saved githubTokenRef when config has not propagated yet', async () => {

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -439,6 +439,43 @@ test('search_repository_items infers the mapped repository from the tool run con
   }
 });
 
+test('search_repository_items strips repository qualifiers from the free-text query', async () => {
+  const harness = await createGitHubAgentToolHarness();
+  const originalFetch = globalThis.fetch;
+  let capturedQuery = '';
+
+  globalThis.fetch = async (input) => {
+    const url = new URL(getRequestUrl(input));
+    if (url.pathname === '/search/issues') {
+      capturedQuery = url.searchParams.get('q') ?? '';
+      return jsonResponse({
+        total_count: 0,
+        incomplete_results: false,
+        items: []
+      });
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    const result = await harness.executeTool('search_repository_items', {
+      query: 'repo:other/repo org:other duplicate crash'
+    }, {
+      companyId: 'company-1',
+      projectId: 'project-1'
+    });
+
+    assert.ok(!result.error);
+    assert.match(capturedQuery, /^repo:paperclipai\/example-repo /);
+    assert.doesNotMatch(capturedQuery, /repo:other\/repo/);
+    assert.doesNotMatch(capturedQuery, /org:other/);
+    assert.match(capturedQuery, /duplicate crash/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('add_issue_comment appends the required AI footer with the llm model', async () => {
   const harness = await createGitHubAgentToolHarness();
   const originalFetch = globalThis.fetch;
@@ -480,6 +517,62 @@ test('add_issue_comment appends the required AI footer with the llm model', asyn
   } finally {
     globalThis.fetch = originalFetch;
   }
+});
+
+test('issue-targeted tools reject repository overrides that do not match the linked GitHub issue repository', async () => {
+  const harness = await createGitHubAgentToolHarness();
+  harness.seed({
+    issues: [
+      {
+        id: 'issue-1',
+        companyId: 'company-1',
+        projectId: 'project-1',
+        title: 'Imported issue',
+        description: '',
+        status: 'todo'
+      } as never
+    ]
+  });
+
+  await harness.ctx.entities.upsert({
+    entityType: 'paperclip-github-plugin.issue-link',
+    scopeKind: 'issue',
+    scopeId: 'issue-1',
+    data: {
+      companyId: 'company-1',
+      paperclipProjectId: 'project-1',
+      repositoryUrl: 'https://github.com/paperclipai/example-repo',
+      githubIssueId: 1234,
+      githubIssueNumber: 12,
+      githubIssueUrl: 'https://github.com/paperclipai/example-repo/issues/12',
+      githubIssueState: 'open',
+      commentsCount: 0,
+      linkedPullRequestNumbers: [7],
+      labels: [],
+      syncedAt: '2026-04-12T10:00:00Z'
+    }
+  });
+
+  const issueResult = await harness.executeTool('add_issue_comment', {
+    paperclipIssueId: 'issue-1',
+    repository: 'paperclipai/other-repo',
+    body: 'Investigating.',
+    llmModel: 'gpt-5.4'
+  }, {
+    companyId: 'company-1',
+    projectId: 'project-1'
+  });
+  assert.match(issueResult.error ?? '', /does not match the linked GitHub repository/);
+
+  const pullRequestResult = await harness.executeTool('get_pull_request', {
+    paperclipIssueId: 'issue-1',
+    repository: 'paperclipai/other-repo',
+    pullRequestNumber: 7
+  }, {
+    companyId: 'company-1',
+    projectId: 'project-1'
+  });
+  assert.match(pullRequestResult.error ?? '', /repository must match the GitHub repository linked to the provided Paperclip issue/);
 });
 
 test('get_pull_request_checks returns CI jobs, status contexts, and workflow runs', async () => {


### PR DESCRIPTION
## Summary
- add manifest-declared GitHub agent tools for issue triage, issue updates, PR creation, CI inspection, review-thread handling, and reviewer requests
- implement worker-side tool registration, repository inference from Paperclip mappings, and shared GitHub API helpers
- enforce AI-authorship footers on GitHub comments and review-thread replies by requiring `llmModel`
- document the new agent-tool contract in the spec and README
- add contract tests covering tool registration, repository inference, CI data, review-thread operations, reviewer requests, and footer enforcement

## Testing
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Model Used
- `gpt-5.4` via Codex
- Context window size: not exposed by the runtime
- Reasoning: medium
- Capabilities: repository inspection, shell commands, `apply_patch` file edits, and test execution