### PR TITLE
Fix manifest version stamping for published plugin builds

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { mkdir, rm } from 'node:fs/promises';
+import { mkdir, readFile, rm } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -9,6 +9,11 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(__dirname, '..');
 const outdir = resolve(packageRoot, 'dist');
 const watch = process.argv.includes('--watch');
+const packageJson = JSON.parse(await readFile(resolve(packageRoot, 'package.json'), 'utf8'));
+const pluginVersion =
+  process.env.PLUGIN_VERSION?.trim()
+  || (typeof packageJson.version === 'string' && packageJson.version.trim())
+  || '0.0.0-dev';
 
 await rm(outdir, { recursive: true, force: true });
 await mkdir(resolve(outdir, 'ui'), { recursive: true });
@@ -26,7 +31,10 @@ const nodeSharedOptions = {
 const manifestBuildOptions = {
   ...nodeSharedOptions,
   entryPoints: [resolve(packageRoot, 'src/manifest.ts')],
-  outfile: resolve(outdir, 'manifest.js')
+  outfile: resolve(outdir, 'manifest.js'),
+  define: {
+    'process.env.PLUGIN_VERSION': JSON.stringify(pluginVersion)
+  }
 };
 
 const workerBuildOptions = {

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'node:assert';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
@@ -16,6 +16,30 @@ import {
   filterExistingProjectSyncCandidates
 } from '../src/ui/project-bindings.ts';
 import plugin from '../src/worker.ts';
+
+async function importManifestWithPluginVersion(pluginVersion?: string): Promise<typeof manifest> {
+  const previousPluginVersion = process.env.PLUGIN_VERSION;
+  const manifestModuleUrl = new URL(
+    `../src/manifest.ts?plugin-version-test=${encodeURIComponent(pluginVersion ?? 'package')}-${Date.now()}`,
+    import.meta.url
+  );
+
+  if (pluginVersion === undefined) {
+    delete process.env.PLUGIN_VERSION;
+  } else {
+    process.env.PLUGIN_VERSION = pluginVersion;
+  }
+
+  try {
+    return (await import(manifestModuleUrl.href)).default;
+  } finally {
+    if (previousPluginVersion === undefined) {
+      delete process.env.PLUGIN_VERSION;
+    } else {
+      process.env.PLUGIN_VERSION = previousPluginVersion;
+    }
+  }
+}
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -155,6 +179,21 @@ function delay(ms: number): Promise<void> {
     globalThis.setTimeout(resolve, ms);
   });
 }
+
+test('manifest version defaults to package.json when no build-stamped version is provided', async () => {
+  const packageJson = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8')) as {
+    version?: unknown;
+  };
+  const resolvedManifest = await importManifestWithPluginVersion();
+
+  assert.equal(resolvedManifest.version, packageJson.version);
+});
+
+test('manifest version prefers the build-stamped plugin version when provided', async () => {
+  const resolvedManifest = await importManifestWithPluginVersion('9.9.9-test');
+
+  assert.equal(resolvedManifest.version, '9.9.9-test');
+});
 
 async function createGitHubAgentToolHarness() {
   const harness = createTestHarness({

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -180,20 +180,28 @@ function delay(ms: number): Promise<void> {
   });
 }
 
-test('manifest version defaults to package.json when no build-stamped version is provided', async () => {
-  const packageJson = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8')) as {
-    version?: unknown;
-  };
-  const resolvedManifest = await importManifestWithPluginVersion();
+test(
+  'manifest version defaults to package.json when no build-stamped version is provided',
+  { concurrency: false },
+  async () => {
+    const packageJson = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8')) as {
+      version?: unknown;
+    };
+    const resolvedManifest = await importManifestWithPluginVersion();
 
-  assert.equal(resolvedManifest.version, packageJson.version);
-});
+    assert.equal(resolvedManifest.version, packageJson.version);
+  }
+);
 
-test('manifest version prefers the build-stamped plugin version when provided', async () => {
-  const resolvedManifest = await importManifestWithPluginVersion('9.9.9-test');
+test(
+  'manifest version prefers the build-stamped plugin version when provided',
+  { concurrency: false },
+  async () => {
+    const resolvedManifest = await importManifestWithPluginVersion('9.9.9-test');
 
-  assert.equal(resolvedManifest.version, '9.9.9-test');
-});
+    assert.equal(resolvedManifest.version, '9.9.9-test');
+  }
+);
 
 async function createGitHubAgentToolHarness() {
   const harness = createTestHarness({


### PR DESCRIPTION
## Summary
- Stamp the manifest version during build from `PLUGIN_VERSION` or `package.json` so installed Paperclip instances show the packaged plugin version.
- Keep the existing package-version fallback, but remove reliance on runtime-only resolution for published artifacts.
- Add coverage for both manifest version paths: defaulting to `package.json` and preferring an explicit build-stamped version.

## Testing
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Model Used
- `gpt-5.4` via Codex
- Context window size: not exposed by this environment
- Reasoning mode: medium
- Capabilities used: shell commands, file patching, test execution