### PR TITLE
Fix default assignee dropdown fallback in settings

### DIFF
--- a/src/ui/assignees.ts
+++ b/src/ui/assignees.ts
@@ -1,0 +1,38 @@
+export interface GitHubSyncAssigneeOption {
+  id: string;
+  name: string;
+  title?: string;
+  status?: string;
+}
+
+export function normalizeCompanyAssigneeOptionsResponse(response: unknown): GitHubSyncAssigneeOption[] {
+  if (!Array.isArray(response)) {
+    throw new Error('Unexpected company agents response: expected an array.');
+  }
+
+  return response
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') {
+        return null;
+      }
+
+      const record = entry as Record<string, unknown>;
+      const id = typeof record.id === 'string' ? record.id.trim() : '';
+      const name = typeof record.name === 'string' ? record.name.trim() : '';
+      const status = typeof record.status === 'string' ? record.status.trim() : '';
+      const title = typeof record.title === 'string' ? record.title.trim() : '';
+
+      if (!id || !name || status === 'terminated') {
+        return null;
+      }
+
+      return {
+        id,
+        name,
+        ...(title ? { title } : {}),
+        ...(status ? { status } : {})
+      };
+    })
+    .filter((entry): entry is GitHubSyncAssigneeOption => entry !== null)
+    .sort((left, right) => left.name.localeCompare(right.name));
+}

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -4021,6 +4021,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
   const boardAccessRequirement = usePaperclipBoardAccessRequirement();
   const armSyncCompletionToast = useSyncCompletionToast(form.syncState, toast);
   const boardAccessConfigSyncAttemptRef = useRef<string | null>(null);
+  const assigneeFallbackAttemptRef = useRef<string | null>(null);
 
   const currentSettings = settings.data ?? cachedSettings;
   const showInitialLoadingState = settings.loading && !settings.data && !cachedSettings;
@@ -4112,17 +4113,26 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
 
   useEffect(() => {
     const companyId = hostContext.companyId;
-    const workerAvailableAssignees = settings.data?.availableAssignees ?? [];
+    const workerAvailableAssignees = currentSettings?.availableAssignees ?? [];
+    const snapshotKey = `${companyId ?? 'none'}:${currentSettings?.updatedAt ?? 'none'}`;
 
     if (!companyId) {
+      assigneeFallbackAttemptRef.current = null;
       setBrowserAvailableAssignees([]);
       return;
     }
 
     if (workerAvailableAssignees.length > 0) {
+      assigneeFallbackAttemptRef.current = snapshotKey;
       setBrowserAvailableAssignees([]);
       return;
     }
+
+    if (assigneeFallbackAttemptRef.current === snapshotKey) {
+      return;
+    }
+
+    assigneeFallbackAttemptRef.current = snapshotKey;
 
     let cancelled = false;
 
@@ -4146,7 +4156,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
     return () => {
       cancelled = true;
     };
-  }, [hostContext.companyId, settings.data?.availableAssignees, settings.data?.updatedAt]);
+  }, [currentSettings?.availableAssignees?.length, currentSettings?.updatedAt, hostContext.companyId]);
 
   useEffect(() => {
     const companyId = hostContext.companyId;

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -3,6 +3,7 @@ import { useHostContext, usePluginAction, usePluginData, usePluginToast } from '
 
 import { parseRepositoryReference, type ParsedRepositoryReference } from '../github-repo.ts';
 import { requiresPaperclipBoardAccess } from '../paperclip-health.ts';
+import { normalizeCompanyAssigneeOptionsResponse, type GitHubSyncAssigneeOption } from './assignees.ts';
 import { buildPaperclipUrl, fetchJson, fetchPaperclipHealth, resolveCliAuthPollUrl } from './http.ts';
 import { mergePluginConfig, normalizePluginConfig } from './plugin-config.ts';
 import {
@@ -130,13 +131,6 @@ interface GitHubSyncAdvancedSettings {
   defaultAssigneeAgentId?: string;
   defaultStatus: PaperclipIssueStatus;
   ignoredIssueAuthorUsernames: string[];
-}
-
-interface GitHubSyncAssigneeOption {
-  id: string;
-  name: string;
-  title?: string;
-  status?: string;
 }
 
 interface GitHubSyncSettings {
@@ -2950,6 +2944,12 @@ async function listCompanyProjects(companyId: string): Promise<Array<{ id: strin
     .filter((entry): entry is { id: string; name: string } => entry !== null);
 }
 
+async function listCompanyAssigneeOptions(companyId: string): Promise<GitHubSyncAssigneeOption[]> {
+  return normalizeCompanyAssigneeOptionsResponse(
+    await fetchJson<unknown>(`/api/companies/${companyId}/agents`)
+  );
+}
+
 async function listProjectWorkspaces(projectId: string): Promise<ProjectWorkspaceSummary[]> {
   const response = await fetchJson<unknown>(`/api/projects/${projectId}/workspaces`);
   if (!Array.isArray(response)) {
@@ -4016,6 +4016,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
   const [existingProjectCandidates, setExistingProjectCandidates] = useState<ExistingProjectSyncCandidate[]>([]);
   const [existingProjectCandidatesLoading, setExistingProjectCandidatesLoading] = useState(false);
   const [existingProjectCandidatesError, setExistingProjectCandidatesError] = useState<string | null>(null);
+  const [browserAvailableAssignees, setBrowserAvailableAssignees] = useState<GitHubSyncAssigneeOption[]>([]);
   const themeMode = useResolvedThemeMode();
   const boardAccessRequirement = usePaperclipBoardAccessRequirement();
   const armSyncCompletionToast = useSyncCompletionToast(form.syncState, toast);
@@ -4108,6 +4109,44 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
       cancelled = true;
     };
   }, [hostContext.companyId, settings.data?.updatedAt, tokenStatusOverride]);
+
+  useEffect(() => {
+    const companyId = hostContext.companyId;
+    const workerAvailableAssignees = settings.data?.availableAssignees ?? [];
+
+    if (!companyId) {
+      setBrowserAvailableAssignees([]);
+      return;
+    }
+
+    if (workerAvailableAssignees.length > 0) {
+      setBrowserAvailableAssignees([]);
+      return;
+    }
+
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const assignees = await listCompanyAssigneeOptions(companyId);
+        if (cancelled) {
+          return;
+        }
+
+        setBrowserAvailableAssignees(assignees);
+      } catch {
+        if (cancelled) {
+          return;
+        }
+
+        setBrowserAvailableAssignees([]);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hostContext.companyId, settings.data?.availableAssignees, settings.data?.updatedAt]);
 
   useEffect(() => {
     const companyId = hostContext.companyId;
@@ -4254,7 +4293,9 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
   const boardAccessSectionDescription = '';
   const repositoriesUnlocked = tokenStatus === 'valid';
   const availableAssignees = getAvailableAssigneeOptions(
-    currentSettings?.availableAssignees ?? form.availableAssignees,
+    (currentSettings?.availableAssignees?.length ? currentSettings.availableAssignees : null)
+    ?? (form.availableAssignees?.length ? form.availableAssignees : null)
+    ?? browserAvailableAssignees,
     form.advancedSettings.defaultAssigneeAgentId
   );
   const savedMappingsSource = currentSettings ? currentSettings.mappings ?? [] : form.mappings;

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -284,6 +284,10 @@ test('normalizeCompanyAssigneeOptionsResponse keeps assignable agents and trims 
   assert.deepEqual(
     normalizeCompanyAssigneeOptionsResponse([
       {
+        id: 'agent-3',
+        name: 'Casey'
+      },
+      {
         id: ' agent-2 ',
         name: ' Bailey ',
         title: ' Operator ',
@@ -293,10 +297,6 @@ test('normalizeCompanyAssigneeOptionsResponse keeps assignable agents and trims 
         id: 'agent-1',
         name: 'Alex',
         status: 'terminated'
-      },
-      {
-        id: 'agent-3',
-        name: 'Casey'
       },
       null
     ]),

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -9,6 +9,7 @@ import { createTestHarness } from '@paperclipai/plugin-sdk/testing';
 
 import manifest from '../src/manifest.ts';
 import { requiresPaperclipBoardAccess } from '../src/paperclip-health.ts';
+import { normalizeCompanyAssigneeOptionsResponse } from '../src/ui/assignees.ts';
 import { fetchJson, fetchPaperclipHealth, resolveCliAuthPollUrl } from '../src/ui/http.ts';
 import { mergePluginConfig, normalizePluginConfig } from '../src/ui/plugin-config.ts';
 import {
@@ -277,6 +278,41 @@ test('filterExistingProjectSyncCandidates hides projects already enabled in plug
       sourceType: 'git_repo'
     }
   ]);
+});
+
+test('normalizeCompanyAssigneeOptionsResponse keeps assignable agents and trims their labels', () => {
+  assert.deepEqual(
+    normalizeCompanyAssigneeOptionsResponse([
+      {
+        id: ' agent-2 ',
+        name: ' Bailey ',
+        title: ' Operator ',
+        status: ' idle '
+      },
+      {
+        id: 'agent-1',
+        name: 'Alex',
+        status: 'terminated'
+      },
+      {
+        id: 'agent-3',
+        name: 'Casey'
+      },
+      null
+    ]),
+    [
+      {
+        id: 'agent-2',
+        name: 'Bailey',
+        title: 'Operator',
+        status: 'idle'
+      },
+      {
+        id: 'agent-3',
+        name: 'Casey'
+      }
+    ]
+  );
 });
 
 function createAgentFixture(params: {


### PR DESCRIPTION
## Summary
- add a shared assignee response normalizer for company agent data
- fall back to fetching `/api/companies/:companyId/agents` in the settings UI when the worker returns no assignees
- prefer worker-provided assignees when available and keep the browser-fetched list as a fallback only
- add a unit test covering trimming, filtering, and sorting of assignee options

## Testing
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Model Used
- `gpt-5.4`
- Context window: 400k tokens
- Reasoning mode: medium
- Capabilities: code generation, repository diff analysis, test-aware change summarization