### PR TITLE
Add saved sync failure details to GitHub Sync diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The plugin adds a full in-host workflow instead of a one-off import script:
 
 - a hosted settings page for GitHub auth, repository mappings, company defaults, and sync controls
 - a dashboard widget that shows readiness, sync status, and last-run results
+- saved sync diagnostics that let operators inspect the latest per-issue failures, raw errors, and suggested next steps
 - manual sync actions from global, project, and issue toolbar surfaces
 - a GitHub detail tab on synced Paperclip issues
 - GitHub link annotations on sync-generated status transition comments when the host supports comment annotations
@@ -170,6 +171,7 @@ When an agent posts a GitHub comment or review-thread reply through the plugin, 
 - If setup is reported as incomplete, confirm that a GitHub token has been saved or that `~/.paperclip/plugins/github-sync/config.json` contains `githubToken`, and make sure at least one mapping has a created Paperclip project.
 - If Paperclip says board access is required, open plugin settings inside the affected company and complete the Paperclip board access flow before retrying sync.
 - If the worker reaches an authenticated HTML page instead of the Paperclip API JSON responses it expects, connect Paperclip board access for that company or set `PAPERCLIP_API_URL` to a worker-accessible Paperclip API origin.
+- If a sync run finishes with partial failures, open the saved troubleshooting panel in GitHub Sync to inspect the repository, issue number, raw error, and suggested fix for each recorded failure.
 - If sync says the Paperclip API URL is not trusted, reopen the plugin from the current Paperclip host so the settings UI can refresh the saved origin, or set `PAPERCLIP_API_URL` for the worker.
 - If GitHub rate limiting is hit, the plugin pauses sync until the reported reset time instead of retrying pointlessly.
 - If a manual sync takes longer than the host action window, it continues in the background and updates the UI when it finishes.

--- a/SPEC.md
+++ b/SPEC.md
@@ -97,6 +97,7 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 - The plugin SHOULD expose an issue detail contribution for GitHub metadata.
 - The plugin SHOULD expose manual sync buttons in the global toolbar and on mapped project/issue surfaces when the host renders those slot types.
 - The dashboard widget MUST summarize the current GitHub sync readiness and link to setup.
+- When the latest sync run records issue-level failures, the settings page SHOULD expose a saved failure log with per-failure repository, issue, phase, raw error, and suggested next-step details, and compact surfaces SHOULD still surface at least the latest saved failure snapshot.
 - The settings page MUST render inside the real Paperclip host.
 - The plugin MUST include end-to-end automation that boots a disposable Paperclip instance, installs the plugin, and verifies the settings page renders.
 

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -980,6 +980,9 @@ const PAGE_STYLES = `
 .ghsync-diagnostics__failures {
   max-height: 420px;
   overflow: auto;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
 .ghsync-diagnostics__failure {
@@ -992,6 +995,10 @@ const PAGE_STYLES = `
   background: var(--ghsync-surfaceAlt);
   text-align: left;
   transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
+}
+
+.ghsync-diagnostics__failure-item {
+  list-style: none;
 }
 
 .ghsync-diagnostics__failure:hover {
@@ -2020,6 +2027,9 @@ const WIDGET_STYLES = `
 .ghsync-diagnostics__failures {
   max-height: 320px;
   overflow: auto;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
 .ghsync-diagnostics__failure {
@@ -2031,6 +2041,10 @@ const WIDGET_STYLES = `
   border: 1px solid var(--ghsync-dangerBorder);
   background: var(--ghsync-surfaceAlt);
   text-align: left;
+}
+
+.ghsync-diagnostics__failure-item {
+  list-style: none;
 }
 
 .ghsync-diagnostics__failure--active {
@@ -4095,16 +4109,17 @@ function SyncDiagnosticsPanel(props: {
   compact?: boolean;
 }): React.JSX.Element | null {
   const failureEntries = getSyncFailureLogEntries(props.syncState);
-  const [selectedFailureIndex, setSelectedFailureIndex] = useState(0);
-  const selectedFailure = failureEntries[Math.min(selectedFailureIndex, Math.max(failureEntries.length - 1, 0))];
+  const latestFailureIndex = Math.max(failureEntries.length - 1, 0);
+  const [selectedFailureIndex, setSelectedFailureIndex] = useState(latestFailureIndex);
+  const selectedFailure = failureEntries[Math.min(selectedFailureIndex, latestFailureIndex)];
   const diagnostics = selectedFailure ? getSyncDiagnostics(selectedFailure) : null;
   const requestError = props.requestError?.trim() ? props.requestError.trim() : null;
   const canSelectFailures = !props.compact && failureEntries.length > 1;
   const savedFailureCount = props.syncState.erroredIssuesCount ?? failureEntries.length;
 
   useEffect(() => {
-    setSelectedFailureIndex(0);
-  }, [props.syncState.checkedAt, props.syncState.status]);
+    setSelectedFailureIndex(latestFailureIndex);
+  }, [latestFailureIndex, props.syncState.checkedAt, props.syncState.status]);
 
   if (!diagnostics && !requestError) {
     return null;
@@ -4135,7 +4150,7 @@ function SyncDiagnosticsPanel(props: {
       {diagnostics ? (
         <div className={`ghsync-diagnostics__layout${canSelectFailures ? ' ghsync-diagnostics__layout--split' : ''}`}>
           {canSelectFailures ? (
-            <div className="ghsync-diagnostics__failures" role="list" aria-label="Latest sync failures">
+            <ul className="ghsync-diagnostics__failures" aria-label="Latest sync failures">
               {failureEntries.map((failure, index) => {
                 const repositoryLabel = formatSyncFailureRepository(failure.repositoryUrl);
                 const issueLabel =
@@ -4147,21 +4162,26 @@ function SyncDiagnosticsPanel(props: {
                   .join(' · ');
 
                 return (
-                  <button
+                  <li
                     key={`${failure.occurredAt ?? 'unknown'}-${failure.githubIssueNumber ?? 'no-issue'}-${index}`}
-                    type="button"
-                    className={`ghsync-diagnostics__failure${index === selectedFailureIndex ? ' ghsync-diagnostics__failure--active' : ''}`}
-                    onClick={() => setSelectedFailureIndex(index)}
+                    className="ghsync-diagnostics__failure-item"
                   >
-                    <strong className="ghsync-diagnostics__failure-title">
-                      {title || `Failure ${index + 1}`}
-                    </strong>
-                    {meta ? <span className="ghsync-diagnostics__failure-meta">{meta}</span> : null}
-                    <span className="ghsync-diagnostics__failure-preview">{failure.message}</span>
-                  </button>
+                    <button
+                      type="button"
+                      className={`ghsync-diagnostics__failure${index === selectedFailureIndex ? ' ghsync-diagnostics__failure--active' : ''}`}
+                      aria-pressed={index === selectedFailureIndex}
+                      onClick={() => setSelectedFailureIndex(index)}
+                    >
+                      <strong className="ghsync-diagnostics__failure-title">
+                        {title || `Failure ${index + 1}`}
+                      </strong>
+                      {meta ? <span className="ghsync-diagnostics__failure-meta">{meta}</span> : null}
+                      <span className="ghsync-diagnostics__failure-preview">{failure.message}</span>
+                    </button>
+                  </li>
                 );
               })}
-            </div>
+            </ul>
           ) : null}
 
           <div className="ghsync-diagnostics__detail">

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -87,6 +87,7 @@ interface SyncRunState {
   lastRunTrigger?: 'manual' | 'schedule' | 'retry';
   progress?: SyncProgressState;
   errorDetails?: SyncErrorDetails;
+  recentFailures?: SyncFailureLogEntry[];
 }
 
 type SyncProgressPhase = 'preparing' | 'importing' | 'syncing';
@@ -123,6 +124,11 @@ interface SyncErrorDetails {
   suggestedAction?: string;
   rateLimitResetAt?: string;
   rateLimitResource?: string;
+}
+
+interface SyncFailureLogEntry extends SyncErrorDetails {
+  message: string;
+  occurredAt?: string;
 }
 
 type PaperclipIssueStatus = 'backlog' | 'todo' | 'in_progress' | 'in_review' | 'done' | 'blocked' | 'cancelled';
@@ -723,6 +729,10 @@ const SHARED_PROGRESS_STYLES = `
     align-items: stretch;
     flex-direction: column;
   }
+
+  .ghsync-diagnostics__layout--split {
+    grid-template-columns: 1fr;
+  }
 }
 `;
 
@@ -949,6 +959,72 @@ const PAGE_STYLES = `
   display: grid;
   gap: 10px;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.ghsync-diagnostics__layout {
+  display: grid;
+  gap: 10px;
+}
+
+.ghsync-diagnostics__layout--split {
+  grid-template-columns: minmax(220px, 300px) minmax(0, 1fr);
+  align-items: start;
+}
+
+.ghsync-diagnostics__detail,
+.ghsync-diagnostics__failures {
+  display: grid;
+  gap: 10px;
+}
+
+.ghsync-diagnostics__failures {
+  max-height: 420px;
+  overflow: auto;
+}
+
+.ghsync-diagnostics__failure {
+  display: grid;
+  gap: 6px;
+  width: 100%;
+  padding: 12px;
+  border-radius: 10px;
+  border: 1px solid var(--ghsync-dangerBorder);
+  background: var(--ghsync-surfaceAlt);
+  text-align: left;
+  transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
+}
+
+.ghsync-diagnostics__failure:hover {
+  border-color: var(--ghsync-dangerText);
+  transform: translateY(-1px);
+}
+
+.ghsync-diagnostics__failure--active {
+  border-color: var(--ghsync-dangerText);
+  background: color-mix(in srgb, var(--ghsync-dangerBg) 35%, var(--ghsync-surfaceAlt));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--ghsync-dangerText) 22%, transparent);
+}
+
+.ghsync-diagnostics__failure-title {
+  color: var(--ghsync-title);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.ghsync-diagnostics__failure-meta {
+  color: var(--ghsync-muted);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.ghsync-diagnostics__failure-preview {
+  color: var(--ghsync-text);
+  font-size: 12px;
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
 }
 
 .ghsync-diagnostics__item,
@@ -1925,6 +2001,65 @@ const WIDGET_STYLES = `
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
 }
 
+.ghsync-diagnostics__layout {
+  display: grid;
+  gap: 10px;
+}
+
+.ghsync-diagnostics__layout--split {
+  grid-template-columns: minmax(200px, 240px) minmax(0, 1fr);
+  align-items: start;
+}
+
+.ghsync-diagnostics__detail,
+.ghsync-diagnostics__failures {
+  display: grid;
+  gap: 10px;
+}
+
+.ghsync-diagnostics__failures {
+  max-height: 320px;
+  overflow: auto;
+}
+
+.ghsync-diagnostics__failure {
+  display: grid;
+  gap: 6px;
+  width: 100%;
+  padding: 12px;
+  border-radius: 10px;
+  border: 1px solid var(--ghsync-dangerBorder);
+  background: var(--ghsync-surfaceAlt);
+  text-align: left;
+}
+
+.ghsync-diagnostics__failure--active {
+  border-color: var(--ghsync-dangerText);
+  background: color-mix(in srgb, var(--ghsync-dangerBg) 35%, var(--ghsync-surfaceAlt));
+}
+
+.ghsync-diagnostics__failure-title {
+  color: var(--ghsync-title);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.ghsync-diagnostics__failure-meta {
+  color: var(--ghsync-muted);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.ghsync-diagnostics__failure-preview {
+  color: var(--ghsync-text);
+  font-size: 12px;
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+}
+
 .ghsync-diagnostics__item,
 .ghsync-diagnostics__block {
   display: grid;
@@ -2064,6 +2199,10 @@ const WIDGET_STYLES = `
   .ghsync__button,
   .ghsync-widget__link {
     flex: 1 1 auto;
+  }
+
+  .ghsync-diagnostics__layout--split {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -3807,21 +3946,36 @@ function formatSyncFailureRepository(repositoryUrl?: string): string | null {
   return repositoryUrl.trim();
 }
 
-function getSyncDiagnostics(syncState: SyncRunState): {
+function getSyncFailureLogEntries(syncState: SyncRunState): SyncFailureLogEntry[] {
+  if (syncState.recentFailures?.length) {
+    return syncState.recentFailures.filter((entry) => typeof entry.message === 'string' && entry.message.trim());
+  }
+
+  if (syncState.status !== 'error') {
+    return [];
+  }
+
+  return [
+    {
+      message: syncState.message?.trim() || 'GitHub sync failed.',
+      occurredAt: syncState.checkedAt,
+      ...(syncState.errorDetails ?? {})
+    }
+  ];
+}
+
+function getSyncDiagnostics(entry: SyncFailureLogEntry): {
+  message: string;
   rows: Array<{ label: string; value: string }>;
   rawMessage?: string;
   suggestedAction?: string;
 } | null {
-  if (syncState.status !== 'error') {
-    return null;
-  }
-
   const rows: Array<{ label: string; value: string }> = [];
-  const repositoryLabel = formatSyncFailureRepository(syncState.errorDetails?.repositoryUrl);
-  const phaseLabel = formatSyncFailurePhase(syncState.errorDetails?.phase);
-  const issueNumber = syncState.errorDetails?.githubIssueNumber;
-  const rateLimitResetAt = syncState.errorDetails?.rateLimitResetAt;
-  const rateLimitResourceLabel = getGitHubRateLimitResourceLabel(syncState.errorDetails?.rateLimitResource);
+  const repositoryLabel = formatSyncFailureRepository(entry.repositoryUrl);
+  const phaseLabel = formatSyncFailurePhase(entry.phase);
+  const issueNumber = entry.githubIssueNumber;
+  const rateLimitResetAt = entry.rateLimitResetAt;
+  const rateLimitResourceLabel = getGitHubRateLimitResourceLabel(entry.rateLimitResource);
 
   if (repositoryLabel) {
     rows.push({
@@ -3858,17 +4012,25 @@ function getSyncDiagnostics(syncState: SyncRunState): {
     });
   }
 
-  const rawMessage =
-    syncState.errorDetails?.rawMessage && syncState.errorDetails.rawMessage !== syncState.message
-      ? syncState.errorDetails.rawMessage
-      : undefined;
-  const suggestedAction = syncState.errorDetails?.suggestedAction;
+  if (entry.occurredAt) {
+    rows.push({
+      label: 'Captured',
+      value: formatDate(entry.occurredAt, entry.occurredAt)
+    });
+  }
 
-  if (rows.length === 0 && !rawMessage && !suggestedAction) {
+  const rawMessage =
+    entry.rawMessage && entry.rawMessage !== entry.message
+      ? entry.rawMessage
+      : undefined;
+  const suggestedAction = entry.suggestedAction;
+
+  if (!entry.message && rows.length === 0 && !rawMessage && !suggestedAction) {
     return null;
   }
 
   return {
+    message: entry.message,
     rows,
     ...(rawMessage ? { rawMessage } : {}),
     ...(suggestedAction ? { suggestedAction } : {})
@@ -3932,8 +4094,17 @@ function SyncDiagnosticsPanel(props: {
   requestError?: string | null;
   compact?: boolean;
 }): React.JSX.Element | null {
-  const diagnostics = getSyncDiagnostics(props.syncState);
+  const failureEntries = getSyncFailureLogEntries(props.syncState);
+  const [selectedFailureIndex, setSelectedFailureIndex] = useState(0);
+  const selectedFailure = failureEntries[Math.min(selectedFailureIndex, Math.max(failureEntries.length - 1, 0))];
+  const diagnostics = selectedFailure ? getSyncDiagnostics(selectedFailure) : null;
   const requestError = props.requestError?.trim() ? props.requestError.trim() : null;
+  const canSelectFailures = !props.compact && failureEntries.length > 1;
+  const savedFailureCount = props.syncState.erroredIssuesCount ?? failureEntries.length;
+
+  useEffect(() => {
+    setSelectedFailureIndex(0);
+  }, [props.syncState.checkedAt, props.syncState.status]);
 
   if (!diagnostics && !requestError) {
     return null;
@@ -3945,7 +4116,11 @@ function SyncDiagnosticsPanel(props: {
         <strong>{diagnostics ? 'Troubleshooting details' : 'Sync request failed'}</strong>
         <span>
           {diagnostics
-            ? 'GitHub Sync saved this snapshot from the latest failed run.'
+            ? canSelectFailures
+              ? savedFailureCount > failureEntries.length
+                ? `GitHub Sync saved the latest ${failureEntries.length} of ${savedFailureCount} failures from the latest run. Select one to inspect.`
+                : `GitHub Sync saved ${failureEntries.length} failure${failureEntries.length === 1 ? '' : 's'} from the latest run. Select one to inspect.`
+              : 'GitHub Sync saved this snapshot from the latest failed run.'
             : 'The sync request failed before the worker returned a saved result.'}
         </span>
       </div>
@@ -3957,28 +4132,69 @@ function SyncDiagnosticsPanel(props: {
         </div>
       ) : null}
 
-      {diagnostics?.rows.length ? (
-        <div className="ghsync-diagnostics__grid">
-          {diagnostics.rows.map((row) => (
-            <div key={row.label} className="ghsync-diagnostics__item">
-              <span className="ghsync-diagnostics__label">{row.label}</span>
-              <strong className="ghsync-diagnostics__value">{row.value}</strong>
+      {diagnostics ? (
+        <div className={`ghsync-diagnostics__layout${canSelectFailures ? ' ghsync-diagnostics__layout--split' : ''}`}>
+          {canSelectFailures ? (
+            <div className="ghsync-diagnostics__failures" role="list" aria-label="Latest sync failures">
+              {failureEntries.map((failure, index) => {
+                const repositoryLabel = formatSyncFailureRepository(failure.repositoryUrl);
+                const issueLabel =
+                  failure.githubIssueNumber !== undefined ? `Issue #${failure.githubIssueNumber}` : null;
+                const phaseLabel = formatSyncFailurePhase(failure.phase);
+                const title = [repositoryLabel, issueLabel].filter((value): value is string => Boolean(value)).join(' · ');
+                const meta = [phaseLabel, failure.occurredAt ? formatDate(failure.occurredAt, failure.occurredAt) : null]
+                  .filter((value): value is string => Boolean(value))
+                  .join(' · ');
+
+                return (
+                  <button
+                    key={`${failure.occurredAt ?? 'unknown'}-${failure.githubIssueNumber ?? 'no-issue'}-${index}`}
+                    type="button"
+                    className={`ghsync-diagnostics__failure${index === selectedFailureIndex ? ' ghsync-diagnostics__failure--active' : ''}`}
+                    onClick={() => setSelectedFailureIndex(index)}
+                  >
+                    <strong className="ghsync-diagnostics__failure-title">
+                      {title || `Failure ${index + 1}`}
+                    </strong>
+                    {meta ? <span className="ghsync-diagnostics__failure-meta">{meta}</span> : null}
+                    <span className="ghsync-diagnostics__failure-preview">{failure.message}</span>
+                  </button>
+                );
+              })}
             </div>
-          ))}
-        </div>
-      ) : null}
+          ) : null}
 
-      {diagnostics?.rawMessage ? (
-        <div className="ghsync-diagnostics__block">
-          <span className="ghsync-diagnostics__label">Raw error</span>
-          <div className="ghsync-diagnostics__value ghsync-diagnostics__value--code">{diagnostics.rawMessage}</div>
-        </div>
-      ) : null}
+          <div className="ghsync-diagnostics__detail">
+            <div className="ghsync-diagnostics__block">
+              <span className="ghsync-diagnostics__label">Summary</span>
+              <div className="ghsync-diagnostics__value">{diagnostics.message}</div>
+            </div>
 
-      {diagnostics?.suggestedAction ? (
-        <div className="ghsync-diagnostics__block">
-          <span className="ghsync-diagnostics__label">Next step</span>
-          <div className="ghsync-diagnostics__value">{diagnostics.suggestedAction}</div>
+            {diagnostics.rows.length ? (
+              <div className="ghsync-diagnostics__grid">
+                {diagnostics.rows.map((row) => (
+                  <div key={row.label} className="ghsync-diagnostics__item">
+                    <span className="ghsync-diagnostics__label">{row.label}</span>
+                    <strong className="ghsync-diagnostics__value">{row.value}</strong>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+
+            {diagnostics.rawMessage ? (
+              <div className="ghsync-diagnostics__block">
+                <span className="ghsync-diagnostics__label">Raw error</span>
+                <div className="ghsync-diagnostics__value ghsync-diagnostics__value--code">{diagnostics.rawMessage}</div>
+              </div>
+            ) : null}
+
+            {diagnostics.suggestedAction ? (
+              <div className="ghsync-diagnostics__block">
+                <span className="ghsync-diagnostics__label">Next step</span>
+                <div className="ghsync-diagnostics__value">{diagnostics.suggestedAction}</div>
+              </div>
+            ) : null}
+          </div>
         </div>
       ) : null}
     </section>

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -32,6 +32,7 @@ const PAPERCLIP_LABEL_PAGE_SIZE = 100;
 const MANUAL_SYNC_RESPONSE_GRACE_PERIOD_MS = 500;
 const RUNNING_SYNC_MESSAGE = 'GitHub sync is running in the background. This page will update when it finishes.';
 const SYNC_PROGRESS_PERSIST_INTERVAL_MS = 250;
+const MAX_SYNC_FAILURE_LOG_ENTRIES = 25;
 const GITHUB_SECONDARY_RATE_LIMIT_FALLBACK_MS = 60_000;
 const MISSING_GITHUB_TOKEN_SYNC_MESSAGE = 'Configure a GitHub token before running sync.';
 const MISSING_GITHUB_TOKEN_SYNC_ACTION =
@@ -130,6 +131,7 @@ interface SyncRunState {
   lastRunTrigger?: 'manual' | 'schedule' | 'retry';
   progress?: SyncProgressState;
   errorDetails?: SyncErrorDetails;
+  recentFailures?: SyncFailureLogEntry[];
 }
 
 type SyncFailurePhase =
@@ -167,6 +169,11 @@ interface SyncErrorDetails {
   suggestedAction?: string;
   rateLimitResetAt?: string;
   rateLimitResource?: string;
+}
+
+interface SyncFailureLogEntry extends SyncErrorDetails {
+  message: string;
+  occurredAt: string;
 }
 
 interface GitHubRateLimitPauseDetails {
@@ -684,6 +691,7 @@ interface GitHubReviewThreadRecord {
 interface SyncProcessingFailure {
   error: unknown;
   context: SyncFailureContext;
+  occurredAt: string;
 }
 
 const SUCCESSFUL_CHECK_RUN_CONCLUSIONS = new Set(['SUCCESS', 'NEUTRAL', 'SKIPPED']);
@@ -1233,6 +1241,7 @@ function normalizeSyncConfigurationIssue(value: unknown): SyncConfigurationIssue
   switch (value) {
     case 'missing_token':
     case 'missing_mapping':
+    case 'missing_board_access':
       return value;
     default:
       return undefined;
@@ -1367,6 +1376,42 @@ function normalizeSyncErrorDetails(value: unknown): SyncErrorDetails | undefined
     ...(rateLimitResetAt ? { rateLimitResetAt } : {}),
     ...(rateLimitResource ? { rateLimitResource } : {})
   };
+}
+
+function normalizeSyncFailureLogEntry(value: unknown): SyncFailureLogEntry | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  const details = normalizeSyncErrorDetails(record);
+  const message =
+    typeof record.message === 'string' && record.message.trim() ? record.message.trim() : undefined;
+  const occurredAt =
+    typeof record.occurredAt === 'string' && record.occurredAt.trim() ? record.occurredAt.trim() : undefined;
+
+  if (!message || !occurredAt) {
+    return undefined;
+  }
+
+  return {
+    message,
+    occurredAt,
+    ...(details ?? {})
+  };
+}
+
+function normalizeSyncFailureLogEntries(value: unknown): SyncFailureLogEntry[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const entries = value
+    .map((entry) => normalizeSyncFailureLogEntry(entry))
+    .filter((entry): entry is SyncFailureLogEntry => entry !== undefined)
+    .slice(-MAX_SYNC_FAILURE_LOG_ENTRIES);
+
+  return entries.length > 0 ? entries : undefined;
 }
 
 function formatSyncFailurePhase(phase?: SyncFailurePhase): string {
@@ -1567,6 +1612,61 @@ function buildSyncErrorDetails(error: unknown, context: SyncFailureContext): Syn
   };
 }
 
+function createSyncFailureLogEntry(params: {
+  message: string;
+  occurredAt?: string;
+  errorDetails?: SyncErrorDetails;
+}): SyncFailureLogEntry | undefined {
+  const message = params.message.trim();
+  const occurredAt =
+    typeof params.occurredAt === 'string' && params.occurredAt.trim()
+      ? params.occurredAt.trim()
+      : new Date().toISOString();
+  const errorDetails = normalizeSyncErrorDetails(params.errorDetails);
+
+  if (!message) {
+    return undefined;
+  }
+
+  return {
+    message,
+    occurredAt,
+    ...(errorDetails ?? {})
+  };
+}
+
+function buildSyncFailureLogEntry(
+  error: unknown,
+  context: SyncFailureContext,
+  occurredAt?: string
+): SyncFailureLogEntry | undefined {
+  return createSyncFailureLogEntry({
+    message: buildSyncFailureMessage(error, context),
+    occurredAt,
+    errorDetails: buildSyncErrorDetails(error, context)
+  });
+}
+
+function buildRecentSyncFailureLogEntries(failures: SyncProcessingFailure[]): SyncFailureLogEntry[] | undefined {
+  const entries = failures
+    .map((failure) => buildSyncFailureLogEntry(failure.error, failure.context, failure.occurredAt))
+    .filter((entry): entry is SyncFailureLogEntry => entry !== undefined)
+    .slice(-MAX_SYNC_FAILURE_LOG_ENTRIES);
+
+  return entries.length > 0 ? entries : undefined;
+}
+
+function appendRecentSyncFailureLogEntry(
+  entries: SyncFailureLogEntry[] | undefined,
+  entry: SyncFailureLogEntry | undefined
+): SyncFailureLogEntry[] | undefined {
+  if (!entry) {
+    return entries;
+  }
+
+  return [...(entries ?? []), entry].slice(-MAX_SYNC_FAILURE_LOG_ENTRIES);
+}
+
 function createErrorSyncState(params: {
   message: string;
   trigger: 'manual' | 'schedule' | 'retry';
@@ -1576,8 +1676,20 @@ function createErrorSyncState(params: {
   erroredIssuesCount?: number;
   progress?: SyncProgressState;
   errorDetails?: SyncErrorDetails;
+  recentFailures?: SyncFailureLogEntry[];
 }): SyncRunState {
-  const { message, trigger, syncedIssuesCount, createdIssuesCount, skippedIssuesCount, erroredIssuesCount, progress, errorDetails } = params;
+  const {
+    message,
+    trigger,
+    syncedIssuesCount,
+    createdIssuesCount,
+    skippedIssuesCount,
+    erroredIssuesCount,
+    progress,
+    errorDetails,
+    recentFailures
+  } = params;
+  const normalizedRecentFailures = normalizeSyncFailureLogEntries(recentFailures);
 
   return {
     status: 'error',
@@ -1589,7 +1701,8 @@ function createErrorSyncState(params: {
     erroredIssuesCount,
     lastRunTrigger: trigger,
     ...(progress ? { progress: normalizeSyncProgress(progress) } : {}),
-    ...(errorDetails ? { errorDetails } : {})
+    ...(errorDetails ? { errorDetails } : {}),
+    ...(normalizedRecentFailures ? { recentFailures: normalizedRecentFailures } : {})
   };
 }
 
@@ -1603,8 +1716,11 @@ function createRunningSyncState(
     erroredIssuesCount?: number;
     progress?: SyncProgressState;
     message?: string;
+    recentFailures?: SyncFailureLogEntry[];
   } = {}
 ): SyncRunState {
+  const normalizedRecentFailures = normalizeSyncFailureLogEntries(options.recentFailures);
+
   return {
     status: 'running',
     message: options.message ?? RUNNING_SYNC_MESSAGE,
@@ -1614,7 +1730,8 @@ function createRunningSyncState(
     skippedIssuesCount: options.skippedIssuesCount ?? 0,
     erroredIssuesCount: options.erroredIssuesCount ?? 0,
     lastRunTrigger: trigger,
-    ...(options.progress ? { progress: normalizeSyncProgress(options.progress) } : {})
+    ...(options.progress ? { progress: normalizeSyncProgress(options.progress) } : {}),
+    ...(normalizedRecentFailures ? { recentFailures: normalizedRecentFailures } : {})
   };
 }
 
@@ -2288,7 +2405,16 @@ function createSetupConfigurationErrorSyncState(
           phase: 'configuration',
           configurationIssue: 'missing_token',
           suggestedAction: MISSING_GITHUB_TOKEN_SYNC_ACTION
-        }
+        },
+        recentFailures: [
+          {
+            message: MISSING_GITHUB_TOKEN_SYNC_MESSAGE,
+            occurredAt: new Date().toISOString(),
+            phase: 'configuration',
+            configurationIssue: 'missing_token',
+            suggestedAction: MISSING_GITHUB_TOKEN_SYNC_ACTION
+          }
+        ]
       });
     case 'missing_mapping':
       return createErrorSyncState({
@@ -2302,7 +2428,16 @@ function createSetupConfigurationErrorSyncState(
           phase: 'configuration',
           configurationIssue: 'missing_mapping',
           suggestedAction: MISSING_MAPPING_SYNC_ACTION
-        }
+        },
+        recentFailures: [
+          {
+            message: MISSING_MAPPING_SYNC_MESSAGE,
+            occurredAt: new Date().toISOString(),
+            phase: 'configuration',
+            configurationIssue: 'missing_mapping',
+            suggestedAction: MISSING_MAPPING_SYNC_ACTION
+          }
+        ]
       });
     case 'missing_board_access':
       return createErrorSyncState({
@@ -2316,7 +2451,16 @@ function createSetupConfigurationErrorSyncState(
           phase: 'configuration',
           configurationIssue: 'missing_board_access',
           suggestedAction: MISSING_BOARD_ACCESS_SYNC_ACTION
-        }
+        },
+        recentFailures: [
+          {
+            message: MISSING_BOARD_ACCESS_SYNC_MESSAGE,
+            occurredAt: new Date().toISOString(),
+            phase: 'configuration',
+            configurationIssue: 'missing_board_access',
+            suggestedAction: MISSING_BOARD_ACCESS_SYNC_ACTION
+          }
+        ]
       });
   }
 }
@@ -2361,7 +2505,14 @@ async function createUnexpectedSyncErrorResult(
       createdIssuesCount: settings.syncState.createdIssuesCount ?? 0,
       skippedIssuesCount: settings.syncState.skippedIssuesCount ?? 0,
       erroredIssuesCount: 0,
-      errorDetails
+      errorDetails,
+      recentFailures: appendRecentSyncFailureLogEntry(
+        undefined,
+        createSyncFailureLogEntry({
+          message,
+          errorDetails
+        })
+      )
     })
   );
 }
@@ -2430,7 +2581,8 @@ function recordRecoverableSyncFailure(
   const snapshot = cloneSyncFailureContext(context);
   failures.push({
     error,
-    context: snapshot
+    context: snapshot,
+    occurredAt: new Date().toISOString()
   });
 
   ctx.logger.warn('GitHub sync skipped a failed item and continued.', {
@@ -2576,6 +2728,7 @@ function normalizeSyncState(value: unknown): SyncRunState {
   const lastRunTrigger = record.lastRunTrigger;
   const progress = normalizeSyncProgress(record.progress);
   const errorDetails = normalizeSyncErrorDetails(record.errorDetails);
+  const recentFailures = normalizeSyncFailureLogEntries(record.recentFailures);
 
   return {
     status: status === 'running' || status === 'success' || status === 'error' ? status : 'idle',
@@ -2587,7 +2740,8 @@ function normalizeSyncState(value: unknown): SyncRunState {
     erroredIssuesCount: typeof record.erroredIssuesCount === 'number' ? record.erroredIssuesCount : undefined,
     lastRunTrigger: lastRunTrigger === 'manual' || lastRunTrigger === 'schedule' || lastRunTrigger === 'retry' ? lastRunTrigger : undefined,
     ...(progress ? { progress } : {}),
-    ...(errorDetails ? { errorDetails } : {})
+    ...(errorDetails ? { errorDetails } : {}),
+    ...(recentFailures ? { recentFailures } : {})
   };
 }
 
@@ -7135,6 +7289,10 @@ async function performSync(
   }
 
   if (!ctx.issues || typeof ctx.issues.create !== 'function') {
+    const errorDetails: SyncErrorDetails = {
+      phase: 'configuration',
+      suggestedAction: 'Update Paperclip to a runtime that supports plugin issue creation, then retry sync.'
+    };
     const next = {
       ...settings,
       syncState: createErrorSyncState({
@@ -7144,10 +7302,14 @@ async function performSync(
         createdIssuesCount: 0,
         skippedIssuesCount: 0,
         erroredIssuesCount: 0,
-        errorDetails: {
-          phase: 'configuration',
-          suggestedAction: 'Update Paperclip to a runtime that supports plugin issue creation, then retry sync.'
-        }
+        errorDetails,
+        recentFailures: appendRecentSyncFailureLogEntry(
+          undefined,
+          createSyncFailureLogEntry({
+            message: 'This Paperclip runtime does not expose plugin issue creation yet.',
+            errorDetails
+          })
+        )
       })
     };
     await ctx.state.set(SETTINGS_SCOPE, next);
@@ -7190,12 +7352,14 @@ async function performSync(
 
   async function persistRunningProgress(force = false): Promise<void> {
     const progress = normalizeSyncProgress(currentProgress);
+    const recentFailures = buildRecentSyncFailureLogEntries(recoverableFailures);
     const signature = JSON.stringify({
       syncedIssuesCount,
       createdIssuesCount,
       skippedIssuesCount,
       erroredIssuesCount: recoverableFailures.length,
-      progress
+      progress,
+      recentFailures
     });
     const now = Date.now();
 
@@ -7217,7 +7381,8 @@ async function performSync(
         createdIssuesCount,
         skippedIssuesCount,
         erroredIssuesCount: recoverableFailures.length,
-        progress
+        progress,
+        recentFailures
       })
     );
     activeRunningSyncState = currentSettings;
@@ -7566,7 +7731,8 @@ async function performSync(
           skippedIssuesCount,
           erroredIssuesCount: recoverableFailures.length,
           progress: currentProgress,
-          errorDetails
+          errorDetails,
+          recentFailures: buildRecentSyncFailureLogEntries(recoverableFailures)
         })
       };
       await ctx.state.set(SETTINGS_SCOPE, next);
@@ -7604,7 +7770,11 @@ async function performSync(
         skippedIssuesCount,
         erroredIssuesCount: recoverableFailures.length,
         progress: currentProgress,
-        errorDetails
+        errorDetails,
+        recentFailures: appendRecentSyncFailureLogEntry(
+          buildRecentSyncFailureLogEntries(recoverableFailures),
+          buildSyncFailureLogEntry(error, failureContext)
+        )
       })
     };
     await ctx.state.set(SETTINGS_SCOPE, next);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1649,9 +1649,9 @@ function buildSyncFailureLogEntry(
 
 function buildRecentSyncFailureLogEntries(failures: SyncProcessingFailure[]): SyncFailureLogEntry[] | undefined {
   const entries = failures
+    .slice(-MAX_SYNC_FAILURE_LOG_ENTRIES)
     .map((failure) => buildSyncFailureLogEntry(failure.error, failure.context, failure.occurredAt))
-    .filter((entry): entry is SyncFailureLogEntry => entry !== undefined)
-    .slice(-MAX_SYNC_FAILURE_LOG_ENTRIES);
+    .filter((entry): entry is SyncFailureLogEntry => entry !== undefined);
 
   return entries.length > 0 ? entries : undefined;
 }

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -3838,6 +3838,14 @@ test('worker surfaces an actionable sync error when the Paperclip label API retu
           rawMessage?: string;
           suggestedAction?: string;
         };
+        recentFailures?: Array<{
+          message?: string;
+          phase?: string;
+          repositoryUrl?: string;
+          githubIssueNumber?: number;
+          rawMessage?: string;
+          suggestedAction?: string;
+        }>;
       };
     };
 
@@ -3848,6 +3856,14 @@ test('worker surfaces an actionable sync error when the Paperclip label API retu
     assert.match(sync.syncState.errorDetails?.rawMessage ?? '', /PAPERCLIP_API_URL/);
     assert.match(sync.syncState.errorDetails?.suggestedAction ?? '', /PAPERCLIP_API_URL/);
     assert.ok((sync.syncState.erroredIssuesCount ?? 0) >= 1);
+    assert.ok((sync.syncState.recentFailures?.length ?? 0) >= 1);
+    const labelFailure = sync.syncState.recentFailures?.find((entry) =>
+      /authenticated Paperclip API response/.test(entry.rawMessage ?? '')
+    );
+    assert.ok(labelFailure);
+    assert.match(labelFailure?.message ?? '', /syncing issue labels/i);
+    assert.match(labelFailure?.rawMessage ?? '', /authenticated Paperclip API response/);
+    assert.match(labelFailure?.suggestedAction ?? '', /PAPERCLIP_API_URL/);
     assert.ok(
       harness.logs.find((entry) =>
         entry.level === 'warn'


### PR DESCRIPTION
## Summary
- persist a bounded `recentFailures` log in sync state so the latest run keeps per-failure repository, issue, phase, raw error, suggested action, and timestamp details
- update the settings and widget diagnostics UI to show a selectable saved failure list on larger surfaces and preserve a compact latest-failure snapshot elsewhere
- document the new troubleshooting behavior in `README.md` and `SPEC.md`
- extend tests to cover the saved failure log behavior

## Testing
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Model Used
- `gpt-5.4`
- Context window: 400k tokens
- Reasoning: medium
- Capabilities: tool-assisted coding, patch application, terminal commands