### PR TITLE
Fix trusted Paperclip API origin handling for sync and release checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Lint
-        run: pnpm lint
-
       - name: Typecheck
         run: pnpm typecheck
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,9 +54,6 @@ jobs:
           RELEASE_VERSION: ${{ steps.release_version.outputs.version }}
         run: npm pkg set version="$RELEASE_VERSION"
 
-      - name: Lint
-        run: pnpm lint
-
       - name: Typecheck
         run: pnpm typecheck
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,7 @@ This repo contains a single Paperclip plugin package for GitHub synchronization 
 .
 ├── .github/workflows/
 ├── scripts/
-│   ├── e2e/
-│   └── noop.mjs
+│   └── e2e/
 ├── src/
 │   ├── manifest.ts
 │   ├── worker.ts

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Imported issues stay linked to GitHub and continue to receive description, label
 - If token validation fails, confirm the token is still valid and can access the target repositories through the GitHub API.
 - If the dashboard, toolbar, or settings page says board access is required, open plugin settings inside the target company and complete the Paperclip board access approval flow before retrying sync.
 - If sync reports that the Paperclip API returned an authenticated HTML page instead of JSON, the worker is reaching a board URL that requires the browser login session. Connect Paperclip board access from plugin settings for that company, or set `PAPERCLIP_API_URL` for the Paperclip worker to a worker-accessible Paperclip API origin, then rerun sync.
+- If sync says the Paperclip API URL is not trusted, reopen GitHub Sync from the current Paperclip host so the settings UI can refresh the trusted origin in plugin config, or set `PAPERCLIP_API_URL` for the worker.
 - If GitHub rate limiting is hit, the plugin pauses sync until the reset time shown in Paperclip.
 - If a sync takes longer than a quick action window, the plugin continues in the background and updates the UI when it finishes.
 - If older imported issues are missing rich GitHub metadata, run sync once to refresh the link, labels, and pull request details.

--- a/SPEC.md
+++ b/SPEC.md
@@ -55,6 +55,7 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 - GitHub repository, issue, PR, label, and sync metadata SHOULD move into a dedicated issue detail surface instead of being prepended into the issue description.
 - Repeated sync runs MUST continue reconciling imported Paperclip issue descriptions against the latest GitHub issue body.
 - Saving setup MUST persist the current Paperclip host origin so scheduled sync runs can call the local Paperclip label API later.
+- The worker MUST treat the runtime `PAPERCLIP_API_URL` or plugin-configured Paperclip API origin as the trusted source for direct authenticated Paperclip REST calls, and MUST reject ad hoc action inputs that point at a different origin.
 - When the worker is configured with a runtime `PAPERCLIP_API_URL`, that worker-accessible API origin MUST take precedence over the UI-saved host origin for local Paperclip REST calls.
 - Before a manual or scheduled sync touches any mapping whose company is missing board access, the worker MUST probe `/api/health` on the resolved Paperclip API origin and fail fast with configuration guidance when that deployment reports `deploymentMode: "authenticated"`.
 - When a company has connected Paperclip board access, the worker MUST attach `Authorization: Bearer <board-token>` to direct Paperclip REST issue and label calls for that company.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "dev": "node ./scripts/build.mjs --watch",
     "dev:ui": "paperclip-plugin-dev-server --root . --ui-dir dist/ui --port 4177",
     "prepack": "pnpm build",
-    "lint": "node ./scripts/noop.mjs lint",
     "test": "tsx --test tests/plugin.spec.ts",
     "test:e2e": "pnpm build && pnpm exec playwright install chromium && node ./scripts/e2e/run-paperclip-smoke.mjs",
     "typecheck": "tsc --noEmit",

--- a/scripts/noop.mjs
+++ b/scripts/noop.mjs
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-const command = process.argv[2] ?? 'noop';
-console.log(`[paperclip-github-plugin] no-op ${command}`);

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -54,6 +54,10 @@ export const manifest: PaperclipPluginManifestV1 = {
         additionalProperties: {
           type: 'string'
         }
+      },
+      paperclipApiBaseUrl: {
+        type: 'string',
+        title: 'Trusted Paperclip API Origin'
       }
     }
   },

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -2350,6 +2350,19 @@ function getPaperclipApiBaseUrl(): string | undefined {
   return window.location.origin;
 }
 
+async function syncTrustedPaperclipApiBaseUrl(pluginId: string | null): Promise<string | undefined> {
+  const paperclipApiBaseUrl = getPaperclipApiBaseUrl();
+  if (!pluginId || !paperclipApiBaseUrl) {
+    return paperclipApiBaseUrl;
+  }
+
+  await patchPluginConfig(pluginId, {
+    paperclipApiBaseUrl
+  });
+
+  return paperclipApiBaseUrl;
+}
+
 function formatDate(value?: string, fallback = 'Never'): string {
   if (!value) {
     return fallback;
@@ -4225,13 +4238,14 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
         });
       }
 
+      const trustedPaperclipApiBaseUrl = await syncTrustedPaperclipApiBaseUrl(pluginIdFromLocation);
       const result = await saveRegistration({
         companyId,
         mappings: resolvedMappings,
         advancedSettings: draftAdvancedSettings,
         syncState: form.syncState,
         scheduleFrequencyMinutes,
-        paperclipApiBaseUrl: getPaperclipApiBaseUrl()
+        ...(trustedPaperclipApiBaseUrl ? { paperclipApiBaseUrl: trustedPaperclipApiBaseUrl } : {})
       }) as GitHubSyncSettings;
 
       setForm((current) => ({
@@ -4278,9 +4292,10 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
         throw new Error(syncSetupMessage);
       }
 
+      const trustedPaperclipApiBaseUrl = await syncTrustedPaperclipApiBaseUrl(pluginIdFromLocation);
       const result = await runSyncNow({
         ...(hostContext.companyId ? { companyId: hostContext.companyId } : {}),
-        paperclipApiBaseUrl: getPaperclipApiBaseUrl()
+        ...(trustedPaperclipApiBaseUrl ? { paperclipApiBaseUrl: trustedPaperclipApiBaseUrl } : {})
       }) as GitHubSyncSettings;
 
       setForm((current) => ({
@@ -5013,6 +5028,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
 export function GitHubSyncDashboardWidget(): React.JSX.Element {
   const hostContext = useHostContext();
   const toast = usePluginToast();
+  const pluginIdFromLocation = getPluginIdFromLocation();
   const settings = usePluginData<GitHubSyncSettings>(
     'settings.registration',
     hostContext.companyId ? { companyId: hostContext.companyId } : {}
@@ -5132,9 +5148,10 @@ export function GitHubSyncDashboardWidget(): React.JSX.Element {
         throw new Error(syncSetupMessage);
       }
 
+      const trustedPaperclipApiBaseUrl = await syncTrustedPaperclipApiBaseUrl(pluginIdFromLocation);
       const result = await runSyncNow({
         ...(hostContext.companyId ? { companyId: hostContext.companyId } : {}),
-        paperclipApiBaseUrl: getPaperclipApiBaseUrl()
+        ...(trustedPaperclipApiBaseUrl ? { paperclipApiBaseUrl: trustedPaperclipApiBaseUrl } : {})
       }) as GitHubSyncSettings;
       const nextSyncState = result.syncState ?? EMPTY_SETTINGS.syncState;
       setManualSyncRequestError(null);
@@ -5303,6 +5320,7 @@ function GitHubSyncToolbarButtonSurface(props: {
 }): React.JSX.Element | null {
   const toast = usePluginToast();
   const runSyncNow = usePluginAction('sync.runNow');
+  const pluginIdFromLocation = getPluginIdFromLocation();
   const surfaceRef = useRef<HTMLDivElement | null>(null);
   const resolvedIssue = useResolvedIssueId({
     companyId: props.companyId,
@@ -5446,11 +5464,13 @@ function GitHubSyncToolbarButtonSurface(props: {
       }
 
       setRunningSync(true);
+      const trustedPaperclipApiBaseUrl = await syncTrustedPaperclipApiBaseUrl(pluginIdFromLocation);
       const result = await runSyncNow({
         waitForCompletion: false,
         ...(props.companyId ? { companyId: props.companyId } : {}),
         ...(props.entityType === 'project' && props.entityId ? { projectId: props.entityId } : {}),
-        ...(props.entityType === 'issue' && resolvedIssue.issueId ? { issueId: resolvedIssue.issueId } : {})
+        ...(props.entityType === 'issue' && resolvedIssue.issueId ? { issueId: resolvedIssue.issueId } : {}),
+        ...(trustedPaperclipApiBaseUrl ? { paperclipApiBaseUrl: trustedPaperclipApiBaseUrl } : {})
       }) as {
         syncState?: SyncRunState;
       };

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -2350,15 +2350,29 @@ function getPaperclipApiBaseUrl(): string | undefined {
   return window.location.origin;
 }
 
+const syncedPaperclipApiBaseUrlsByPluginId = new Map<string, string>();
+
 async function syncTrustedPaperclipApiBaseUrl(pluginId: string | null): Promise<string | undefined> {
   const paperclipApiBaseUrl = getPaperclipApiBaseUrl();
-  if (!pluginId || !paperclipApiBaseUrl) {
+  if (!paperclipApiBaseUrl) {
+    return undefined;
+  }
+
+  if (!pluginId) {
+    throw new Error(
+      'Unable to sync the trusted Paperclip API origin because the plugin ID is missing. Reload the plugin and try again before saving or syncing.'
+    );
+  }
+
+  const lastSyncedPaperclipApiBaseUrl = syncedPaperclipApiBaseUrlsByPluginId.get(pluginId);
+  if (lastSyncedPaperclipApiBaseUrl === paperclipApiBaseUrl) {
     return paperclipApiBaseUrl;
   }
 
   await patchPluginConfig(pluginId, {
     paperclipApiBaseUrl
   });
+  syncedPaperclipApiBaseUrlsByPluginId.set(pluginId, paperclipApiBaseUrl);
 
   return paperclipApiBaseUrl;
 }
@@ -2591,6 +2605,10 @@ async function patchPluginConfig(pluginId: string, patch: Record<string, unknown
   const currentConfigResponse = await fetchJson<PluginConfigResponse | null>(`/api/plugins/${pluginId}/config`);
   const currentConfig = normalizePluginConfig(currentConfigResponse?.configJson);
   const nextConfig = mergePluginConfig(currentConfig, patch);
+
+  if (JSON.stringify(nextConfig) === JSON.stringify(currentConfig)) {
+    return;
+  }
 
   await fetchJson(`/api/plugins/${pluginId}/config`, {
     method: 'POST',

--- a/src/ui/plugin-config.ts
+++ b/src/ui/plugin-config.ts
@@ -3,6 +3,7 @@ export type PluginConfigBoardTokenRefs = Record<string, string>;
 export interface GitHubSyncPluginConfig extends Record<string, unknown> {
   githubTokenRef?: string;
   paperclipBoardApiTokenRefs?: PluginConfigBoardTokenRefs;
+  paperclipApiBaseUrl?: string;
 }
 
 function normalizeOptionalString(value: unknown): string | undefined {
@@ -39,6 +40,7 @@ export function normalizePluginConfig(value: unknown): GitHubSyncPluginConfig {
   const record = { ...(value as Record<string, unknown>) };
   const githubTokenRef = normalizeOptionalString(record.githubTokenRef);
   const paperclipBoardApiTokenRefs = normalizePluginConfigBoardTokenRefs(record.paperclipBoardApiTokenRefs);
+  const paperclipApiBaseUrl = normalizeOptionalString(record.paperclipApiBaseUrl);
 
   if (githubTokenRef) {
     record.githubTokenRef = githubTokenRef;
@@ -50,6 +52,12 @@ export function normalizePluginConfig(value: unknown): GitHubSyncPluginConfig {
     record.paperclipBoardApiTokenRefs = paperclipBoardApiTokenRefs;
   } else {
     delete record.paperclipBoardApiTokenRefs;
+  }
+
+  if (paperclipApiBaseUrl) {
+    record.paperclipApiBaseUrl = paperclipApiBaseUrl;
+  } else {
+    delete record.paperclipApiBaseUrl;
   }
 
   return record as GitHubSyncPluginConfig;

--- a/src/ui/plugin-config.ts
+++ b/src/ui/plugin-config.ts
@@ -10,6 +10,19 @@ function normalizeOptionalString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
 
+function normalizePaperclipApiBaseUrl(value: unknown): string | undefined {
+  const normalizedValue = normalizeOptionalString(value);
+  if (!normalizedValue) {
+    return undefined;
+  }
+
+  try {
+    return new URL(normalizedValue).origin;
+  } catch {
+    return undefined;
+  }
+}
+
 export function normalizePluginConfigBoardTokenRefs(value: unknown): PluginConfigBoardTokenRefs | undefined {
   if (!value || typeof value !== 'object') {
     return undefined;
@@ -40,7 +53,7 @@ export function normalizePluginConfig(value: unknown): GitHubSyncPluginConfig {
   const record = { ...(value as Record<string, unknown>) };
   const githubTokenRef = normalizeOptionalString(record.githubTokenRef);
   const paperclipBoardApiTokenRefs = normalizePluginConfigBoardTokenRefs(record.paperclipBoardApiTokenRefs);
-  const paperclipApiBaseUrl = normalizeOptionalString(record.paperclipApiBaseUrl);
+  const paperclipApiBaseUrl = normalizePaperclipApiBaseUrl(record.paperclipApiBaseUrl);
 
   if (githubTokenRef) {
     record.githubTokenRef = githubTokenRef;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -276,6 +276,7 @@ interface GitHubSyncConfig {
   githubTokenRef?: string;
   githubToken?: string;
   paperclipBoardApiTokenRefs?: PaperclipBoardApiTokenRefs;
+  paperclipApiBaseUrl?: string;
 }
 
 interface ResolvedGitHubTokenSource {
@@ -2435,11 +2436,13 @@ function normalizeConfig(value: unknown): GitHubSyncConfig {
   const githubTokenRef = normalizeGitHubTokenRef(record.githubTokenRef);
   const githubToken = normalizeGitHubToken(record.githubToken);
   const paperclipBoardApiTokenRefs = normalizePaperclipBoardApiTokenRefs(record.paperclipBoardApiTokenRefs);
+  const paperclipApiBaseUrl = normalizePaperclipApiBaseUrl(record.paperclipApiBaseUrl);
 
   return {
     ...(githubTokenRef ? { githubTokenRef } : {}),
     ...(githubToken ? { githubToken } : {}),
-    ...(paperclipBoardApiTokenRefs ? { paperclipBoardApiTokenRefs } : {})
+    ...(paperclipBoardApiTokenRefs ? { paperclipBoardApiTokenRefs } : {}),
+    ...(paperclipApiBaseUrl ? { paperclipApiBaseUrl } : {})
   };
 }
 
@@ -2744,6 +2747,50 @@ function resolvePaperclipApiBaseUrl(...values: unknown[]): string | undefined {
   }
 
   return undefined;
+}
+
+function getConfiguredPaperclipApiBaseUrl(
+  settings: Pick<GitHubSyncSettings, 'paperclipApiBaseUrl'> | null | undefined,
+  config: Pick<GitHubSyncConfig, 'paperclipApiBaseUrl'> | null | undefined
+): string | undefined {
+  return resolvePaperclipApiBaseUrl(config?.paperclipApiBaseUrl, settings?.paperclipApiBaseUrl);
+}
+
+function resolveTrustedPaperclipApiBaseUrlInput(
+  value: unknown,
+  settings: Pick<GitHubSyncSettings, 'paperclipApiBaseUrl'> | null | undefined,
+  config: Pick<GitHubSyncConfig, 'paperclipApiBaseUrl'> | null | undefined
+): string | undefined {
+  const runtimePaperclipApiBaseUrl = getRuntimePaperclipApiBaseUrl();
+  if (runtimePaperclipApiBaseUrl) {
+    return runtimePaperclipApiBaseUrl;
+  }
+
+  const requestedPaperclipApiBaseUrl = normalizePaperclipApiBaseUrl(value);
+  const configuredPaperclipApiBaseUrl = normalizePaperclipApiBaseUrl(config?.paperclipApiBaseUrl);
+  const savedPaperclipApiBaseUrl = normalizePaperclipApiBaseUrl(settings?.paperclipApiBaseUrl);
+
+  if (!requestedPaperclipApiBaseUrl) {
+    return configuredPaperclipApiBaseUrl ?? savedPaperclipApiBaseUrl;
+  }
+
+  if (configuredPaperclipApiBaseUrl) {
+    if (requestedPaperclipApiBaseUrl !== configuredPaperclipApiBaseUrl) {
+      throw new Error(
+        'Paperclip API URL must match the trusted plugin config origin. Open GitHub Sync from the current Paperclip host and try again.'
+      );
+    }
+
+    return configuredPaperclipApiBaseUrl;
+  }
+
+  if (savedPaperclipApiBaseUrl && requestedPaperclipApiBaseUrl === savedPaperclipApiBaseUrl) {
+    return savedPaperclipApiBaseUrl;
+  }
+
+  throw new Error(
+    'Paperclip API URL is not trusted yet. Open GitHub Sync settings inside Paperclip from the current host before retrying.'
+  );
 }
 
 function normalizeSettings(value: unknown): GitHubSyncSettings {
@@ -7385,6 +7432,7 @@ async function startSync(
     return quickResult ?? await getActiveOrCurrentSyncState(ctx);
   }
 
+  const config = await getResolvedConfig(ctx);
   const token = await resolveGithubToken(ctx).catch(() => '');
   const persistedSettings = normalizeSettings(await ctx.state.get(SETTINGS_SCOPE));
   let currentSettings = sanitizeSettingsForCurrentSetup(persistedSettings, {
@@ -7394,8 +7442,8 @@ async function startSync(
 
   const nextPaperclipApiBaseUrl =
     trigger === 'manual'
-      ? resolvePaperclipApiBaseUrl(options.paperclipApiBaseUrl, currentSettings.paperclipApiBaseUrl)
-      : resolvePaperclipApiBaseUrl(currentSettings.paperclipApiBaseUrl);
+      ? resolveTrustedPaperclipApiBaseUrlInput(options.paperclipApiBaseUrl, currentSettings, config)
+      : getConfiguredPaperclipApiBaseUrl(currentSettings, config);
 
   if (nextPaperclipApiBaseUrl !== currentSettings.paperclipApiBaseUrl) {
     currentSettings = {
@@ -8243,14 +8291,17 @@ const plugin = definePlugin({
       const normalizedSettings = normalizeSettings(saved);
       const config = await getResolvedConfig(ctx);
       const githubTokenRef = getConfiguredGithubTokenRef(normalizedSettings, config);
+      const paperclipApiBaseUrl = getConfiguredPaperclipApiBaseUrl(normalizedSettings, config);
       const githubTokenConfigured = hasConfiguredGithubToken(normalizedSettings, config);
       const configuredBoardTokenRef = getConfiguredPaperclipBoardApiTokenRef(config, requestedCompanyId);
       const savedBoardTokenRef = getSavedPaperclipBoardApiTokenRef(normalizedSettings, requestedCompanyId);
       const settingsWithResolvedToken = githubTokenRef === normalizedSettings.githubTokenRef
+        && paperclipApiBaseUrl === normalizedSettings.paperclipApiBaseUrl
         ? normalizedSettings
         : {
             ...normalizedSettings,
-            ...(githubTokenRef ? { githubTokenRef } : {})
+            ...(githubTokenRef ? { githubTokenRef } : {}),
+            ...(paperclipApiBaseUrl ? { paperclipApiBaseUrl } : {})
           };
       const settingsForResponse = sanitizeSettingsForCurrentSetup(settingsWithResolvedToken, {
         hasToken: githubTokenConfigured,
@@ -8333,7 +8384,10 @@ const plugin = definePlugin({
         mappings: mergedMappings,
         syncState: previous.syncState,
         scheduleFrequencyMinutes: 'scheduleFrequencyMinutes' in record ? record.scheduleFrequencyMinutes : previous.scheduleFrequencyMinutes,
-        paperclipApiBaseUrl: 'paperclipApiBaseUrl' in record ? record.paperclipApiBaseUrl : previous.paperclipApiBaseUrl,
+        paperclipApiBaseUrl:
+          'paperclipApiBaseUrl' in record
+            ? resolveTrustedPaperclipApiBaseUrlInput(record.paperclipApiBaseUrl, previous, config)
+            : getConfiguredPaperclipApiBaseUrl(previous, config),
         paperclipBoardApiTokenRefs: previous.paperclipBoardApiTokenRefs,
         ...(Object.keys(nextCompanyAdvancedSettingsByCompanyId).length > 0
           ? { companyAdvancedSettingsByCompanyId: nextCompanyAdvancedSettingsByCompanyId }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -6271,9 +6271,15 @@ async function resolvePaperclipApiAuthTokens(
   return tokensByCompanyId;
 }
 
-async function resolveGithubToken(ctx: PluginSetupContext): Promise<string> {
-  const settings = normalizeSettings(await ctx.state.get(SETTINGS_SCOPE));
-  const config = await getResolvedConfig(ctx);
+async function resolveGithubToken(
+  ctx: PluginSetupContext,
+  options: {
+    settings?: Pick<GitHubSyncSettings, 'githubTokenRef'> | null | undefined;
+    config?: GitHubSyncConfig;
+  } = {}
+): Promise<string> {
+  const settings = options.settings ?? normalizeSettings(await ctx.state.get(SETTINGS_SCOPE));
+  const config = options.config ?? await getResolvedConfig(ctx);
   const configuredTokenSource = getConfiguredGithubTokenSource(settings, config);
   if (configuredTokenSource.secretRef) {
     return ctx.secrets.resolve(configuredTokenSource.secretRef);
@@ -7432,9 +7438,14 @@ async function startSync(
     return quickResult ?? await getActiveOrCurrentSyncState(ctx);
   }
 
-  const config = await getResolvedConfig(ctx);
-  const token = await resolveGithubToken(ctx).catch(() => '');
-  const persistedSettings = normalizeSettings(await ctx.state.get(SETTINGS_SCOPE));
+  const [config, persistedSettings] = await Promise.all([
+    getResolvedConfig(ctx),
+    ctx.state.get(SETTINGS_SCOPE).then((value) => normalizeSettings(value))
+  ]);
+  const token = await resolveGithubToken(ctx, {
+    config,
+    settings: persistedSettings
+  }).catch(() => '');
   let currentSettings = sanitizeSettingsForCurrentSetup(persistedSettings, {
     hasToken: Boolean(token.trim()),
     hasMappings: getSyncableMappings(persistedSettings.mappings).length > 0

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -1170,7 +1170,8 @@ test('worker exposes toolbar sync state for global, project, and issue surfaces'
   const harness = createTestHarness({
     manifest,
     config: {
-      githubTokenRef: 'github-secret-ref'
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'https://paperclip.example.test'
     }
   });
   await plugin.definition.setup(harness.ctx);
@@ -2120,7 +2121,12 @@ test('settings.registration reports company-specific board access from plugin co
 });
 
 test('worker normalizes and saves the Paperclip API base URL alongside setup', async () => {
-  const harness = createTestHarness({ manifest });
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
+    }
+  });
   await plugin.definition.setup(harness.ctx);
 
   const result = await harness.performAction('settings.saveRegistration', {
@@ -2130,6 +2136,23 @@ test('worker normalizes and saves the Paperclip API base URL alongside setup', a
   };
 
   assert.equal(result.paperclipApiBaseUrl, 'http://127.0.0.1:63675');
+});
+
+test('worker rejects untrusted Paperclip API origins when saving setup', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+
+  await assert.rejects(
+    harness.performAction('settings.saveRegistration', {
+      paperclipApiBaseUrl: 'https://evil.example'
+    }),
+    /trusted plugin config origin/i
+  );
 });
 
 test('worker validates a GitHub token by reaching the GitHub API', async () => {
@@ -2783,7 +2806,8 @@ test('worker maps GitHub labels onto existing Paperclip labels, creates missing 
   const harness = createTestHarness({
     manifest,
     config: {
-      githubTokenRef: 'github-secret-ref'
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
     }
   });
   await plugin.definition.setup(harness.ctx);
@@ -2940,6 +2964,7 @@ test('worker authenticates direct Paperclip REST label and issue sync calls with
     manifest,
     config: {
       githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675',
       paperclipBoardApiTokenRefs: {
         'company-1': 'board-secret-ref'
       }
@@ -3121,7 +3146,8 @@ test('worker refreshes Paperclip labels before creating a missing label so newly
   const harness = createTestHarness({
     manifest,
     config: {
-      githubTokenRef: 'github-secret-ref'
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
     }
   });
   await plugin.definition.setup(harness.ctx);
@@ -3279,7 +3305,8 @@ test('worker resolves duplicate label create races by refreshing labels without 
   const harness = createTestHarness({
     manifest,
     config: {
-      githubTokenRef: 'github-secret-ref'
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
     }
   });
   await plugin.definition.setup(harness.ctx);
@@ -3439,7 +3466,8 @@ test('worker resyncs labels for already-imported issues when GitHub labels chang
   const harness = createTestHarness({
     manifest,
     config: {
-      githubTokenRef: 'github-secret-ref'
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
     }
   });
   await plugin.definition.setup(harness.ctx);
@@ -3604,7 +3632,8 @@ test('worker surfaces an actionable sync error when the Paperclip label API retu
   const harness = createTestHarness({
     manifest,
     config: {
-      githubTokenRef: 'github-secret-ref'
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'https://board.example.com'
     }
   });
   await plugin.definition.setup(harness.ctx);
@@ -3926,7 +3955,8 @@ test('worker repairs missing descriptions for newly created issues through the l
   const harness = createTestHarness({
     manifest,
     config: {
-      githubTokenRef: 'github-secret-ref'
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
     }
   });
   await plugin.definition.setup(harness.ctx);
@@ -4092,7 +4122,8 @@ test('worker repairs missing descriptions for the reported public issue case', a
   const harness = createTestHarness({
     manifest,
     config: {
-      githubTokenRef: 'github-secret-ref'
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
     }
   });
   await plugin.definition.setup(harness.ctx);
@@ -4272,7 +4303,8 @@ test('worker prefers local Paperclip issue creation for the reported public issu
   const harness = createTestHarness({
     manifest,
     config: {
-      githubTokenRef: 'github-secret-ref'
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
     }
   });
   await plugin.definition.setup(harness.ctx);
@@ -4440,7 +4472,8 @@ test('worker immediately repairs empty descriptions when the local Paperclip cre
   const harness = createTestHarness({
     manifest,
     config: {
-      githubTokenRef: 'github-secret-ref'
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
     }
   });
   await plugin.definition.setup(harness.ctx);
@@ -4751,7 +4784,8 @@ test('worker falls back to the SDK bridge when the local Paperclip description P
   const harness = createTestHarness({
     manifest,
     config: {
-      githubTokenRef: 'github-secret-ref'
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
     }
   });
   await plugin.definition.setup(harness.ctx);
@@ -4934,7 +4968,8 @@ test('worker falls back to the SDK bridge when the local Paperclip description P
   const harness = createTestHarness({
     manifest,
     config: {
-      githubTokenRef: 'github-secret-ref'
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'https://board.example.com'
     }
   });
   await plugin.definition.setup(harness.ctx);
@@ -5098,7 +5133,8 @@ test('worker uses the live Paperclip API URL passed to sync.runNow instead of a 
   const harness = createTestHarness({
     manifest,
     config: {
-      githubTokenRef: 'github-secret-ref'
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
     }
   });
   await plugin.definition.setup(harness.ctx);
@@ -5118,9 +5154,22 @@ test('worker uses the live Paperclip API URL passed to sync.runNow instead of a 
     ],
     syncState: {
       status: 'idle'
-    },
-    paperclipApiBaseUrl: 'http://127.0.0.1:11111'
+    }
   });
+
+  await harness.ctx.state.set(
+    {
+      scopeKind: 'instance',
+      stateKey: 'paperclip-github-plugin-settings'
+    },
+    {
+      ...(harness.getState({
+        scopeKind: 'instance',
+        stateKey: 'paperclip-github-plugin-settings'
+      }) as Record<string, unknown>),
+      paperclipApiBaseUrl: 'http://127.0.0.1:11111'
+    }
+  );
 
   const originalFetch = globalThis.fetch;
   const originalCreate = harness.ctx.issues.create;
@@ -5270,6 +5319,40 @@ test('worker uses the live Paperclip API URL passed to sync.runNow instead of a 
   } finally {
     globalThis.fetch = originalFetch;
   }
+});
+
+test('sync.runNow rejects an untrusted Paperclip API origin override', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+
+  await harness.performAction('settings.saveRegistration', {
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  await assert.rejects(
+    harness.performAction('sync.runNow', {
+      waitForCompletion: true,
+      paperclipApiBaseUrl: 'https://evil.example'
+    }),
+    /trusted plugin config origin/i
+  );
 });
 
 test('sync applies company-wide advanced defaults and ignores configured GitHub authors', async () => {
@@ -5472,7 +5555,8 @@ test('worker repairs empty descriptions before GitHub status snapshot failures c
   const harness = createTestHarness({
     manifest,
     config: {
-      githubTokenRef: 'github-secret-ref'
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
     }
   });
   await plugin.definition.setup(harness.ctx);
@@ -6440,7 +6524,8 @@ test('worker uses the local Paperclip issue PATCH API for status transitions whe
   const harness = createTestHarness({
     manifest,
     config: {
-      githubTokenRef: 'github-secret-ref'
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
     }
   });
   await plugin.definition.setup(harness.ctx);
@@ -6655,7 +6740,8 @@ test('worker falls back to the SDK bridge when the local Paperclip status PATCH 
   const harness = createTestHarness({
     manifest,
     config: {
-      githubTokenRef: 'github-secret-ref'
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'https://board.example.com'
     }
   });
   await plugin.definition.setup(harness.ctx);
@@ -7083,7 +7169,8 @@ test('worker blocks sync when the Paperclip deployment is authenticated and boar
   const harness = createTestHarness({
     manifest,
     config: {
-      githubTokenRef: 'github-secret-ref'
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'https://paperclip.example.test'
     }
   });
   await plugin.definition.setup(harness.ctx);

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -10,7 +10,7 @@ import { createTestHarness } from '@paperclipai/plugin-sdk/testing';
 import manifest from '../src/manifest.ts';
 import { requiresPaperclipBoardAccess } from '../src/paperclip-health.ts';
 import { fetchJson, fetchPaperclipHealth, resolveCliAuthPollUrl } from '../src/ui/http.ts';
-import { mergePluginConfig } from '../src/ui/plugin-config.ts';
+import { mergePluginConfig, normalizePluginConfig } from '../src/ui/plugin-config.ts';
 import {
   discoverExistingProjectSyncCandidates,
   filterExistingProjectSyncCandidates
@@ -1127,6 +1127,24 @@ test('mergePluginConfig preserves existing config while merging board access ref
     'company-2': 'board-secret-ref-2'
   });
   assert.equal(result.customFlag, true);
+});
+
+test('normalizePluginConfig canonicalizes the trusted Paperclip API origin and drops invalid values', () => {
+  assert.deepEqual(
+    normalizePluginConfig({
+      paperclipApiBaseUrl: ' https://paperclip.example.test/api/companies/company-1/issues '
+    }),
+    {
+      paperclipApiBaseUrl: 'https://paperclip.example.test'
+    }
+  );
+
+  assert.deepEqual(
+    normalizePluginConfig({
+      paperclipApiBaseUrl: 'not a url'
+    }),
+    {}
+  );
 });
 
 test('manifest exposes GitHub Sync dashboard and settings UI metadata, config schema, and job', () => {


### PR DESCRIPTION
## Summary
- restrict direct authenticated Paperclip REST calls to runtime or plugin-configured trusted origins
- sync the current host origin into plugin config before settings saves and manual sync actions
- add manifest/config support, tests, and docs for trusted Paperclip API origin handling
- remove the no-op `lint` script and the corresponding release workflow step

## Testing
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Model Used
- `gpt-5.3-codex`
- Context window: 400k
- Reasoning mode: medium
- Capabilities: tool use, code editing, test execution