### PR TITLE
Fix GitHub sync plugin ID and trusted API origin resolution

### DIFF
--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -4,6 +4,7 @@ import { useHostContext, usePluginAction, usePluginData, usePluginToast } from '
 import { parseRepositoryReference, type ParsedRepositoryReference } from '../github-repo.ts';
 import { requiresPaperclipBoardAccess } from '../paperclip-health.ts';
 import { buildPaperclipUrl, fetchJson, fetchPaperclipHealth, resolveCliAuthPollUrl } from './http.ts';
+import { resolveInstalledGitHubSyncPluginId, resolvePluginSettingsHref } from './plugin-installation.ts';
 import { mergePluginConfig, normalizePluginConfig } from './plugin-config.ts';
 import {
   discoverExistingProjectSyncCandidates,
@@ -2794,6 +2795,26 @@ function getPaperclipApiBaseUrl(): string | undefined {
 }
 
 const syncedPaperclipApiBaseUrlsByPluginId = new Map<string, string>();
+let installedGitHubSyncPluginIdPromise: Promise<string | null> | null = null;
+
+async function resolveCurrentPluginId(pluginId: string | null): Promise<string | null> {
+  if (pluginId) {
+    return pluginId;
+  }
+
+  if (!installedGitHubSyncPluginIdPromise) {
+    installedGitHubSyncPluginIdPromise = fetchJson<unknown>('/api/plugins')
+      .then((records) => resolveInstalledGitHubSyncPluginId(records))
+      .catch(() => null);
+  }
+
+  const resolvedPluginId = await installedGitHubSyncPluginIdPromise;
+  if (!resolvedPluginId) {
+    installedGitHubSyncPluginIdPromise = null;
+  }
+
+  return resolvedPluginId;
+}
 
 async function syncTrustedPaperclipApiBaseUrl(pluginId: string | null): Promise<string | undefined> {
   const paperclipApiBaseUrl = getPaperclipApiBaseUrl();
@@ -2801,21 +2822,22 @@ async function syncTrustedPaperclipApiBaseUrl(pluginId: string | null): Promise<
     return undefined;
   }
 
-  if (!pluginId) {
+  const resolvedPluginId = await resolveCurrentPluginId(pluginId);
+  if (!resolvedPluginId) {
     throw new Error(
       'Unable to sync the trusted Paperclip API origin because the plugin ID is missing. Reload the plugin and try again before saving or syncing.'
     );
   }
 
-  const lastSyncedPaperclipApiBaseUrl = syncedPaperclipApiBaseUrlsByPluginId.get(pluginId);
+  const lastSyncedPaperclipApiBaseUrl = syncedPaperclipApiBaseUrlsByPluginId.get(resolvedPluginId);
   if (lastSyncedPaperclipApiBaseUrl === paperclipApiBaseUrl) {
     return paperclipApiBaseUrl;
   }
 
-  await patchPluginConfig(pluginId, {
+  await patchPluginConfig(resolvedPluginId, {
     paperclipApiBaseUrl
   });
-  syncedPaperclipApiBaseUrlsByPluginId.set(pluginId, paperclipApiBaseUrl);
+  syncedPaperclipApiBaseUrlsByPluginId.set(resolvedPluginId, paperclipApiBaseUrl);
 
   return paperclipApiBaseUrl;
 }
@@ -3408,39 +3430,6 @@ function useResolvedIssueId(params: {
     issueIdentifier: null,
     loading: false
   };
-}
-
-function resolvePluginSettingsHref(records: unknown): string {
-  if (!Array.isArray(records)) {
-    return SETTINGS_INDEX_HREF;
-  }
-
-  for (const entry of records) {
-    if (!entry || typeof entry !== 'object') {
-      continue;
-    }
-
-    const record = entry as Record<string, unknown>;
-    const manifest = record.manifest && typeof record.manifest === 'object' ? record.manifest as Record<string, unknown> : null;
-    const id =
-      getStringValue(record, 'id') ??
-      getStringValue(record, 'pluginId');
-    const key =
-      getStringValue(record, 'pluginKey') ??
-      getStringValue(record, 'key') ??
-      getStringValue(record, 'packageName') ??
-      getStringValue(record, 'name') ??
-      (manifest ? getStringValue(manifest, 'id') : null);
-    const displayName =
-      getStringValue(record, 'displayName') ??
-      (manifest ? getStringValue(manifest, 'displayName') : null);
-
-    if (id && (key === 'paperclip-github-plugin' || displayName === 'GitHub Sync')) {
-      return `${SETTINGS_INDEX_HREF}/${id}`;
-    }
-  }
-
-  return SETTINGS_INDEX_HREF;
 }
 
 function formatSyncProgressRepository(repositoryUrl?: string): string | null {
@@ -4116,7 +4105,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
         ? settings.data.paperclipBoardAccessConfigSyncRef
         : undefined;
 
-    if (!companyId || !pluginIdFromLocation || !secretRef) {
+    if (!companyId || !secretRef) {
       return;
     }
 
@@ -4130,7 +4119,12 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
 
     void (async () => {
       try {
-        await patchPluginConfig(pluginIdFromLocation, {
+        const pluginId = await resolveCurrentPluginId(pluginIdFromLocation);
+        if (!pluginId) {
+          throw new Error('Plugin id is required to finish syncing Paperclip board access into plugin config.');
+        }
+
+        await patchPluginConfig(pluginId, {
           paperclipBoardApiTokenRefs: {
             [companyId]: secretRef
           }
@@ -4514,7 +4508,8 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
         throw new Error('Company context is required to save the GitHub token.');
       }
 
-      if (!pluginIdFromLocation) {
+      const pluginId = await resolveCurrentPluginId(pluginIdFromLocation);
+      if (!pluginId) {
         throw new Error('Plugin id is required to save the GitHub token.');
       }
 
@@ -4523,7 +4518,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
       const secretName = `github_sync_${companyId.replace(/[^a-z0-9]+/gi, '_').toLowerCase()}`;
       const secret = await resolveOrCreateCompanySecret(companyId, secretName, trimmedToken);
 
-      await patchPluginConfig(pluginIdFromLocation, {
+      await patchPluginConfig(pluginId, {
         githubTokenRef: secret.id
       });
       await saveRegistration({
@@ -4573,7 +4568,8 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
         throw new Error('Company context is required to connect Paperclip board access.');
       }
 
-      if (!pluginIdFromLocation) {
+      const pluginId = await resolveCurrentPluginId(pluginIdFromLocation);
+      if (!pluginId) {
         throw new Error('Plugin id is required to connect Paperclip board access.');
       }
 
@@ -4602,7 +4598,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
       const secretName = `paperclip_board_api_${companyId.replace(/[^a-z0-9]+/gi, '_').toLowerCase()}`;
       const secret = await resolveOrCreateCompanySecret(companyId, secretName, boardApiToken);
 
-      await patchPluginConfig(pluginIdFromLocation, {
+      await patchPluginConfig(pluginId, {
         paperclipBoardApiTokenRefs: {
           [companyId]: secret.id
         }

--- a/src/ui/plugin-installation.ts
+++ b/src/ui/plugin-installation.ts
@@ -1,0 +1,62 @@
+const SETTINGS_INDEX_HREF = '/settings/plugins';
+const GITHUB_SYNC_PLUGIN_KEY = 'paperclip-github-plugin';
+const GITHUB_SYNC_PLUGIN_DISPLAY_NAME = 'GitHub Sync';
+
+function getStringValue(record: Record<string, unknown> | null, key: string): string | null {
+  if (!record) {
+    return null;
+  }
+
+  const value = record[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function resolveGitHubSyncPluginRecord(records: unknown): Record<string, unknown> | null {
+  if (!Array.isArray(records)) {
+    return null;
+  }
+
+  for (const entry of records) {
+    if (!entry || typeof entry !== 'object') {
+      continue;
+    }
+
+    const record = entry as Record<string, unknown>;
+    const manifest = record.manifest && typeof record.manifest === 'object' ? record.manifest as Record<string, unknown> : null;
+    const key =
+      getStringValue(record, 'pluginKey')
+      ?? getStringValue(record, 'key')
+      ?? getStringValue(record, 'packageName')
+      ?? getStringValue(record, 'name')
+      ?? getStringValue(manifest, 'id');
+    const displayName =
+      getStringValue(record, 'displayName')
+      ?? getStringValue(manifest, 'displayName');
+    const id =
+      getStringValue(record, 'id')
+      ?? getStringValue(record, 'pluginId');
+
+    if (id && (key === GITHUB_SYNC_PLUGIN_KEY || displayName === GITHUB_SYNC_PLUGIN_DISPLAY_NAME)) {
+      return record;
+    }
+  }
+
+  return null;
+}
+
+export function resolveInstalledGitHubSyncPluginId(
+  records: unknown,
+  preferredPluginId?: string | null
+): string | null {
+  if (typeof preferredPluginId === 'string' && preferredPluginId.trim()) {
+    return preferredPluginId.trim();
+  }
+
+  const record = resolveGitHubSyncPluginRecord(records);
+  return getStringValue(record, 'id') ?? getStringValue(record, 'pluginId');
+}
+
+export function resolvePluginSettingsHref(records: unknown): string {
+  const pluginId = resolveInstalledGitHubSyncPluginId(records);
+  return pluginId ? `${SETTINGS_INDEX_HREF}/${pluginId}` : SETTINGS_INDEX_HREF;
+}

--- a/src/ui/plugin-installation.ts
+++ b/src/ui/plugin-installation.ts
@@ -1,4 +1,4 @@
-const SETTINGS_INDEX_HREF = '/settings/plugins';
+const SETTINGS_INDEX_HREF = '/instance/settings/plugins';
 const GITHUB_SYNC_PLUGIN_KEY = 'paperclip-github-plugin';
 const GITHUB_SYNC_PLUGIN_DISPLAY_NAME = 'GitHub Sync';
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -7094,6 +7094,7 @@ async function performSync(
   const config = await getResolvedConfig(ctx);
   const importRegistry = normalizeImportRegistry(await ctx.state.get(IMPORT_REGISTRY_SCOPE));
   const token = typeof options.resolvedToken === 'string' ? options.resolvedToken : await resolveGithubToken(ctx);
+  const paperclipApiBaseUrl = getConfiguredPaperclipApiBaseUrl(settings, config);
   const mappings = getSyncableMappingsForTarget(settings.mappings, options.target);
   activePaperclipApiAuthTokensByCompanyId = null;
   const failureContext: SyncFailureContext = {
@@ -7123,7 +7124,7 @@ async function performSync(
   const mappingsMissingBoardAccess = getMappingsMissingPaperclipBoardAccess(settings, config, mappings);
   if (
     mappingsMissingBoardAccess.length > 0
-    && await detectPaperclipBoardAccessRequirement(settings.paperclipApiBaseUrl)
+    && await detectPaperclipBoardAccessRequirement(paperclipApiBaseUrl)
   ) {
     const next = {
       ...settings,
@@ -7265,7 +7266,7 @@ async function performSync(
           });
           availableLabels =
             supportsPaperclipLabelMapping && companyId
-              ? await buildPaperclipLabelDirectory(ctx, companyId, settings.paperclipApiBaseUrl)
+              ? await buildPaperclipLabelDirectory(ctx, companyId, paperclipApiBaseUrl)
               : new Map();
           if (companyId) {
             companyLabelDirectoryCache.set(companyId, availableLabels);
@@ -7377,7 +7378,7 @@ async function performSync(
           });
           availableLabels =
             supportsPaperclipLabelMapping && companyId
-              ? await buildPaperclipLabelDirectory(ctx, companyId, settings.paperclipApiBaseUrl)
+              ? await buildPaperclipLabelDirectory(ctx, companyId, paperclipApiBaseUrl)
               : new Map();
           if (companyId) {
             companyLabelDirectoryCache.set(companyId, availableLabels);
@@ -7461,7 +7462,7 @@ async function performSync(
               advancedSettings,
               issue,
               availableLabels,
-              settings.paperclipApiBaseUrl,
+              paperclipApiBaseUrl,
               importRegistryByIssueId,
               existingImportedPaperclipIssuesByUrl,
               nextRegistry,
@@ -7513,7 +7514,7 @@ async function performSync(
           importedIssuesForSynchronization,
           createdIssueIds,
           availableLabels,
-          settings.paperclipApiBaseUrl,
+          paperclipApiBaseUrl,
           linkedPullRequestsByIssueNumber,
           issueStatusSnapshotCache,
           pullRequestStatusCache,

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -343,7 +343,7 @@ test('resolveInstalledGitHubSyncPluginId finds the GitHub Sync installation id f
   ];
 
   assert.equal(resolveInstalledGitHubSyncPluginId(records), 'plugin-123');
-  assert.equal(resolvePluginSettingsHref(records), '/settings/plugins/plugin-123');
+  assert.equal(resolvePluginSettingsHref(records), '/instance/settings/plugins/plugin-123');
   assert.equal(resolveInstalledGitHubSyncPluginId(records, 'plugin-from-route'), 'plugin-from-route');
 });
 

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -10,6 +10,7 @@ import { createTestHarness } from '@paperclipai/plugin-sdk/testing';
 import manifest from '../src/manifest.ts';
 import { requiresPaperclipBoardAccess } from '../src/paperclip-health.ts';
 import { fetchJson, fetchPaperclipHealth, resolveCliAuthPollUrl } from '../src/ui/http.ts';
+import { resolveInstalledGitHubSyncPluginId, resolvePluginSettingsHref } from '../src/ui/plugin-installation.ts';
 import { mergePluginConfig, normalizePluginConfig } from '../src/ui/plugin-config.ts';
 import {
   discoverExistingProjectSyncCandidates,
@@ -277,6 +278,25 @@ test('filterExistingProjectSyncCandidates hides projects already enabled in plug
       sourceType: 'git_repo'
     }
   ]);
+});
+
+test('resolveInstalledGitHubSyncPluginId finds the GitHub Sync installation id from plugin listings', () => {
+  const records = [
+    {
+      id: 'plugin-123',
+      pluginKey: 'paperclip-github-plugin',
+      displayName: 'GitHub Sync'
+    },
+    {
+      id: 'plugin-456',
+      pluginKey: 'another-plugin',
+      displayName: 'Another Plugin'
+    }
+  ];
+
+  assert.equal(resolveInstalledGitHubSyncPluginId(records), 'plugin-123');
+  assert.equal(resolvePluginSettingsHref(records), '/settings/plugins/plugin-123');
+  assert.equal(resolveInstalledGitHubSyncPluginId(records, 'plugin-from-route'), 'plugin-from-route');
 });
 
 function createAgentFixture(params: {


### PR DESCRIPTION
## Summary
- add a shared UI helper to resolve the installed GitHub Sync plugin id from `/api/plugins` when a hosted surface is rendered outside a plugin route
- update settings and toolbar sync flows to use the resolved plugin id before patching plugin config or syncing the trusted Paperclip API origin
- use the resolved trusted `paperclipApiBaseUrl` consistently in worker sync paths for board-access checks and label-sensitive operations
- add regression coverage for installed plugin id resolution

## Testing
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Model Used
- `gpt-5.4`
- Reasoning effort: medium
- Context window: 400k tokens
- Capabilities: tool-assisted coding, repository inspection, patch application, test/build execution