### PR TITLE
Add cancellation support for running GitHub syncs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The plugin adds a full in-host workflow instead of a one-off import script:
 
 During sync, the plugin imports one top-level Paperclip issue per GitHub issue, updates already imported issues instead of recreating them, maps GitHub labels into Paperclip labels, and keeps GitHub-specific metadata in dedicated Paperclip surfaces rather than stuffing everything into the issue description.
 
-Long-running syncs continue in the background, so quick actions do not have to wait for the whole import to finish.
+Long-running syncs continue in the background, so quick actions do not have to wait for the whole import to finish. Once a sync has started, the settings page, dashboard widget, and toolbar actions can request cancellation; the worker stops cooperatively after the current repository or issue step finishes.
 
 ## Highlights
 
@@ -172,7 +172,7 @@ When an agent posts a GitHub comment or review-thread reply through the plugin, 
 - If the worker reaches an authenticated HTML page instead of the Paperclip API JSON responses it expects, connect Paperclip board access for that company or set `PAPERCLIP_API_URL` to a worker-accessible Paperclip API origin.
 - If sync says the Paperclip API URL is not trusted, reopen the plugin from the current Paperclip host so the settings UI can refresh the saved origin, or set `PAPERCLIP_API_URL` for the worker.
 - If GitHub rate limiting is hit, the plugin pauses sync until the reported reset time instead of retrying pointlessly.
-- If a manual sync takes longer than the host action window, it continues in the background and updates the UI when it finishes.
+- If a manual sync takes longer than the host action window, it continues in the background and updates the UI when it finishes or when a cancellation request stops it.
 
 ## Development
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -22,6 +22,7 @@ The settings page MUST allow saving mappings and triggering a manual sync.
 - When a company already has Paperclip projects bound to GitHub repository workspaces, the settings page SHOULD surface those projects so an operator can enable sync without recreating the project.
 - The plugin SHOULD also expose manual sync entry points from Paperclip toolbar surfaces when the SDK supports them.
 - When a manual sync will outlive a quick action response, the worker MUST persist a `running` sync state immediately and complete the sync asynchronously.
+- Once a sync is running, the settings page, dashboard widget, and toolbar sync entry points MUST provide a way to request cancellation, and the worker MUST stop cooperatively after the current repository or issue step finishes.
 - The settings page, dashboard widget, and sync toolbar surfaces SHOULD detect authenticated deployments from `/api/health` and MUST require connected Paperclip board access before enabling sync for the affected company.
 
 ## Secret handling

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -4357,7 +4357,10 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
     hasMappings: savedMappingCount > 0,
     hasBoardAccess: boardAccessReady
   });
-  const cancellationRequested = cancellingSync || isSyncCancellationRequested(displaySyncState);
+  const syncPersistedRunning = displaySyncState.status === 'running';
+  const syncStartPending = runningSync && !syncPersistedRunning;
+  const syncInFlight = syncStartPending || syncPersistedRunning;
+  const cancellationRequested = syncPersistedRunning && (cancellingSync || isSyncCancellationRequested(displaySyncState));
   const mappingsDirty = JSON.stringify(draftMappings) !== JSON.stringify(savedMappings);
   const advancedSettingsDirty = JSON.stringify(draftAdvancedSettings) !== JSON.stringify(savedAdvancedSettings);
   const scheduleFrequencyError = getScheduleFrequencyError(scheduleFrequencyDraft);
@@ -4365,7 +4368,6 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
   const savedScheduleFrequencyMinutes = normalizeScheduleFrequencyMinutes(currentSettings?.scheduleFrequencyMinutes);
   const scheduleDirty = scheduleFrequencyError === null && scheduleFrequencyMinutes !== savedScheduleFrequencyMinutes;
   const mappings = form.mappings.length > 0 ? form.mappings : [createEmptyMapping(0)];
-  const syncInFlight = runningSync || displaySyncState.status === 'running';
   const settingsMutationsLocked = syncInFlight;
   const settingsMutationsLockReason = settingsMutationsLocked
     ? 'Settings are temporarily locked while a sync is running to avoid overwriting local edits.'
@@ -4877,6 +4879,10 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
   }
 
   async function handleCancelSync(): Promise<void> {
+    if (!syncPersistedRunning) {
+      return;
+    }
+
     setCancellingSync(true);
     setManualSyncRequestError(null);
 
@@ -5454,14 +5460,16 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
                       </div>
                       <button
                         type="button"
-                        className={getPluginActionClassName({ variant: syncInFlight ? 'danger' : 'primary' })}
-                        onClick={syncInFlight ? handleCancelSync : handleRunSyncNow}
-                        disabled={showInitialLoadingState || (syncInFlight ? cancellationRequested : false)}
+                        className={getPluginActionClassName({ variant: syncPersistedRunning ? 'danger' : 'primary' })}
+                        onClick={syncPersistedRunning ? handleCancelSync : handleRunSyncNow}
+                        disabled={showInitialLoadingState || syncStartPending || (syncPersistedRunning ? cancellationRequested : false)}
                       >
-                        {syncInFlight
+                        {syncPersistedRunning
                           ? cancellationRequested
                             ? 'Cancelling…'
                             : 'Cancel sync'
+                          : syncStartPending
+                            ? 'Running…'
                           : manualSyncButtonLabel}
                       </button>
                     </div>
@@ -5624,8 +5632,10 @@ export function GitHubSyncDashboardWidget(): React.JSX.Element {
     hasBoardAccess: boardAccessReady
   });
   const syncUnlocked = syncSetupIssue === null;
-  const syncInFlight = runningSync || displaySyncState.status === 'running';
-  const cancellationRequested = cancellingSync || isSyncCancellationRequested(displaySyncState);
+  const syncPersistedRunning = displaySyncState.status === 'running';
+  const syncStartPending = runningSync && !syncPersistedRunning;
+  const syncInFlight = syncStartPending || syncPersistedRunning;
+  const cancellationRequested = syncPersistedRunning && (cancellingSync || isSyncCancellationRequested(displaySyncState));
   const scheduleFrequencyMinutes = normalizeScheduleFrequencyMinutes(current.scheduleFrequencyMinutes);
   const scheduleDescription = formatScheduleFrequency(scheduleFrequencyMinutes);
   const summary = getDashboardSummary({
@@ -5743,6 +5753,10 @@ export function GitHubSyncDashboardWidget(): React.JSX.Element {
   }
 
   async function handleCancelSync(): Promise<void> {
+    if (!syncPersistedRunning) {
+      return;
+    }
+
     setCancellingSync(true);
     setManualSyncRequestError(null);
 
@@ -5864,25 +5878,20 @@ export function GitHubSyncDashboardWidget(): React.JSX.Element {
               Open settings
             </a>
             {syncUnlocked ? (
-              syncInFlight ? (
-                <button
-                  type="button"
-                  className={getPluginActionClassName({ variant: 'danger' })}
-                  onClick={handleCancelSync}
-                  disabled={cancellationRequested || showInitialLoadingState}
-                >
-                  {cancellationRequested ? 'Cancelling…' : 'Cancel sync'}
-                </button>
-              ) : (
-                <button
-                  type="button"
-                  className={getPluginActionClassName({ variant: 'primary' })}
-                  onClick={handleRunSync}
-                  disabled={showInitialLoadingState}
-                >
-                  Run sync now
-                </button>
-              )
+              <button
+                type="button"
+                className={getPluginActionClassName({ variant: syncPersistedRunning ? 'danger' : 'primary' })}
+                onClick={syncPersistedRunning ? handleCancelSync : handleRunSync}
+                disabled={showInitialLoadingState || syncStartPending || (syncPersistedRunning ? cancellationRequested : false)}
+              >
+                {syncPersistedRunning
+                  ? cancellationRequested
+                    ? 'Cancelling…'
+                    : 'Cancel sync'
+                  : syncStartPending
+                    ? 'Running…'
+                    : 'Run sync now'}
+              </button>
             ) : null}
           </div>
         </div>
@@ -5966,8 +5975,10 @@ function GitHubSyncToolbarButtonSurface(props: {
       ? getSyncSetupMessage(boardAccessSetupIssue, hasCompanyContext)
       : state.message;
   const effectiveLabel = boardAccessSetupIssue ? 'Board access required' : state.label;
-  const syncInFlight = runningSync || state.syncState.status === 'running';
-  const cancellationRequested = cancellingSync || isSyncCancellationRequested(state.syncState);
+  const syncPersistedRunning = state.syncState.status === 'running';
+  const syncStartPending = runningSync && !syncPersistedRunning;
+  const syncInFlight = syncStartPending || syncPersistedRunning;
+  const cancellationRequested = syncPersistedRunning && (cancellingSync || isSyncCancellationRequested(state.syncState));
   const armSyncCompletionToast = useSyncCompletionToast(state.syncState, toast);
 
   useEffect(() => {
@@ -6095,6 +6106,10 @@ function GitHubSyncToolbarButtonSurface(props: {
   }
 
   async function handleCancelSync(): Promise<void> {
+    if (!syncPersistedRunning) {
+      return;
+    }
+
     try {
       setCancellingSync(true);
       const result = await cancelSync() as {
@@ -6134,15 +6149,17 @@ function GitHubSyncToolbarButtonSurface(props: {
         data-variant="outline"
         data-size="sm"
         className={props.entityType ? HOST_ENTITY_BUTTON_CLASSNAME : HOST_GLOBAL_BUTTON_CLASSNAME}
-        disabled={toolbarState.loading || (syncInFlight ? cancellationRequested : !effectiveCanRun)}
-        onClick={syncInFlight ? handleCancelSync : handleRunSync}
+        disabled={toolbarState.loading || syncStartPending || (syncPersistedRunning ? cancellationRequested : !effectiveCanRun)}
+        onClick={syncPersistedRunning ? handleCancelSync : handleRunSync}
       >
         <GitHubMarkIcon className="mr-1.5 h-3.5 w-3.5" />
         <span>
-          {syncInFlight
+          {syncPersistedRunning
             ? cancellationRequested
               ? 'Cancelling…'
               : 'Cancel sync'
+            : syncStartPending
+              ? 'Syncing…'
             : effectiveLabel}
         </span>
       </button>

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -78,7 +78,7 @@ interface RepositoryMapping {
 }
 
 interface SyncRunState {
-  status: 'idle' | 'running' | 'success' | 'error';
+  status: 'idle' | 'running' | 'success' | 'error' | 'cancelled';
   message?: string;
   checkedAt?: string;
   syncedIssuesCount?: number;
@@ -86,6 +86,7 @@ interface SyncRunState {
   skippedIssuesCount?: number;
   erroredIssuesCount?: number;
   lastRunTrigger?: 'manual' | 'schedule' | 'retry';
+  cancelRequestedAt?: string;
   progress?: SyncProgressState;
   errorDetails?: SyncErrorDetails;
 }
@@ -554,13 +555,21 @@ function getActiveRateLimitPause(syncState: SyncRunState, referenceTimeMs = Date
   };
 }
 
+function isSyncCancellationRequested(syncState: SyncRunState): boolean {
+  return syncState.status === 'running' && Boolean(syncState.cancelRequestedAt?.trim());
+}
+
 function getSyncToastTitle(syncState: SyncRunState): string {
   if (getActiveRateLimitPause(syncState)) {
     return 'GitHub sync is paused';
   }
 
+  if (syncState.status === 'cancelled') {
+    return 'GitHub sync was cancelled';
+  }
+
   if (syncState.status === 'running') {
-    return 'GitHub sync is running';
+    return isSyncCancellationRequested(syncState) ? 'GitHub sync is stopping' : 'GitHub sync is running';
   }
 
   return syncState.status === 'error' ? 'GitHub sync needs attention' : 'GitHub sync finished';
@@ -572,7 +581,9 @@ function getSyncToastBody(syncState: SyncRunState): string {
   }
 
   if (syncState.status === 'running') {
-    return 'GitHub sync is running in the background.';
+    return isSyncCancellationRequested(syncState)
+      ? 'Cancellation requested. GitHub sync will stop after the current step finishes.'
+      : 'GitHub sync is running in the background.';
   }
 
   return 'GitHub sync completed.';
@@ -583,7 +594,7 @@ function getSyncToastTone(syncState: SyncRunState): 'info' | 'error' | 'success'
     return 'info';
   }
 
-  if (syncState.status === 'running') {
+  if (syncState.status === 'running' || syncState.status === 'cancelled') {
     return 'info';
   }
 
@@ -3203,7 +3214,10 @@ function getSyncStatus(syncState: SyncRunState, runningSync: boolean, syncUnlock
   }
 
   if (runningSync || syncState.status === 'running') {
-    return { label: 'Running', tone: 'info' };
+    return {
+      label: isSyncCancellationRequested(syncState) ? 'Cancelling' : 'Running',
+      tone: 'info'
+    };
   }
 
   if (getActiveRateLimitPause(syncState)) {
@@ -3216,6 +3230,10 @@ function getSyncStatus(syncState: SyncRunState, runningSync: boolean, syncUnlock
 
   if (syncState.status === 'success') {
     return { label: 'Ready', tone: 'success' };
+  }
+
+  if (syncState.status === 'cancelled') {
+    return { label: 'Cancelled', tone: 'neutral' };
   }
 
   return { label: 'Ready', tone: 'info' };
@@ -3651,10 +3669,14 @@ function getDashboardSummary(params: {
   if (params.runningSync || params.syncState.status === 'running') {
     const progress = getRunningSyncProgressModel(params.syncState);
     return {
-      label: 'Syncing',
+      label: isSyncCancellationRequested(params.syncState) ? 'Cancelling' : 'Syncing',
       tone: 'info',
-      title: progress?.title ?? 'Sync in progress',
-      body: progress?.description ?? 'GitHub issues are being checked right now. This card refreshes automatically until the run finishes.'
+      title: isSyncCancellationRequested(params.syncState)
+        ? 'Stopping the current sync'
+        : progress?.title ?? 'Sync in progress',
+      body: isSyncCancellationRequested(params.syncState)
+        ? 'GitHub Sync will stop after the current repository or issue step finishes.'
+        : progress?.description ?? 'GitHub issues are being checked right now. This card refreshes automatically until the run finishes.'
     };
   }
 
@@ -3673,6 +3695,15 @@ function getDashboardSummary(params: {
       tone: 'danger',
       title: 'Last sync needs attention',
       body: params.syncState.message ?? 'Open settings to review the latest GitHub sync issue.'
+    };
+  }
+
+  if (params.syncState.status === 'cancelled') {
+    return {
+      label: 'Cancelled',
+      tone: 'neutral',
+      title: 'Sync cancelled',
+      body: params.syncState.message ?? 'The last GitHub sync was cancelled before it finished.'
     };
   }
 
@@ -3986,11 +4017,13 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
   const updateBoardAccess = usePluginAction('settings.updateBoardAccess');
   const validateToken = usePluginAction('settings.validateToken');
   const runSyncNow = usePluginAction('sync.runNow');
+  const cancelSync = usePluginAction('sync.cancel');
   const [form, setForm] = useState<GitHubSyncSettings>(EMPTY_SETTINGS);
   const [submittingToken, setSubmittingToken] = useState(false);
   const [connectingBoardAccess, setConnectingBoardAccess] = useState(false);
   const [submittingSetup, setSubmittingSetup] = useState(false);
   const [runningSync, setRunningSync] = useState(false);
+  const [cancellingSync, setCancellingSync] = useState(false);
   const [manualSyncRequestError, setManualSyncRequestError] = useState<string | null>(null);
   const [scheduleFrequencyDraft, setScheduleFrequencyDraft] = useState(String(DEFAULT_SCHEDULE_FREQUENCY_MINUTES));
   const [ignoredAuthorsDraft, setIgnoredAuthorsDraft] = useState(DEFAULT_ADVANCED_SETTINGS.ignoredIssueAuthorUsernames.join(', '));
@@ -4324,6 +4357,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
     hasMappings: savedMappingCount > 0,
     hasBoardAccess: boardAccessReady
   });
+  const cancellationRequested = cancellingSync || isSyncCancellationRequested(displaySyncState);
   const mappingsDirty = JSON.stringify(draftMappings) !== JSON.stringify(savedMappings);
   const advancedSettingsDirty = JSON.stringify(draftAdvancedSettings) !== JSON.stringify(savedAdvancedSettings);
   const scheduleFrequencyError = getScheduleFrequencyError(scheduleFrequencyDraft);
@@ -4393,6 +4427,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
   });
   const syncSectionDescription = '';
   const syncSummaryPrimaryText =
+    (cancellationRequested ? 'Cancellation requested.' : undefined) ??
     syncProgress?.title ??
     displaySyncState.message ??
     (syncUnlocked ? 'Ready to sync.' : syncSetupMessage);
@@ -4402,6 +4437,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
   const syncSummarySecondaryText = syncProgress
     ? [
         manualSyncScopeSummary,
+        cancellationRequested ? 'Stopping after the current step' : null,
         syncProgress.issueProgressLabel,
         syncProgress.currentIssueLabel ?? syncProgress.repositoryPosition,
         `Auto-sync: ${scheduleDescription}`
@@ -4837,6 +4873,48 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
       }
     } finally {
       setRunningSync(false);
+    }
+  }
+
+  async function handleCancelSync(): Promise<void> {
+    setCancellingSync(true);
+    setManualSyncRequestError(null);
+
+    try {
+      const result = await cancelSync() as GitHubSyncSettings;
+
+      setForm((current) => ({
+        ...current,
+        syncState: result.syncState
+      }));
+      toast({
+        title: getSyncToastTitle(result.syncState),
+        body: getSyncToastBody(result.syncState),
+        tone: getSyncToastTone(result.syncState)
+      });
+      armSyncCompletionToast(result.syncState);
+
+      try {
+        await settings.refresh();
+      } catch {
+        return;
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to cancel sync.';
+      setManualSyncRequestError(message);
+      toast({
+        title: 'Unable to cancel GitHub sync',
+        body: message,
+        tone: 'error'
+      });
+
+      try {
+        await settings.refresh();
+      } catch {
+        return;
+      }
+    } finally {
+      setCancellingSync(false);
     }
   }
 
@@ -5376,11 +5454,15 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
                       </div>
                       <button
                         type="button"
-                        className={getPluginActionClassName({ variant: 'primary' })}
-                        onClick={handleRunSyncNow}
-                        disabled={syncInFlight || showInitialLoadingState}
+                        className={getPluginActionClassName({ variant: syncInFlight ? 'danger' : 'primary' })}
+                        onClick={syncInFlight ? handleCancelSync : handleRunSyncNow}
+                        disabled={showInitialLoadingState || (syncInFlight ? cancellationRequested : false)}
                       >
-                        {syncInFlight ? 'Running…' : manualSyncButtonLabel}
+                        {syncInFlight
+                          ? cancellationRequested
+                            ? 'Cancelling…'
+                            : 'Cancel sync'
+                          : manualSyncButtonLabel}
                       </button>
                     </div>
                   </>
@@ -5508,7 +5590,9 @@ export function GitHubSyncDashboardWidget(): React.JSX.Element {
     hostContext.companyId ? { companyId: hostContext.companyId } : {}
   );
   const runSyncNow = usePluginAction('sync.runNow');
+  const cancelSync = usePluginAction('sync.cancel');
   const [runningSync, setRunningSync] = useState(false);
+  const [cancellingSync, setCancellingSync] = useState(false);
   const [manualSyncRequestError, setManualSyncRequestError] = useState<string | null>(null);
   const [settingsHref, setSettingsHref] = useState(SETTINGS_INDEX_HREF);
   const [cachedSettings, setCachedSettings] = useState<GitHubSyncSettings | null>(null);
@@ -5541,6 +5625,7 @@ export function GitHubSyncDashboardWidget(): React.JSX.Element {
   });
   const syncUnlocked = syncSetupIssue === null;
   const syncInFlight = runningSync || displaySyncState.status === 'running';
+  const cancellationRequested = cancellingSync || isSyncCancellationRequested(displaySyncState);
   const scheduleFrequencyMinutes = normalizeScheduleFrequencyMinutes(current.scheduleFrequencyMinutes);
   const scheduleDescription = formatScheduleFrequency(scheduleFrequencyMinutes);
   const summary = getDashboardSummary({
@@ -5657,6 +5742,33 @@ export function GitHubSyncDashboardWidget(): React.JSX.Element {
     }
   }
 
+  async function handleCancelSync(): Promise<void> {
+    setCancellingSync(true);
+    setManualSyncRequestError(null);
+
+    try {
+      const result = await cancelSync() as GitHubSyncSettings;
+      const nextSyncState = result.syncState ?? EMPTY_SETTINGS.syncState;
+      toast({
+        title: getSyncToastTitle(nextSyncState),
+        body: getSyncToastBody(nextSyncState),
+        tone: getSyncToastTone(nextSyncState)
+      });
+      armSyncCompletionToast(nextSyncState);
+      await settings.refresh();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to cancel GitHub sync.';
+      setManualSyncRequestError(message);
+      toast({
+        title: 'Unable to cancel GitHub sync',
+        body: message,
+        tone: 'error'
+      });
+    } finally {
+      setCancellingSync(false);
+    }
+  }
+
   return (
     <section className="ghsync-widget" style={themeVars}>
       <style>{WIDGET_STYLES}</style>
@@ -5752,14 +5864,25 @@ export function GitHubSyncDashboardWidget(): React.JSX.Element {
               Open settings
             </a>
             {syncUnlocked ? (
-              <button
-                type="button"
-                className={getPluginActionClassName({ variant: 'primary' })}
-                onClick={handleRunSync}
-                disabled={syncInFlight || showInitialLoadingState}
-              >
-                {syncInFlight ? 'Running…' : 'Run sync now'}
-              </button>
+              syncInFlight ? (
+                <button
+                  type="button"
+                  className={getPluginActionClassName({ variant: 'danger' })}
+                  onClick={handleCancelSync}
+                  disabled={cancellationRequested || showInitialLoadingState}
+                >
+                  {cancellationRequested ? 'Cancelling…' : 'Cancel sync'}
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  className={getPluginActionClassName({ variant: 'primary' })}
+                  onClick={handleRunSync}
+                  disabled={showInitialLoadingState}
+                >
+                  Run sync now
+                </button>
+              )
             ) : null}
           </div>
         </div>
@@ -5794,6 +5917,7 @@ function GitHubSyncToolbarButtonSurface(props: {
 }): React.JSX.Element | null {
   const toast = usePluginToast();
   const runSyncNow = usePluginAction('sync.runNow');
+  const cancelSync = usePluginAction('sync.cancel');
   const pluginIdFromLocation = getPluginIdFromLocation();
   const surfaceRef = useRef<HTMLDivElement | null>(null);
   const resolvedIssue = useResolvedIssueId({
@@ -5816,6 +5940,7 @@ function GitHubSyncToolbarButtonSurface(props: {
     props.companyId ? { companyId: props.companyId } : {}
   );
   const [runningSync, setRunningSync] = useState(false);
+  const [cancellingSync, setCancellingSync] = useState(false);
   const themeMode = useResolvedThemeMode();
   const boardAccessRequirement = usePaperclipBoardAccessRequirement();
   const theme = themeMode === 'light' ? LIGHT_PALETTE : DARK_PALETTE;
@@ -5842,6 +5967,7 @@ function GitHubSyncToolbarButtonSurface(props: {
       : state.message;
   const effectiveLabel = boardAccessSetupIssue ? 'Board access required' : state.label;
   const syncInFlight = runningSync || state.syncState.status === 'running';
+  const cancellationRequested = cancellingSync || isSyncCancellationRequested(state.syncState);
   const armSyncCompletionToast = useSyncCompletionToast(state.syncState, toast);
 
   useEffect(() => {
@@ -5968,6 +6094,32 @@ function GitHubSyncToolbarButtonSurface(props: {
     }
   }
 
+  async function handleCancelSync(): Promise<void> {
+    try {
+      setCancellingSync(true);
+      const result = await cancelSync() as {
+        syncState?: SyncRunState;
+      };
+      const nextSyncState = result.syncState ?? EMPTY_SETTINGS.syncState;
+
+      toast({
+        title: getSyncToastTitle(nextSyncState),
+        body: getSyncToastBody(nextSyncState),
+        tone: getSyncToastTone(nextSyncState)
+      });
+      armSyncCompletionToast(nextSyncState);
+      toolbarState.refresh();
+    } catch (error) {
+      toast({
+        title: 'Unable to cancel GitHub sync',
+        body: error instanceof Error ? error.message : 'Unable to cancel GitHub sync.',
+        tone: 'error'
+      });
+    } finally {
+      setCancellingSync(false);
+    }
+  }
+
   return (
     <div
       ref={surfaceRef}
@@ -5982,11 +6134,17 @@ function GitHubSyncToolbarButtonSurface(props: {
         data-variant="outline"
         data-size="sm"
         className={props.entityType ? HOST_ENTITY_BUTTON_CLASSNAME : HOST_GLOBAL_BUTTON_CLASSNAME}
-        disabled={!effectiveCanRun || syncInFlight || toolbarState.loading}
-        onClick={handleRunSync}
+        disabled={toolbarState.loading || (syncInFlight ? cancellationRequested : !effectiveCanRun)}
+        onClick={syncInFlight ? handleCancelSync : handleRunSync}
       >
         <GitHubMarkIcon className="mr-1.5 h-3.5 w-3.5" />
-        <span>{syncInFlight ? 'Syncing…' : effectiveLabel}</span>
+        <span>
+          {syncInFlight
+            ? cancellationRequested
+              ? 'Cancelling…'
+              : 'Cancel sync'
+            : effectiveLabel}
+        </span>
       </button>
     </div>
   );
@@ -6092,7 +6250,7 @@ function GitHubSyncIssueDetailTabContent(props: {
             <div className="ghsync-issue-detail__section">
               <div className="ghsync-issue-detail__section-heading">Linked pull requests</div>
               <div className="ghsync-extension-links">
-                {issueDetails.linkedPullRequestNumbers.map((pullRequestNumber) => (
+                {issueDetails.linkedPullRequestNumbers.map((pullRequestNumber: number) => (
                   <a
                     key={pullRequestNumber}
                     href={`${issueDetails.repositoryUrl}/pull/${pullRequestNumber}`}
@@ -6115,7 +6273,7 @@ function GitHubSyncIssueDetailTabContent(props: {
             <div className="ghsync-issue-detail__section">
               <div className="ghsync-issue-detail__section-heading">Labels</div>
               <div className="ghsync-extension-labels">
-                {issueDetails.labels.map((label) => (
+                {issueDetails.labels.map((label: { name: string; color?: string }) => (
                   <span
                     key={`${label.name}:${label.color ?? 'none'}`}
                     className="ghsync-extension-pill"
@@ -6187,7 +6345,7 @@ export function GitHubSyncCommentAnnotation(): React.JSX.Element | null {
       <style>{EXTENSION_SURFACE_STYLES}</style>
       <div className="ghsync-comment-annotation">
         <span className="ghsync-comment-annotation__label">GitHub refs</span>
-        {annotation.data.links.map((link) => (
+        {annotation.data.links.map((link: CommentAnnotationData['links'][number]) => (
           <a
             key={`${link.type}:${link.href}`}
             href={link.href}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -18,6 +18,11 @@ const SYNC_STATE_SCOPE = {
   stateKey: 'paperclip-github-plugin-last-sync'
 };
 
+const SYNC_CANCELLATION_SCOPE = {
+  scopeKind: 'instance' as const,
+  stateKey: 'paperclip-github-plugin-sync-cancel-request'
+};
+
 const IMPORT_REGISTRY_SCOPE = {
   scopeKind: 'instance' as const,
   stateKey: 'paperclip-github-plugin-import-registry'
@@ -31,6 +36,7 @@ const DEFAULT_PAPERCLIP_LABEL_COLOR = '#6366f1';
 const PAPERCLIP_LABEL_PAGE_SIZE = 100;
 const MANUAL_SYNC_RESPONSE_GRACE_PERIOD_MS = 500;
 const RUNNING_SYNC_MESSAGE = 'GitHub sync is running in the background. This page will update when it finishes.';
+const CANCELLING_SYNC_MESSAGE = 'Cancellation requested. GitHub sync will stop after the current step finishes.';
 const SYNC_PROGRESS_PERSIST_INTERVAL_MS = 250;
 const GITHUB_SECONDARY_RATE_LIMIT_FALLBACK_MS = 60_000;
 const MISSING_GITHUB_TOKEN_SYNC_MESSAGE = 'Configure a GitHub token before running sync.';
@@ -120,7 +126,7 @@ interface GitHubSyncAssigneeOption {
 }
 
 interface SyncRunState {
-  status: 'idle' | 'running' | 'success' | 'error';
+  status: 'idle' | 'running' | 'success' | 'error' | 'cancelled';
   message?: string;
   checkedAt?: string;
   syncedIssuesCount?: number;
@@ -128,6 +134,7 @@ interface SyncRunState {
   skippedIssuesCount?: number;
   erroredIssuesCount?: number;
   lastRunTrigger?: 'manual' | 'schedule' | 'retry';
+  cancelRequestedAt?: string;
   progress?: SyncProgressState;
   errorDetails?: SyncErrorDetails;
 }
@@ -284,6 +291,10 @@ interface ResolvedGitHubTokenSource {
   token?: string;
 }
 
+interface SyncCancellationRequest {
+  requestedAt: string;
+}
+
 function normalizeCompanyId(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
@@ -337,6 +348,16 @@ class PaperclipLabelSyncError extends Error {
     this.paperclipApiBaseUrl = params.paperclipApiBaseUrl;
     this.requiresAuthentication = Boolean(failure?.requiresAuthentication);
     this.labelNames = labelNames;
+  }
+}
+
+class SyncCancellationError extends Error {
+  readonly name = 'SyncCancellationError';
+  readonly requestedAt: string;
+
+  constructor(requestedAt: string) {
+    super(CANCELLING_SYNC_MESSAGE);
+    this.requestedAt = requestedAt;
   }
 }
 
@@ -1013,6 +1034,30 @@ function createIdleSyncState(): SyncRunState {
   };
 }
 
+function createCancelledSyncState(params: {
+  message: string;
+  trigger: 'manual' | 'schedule' | 'retry';
+  syncedIssuesCount: number;
+  createdIssuesCount: number;
+  skippedIssuesCount: number;
+  erroredIssuesCount?: number;
+  progress?: SyncProgressState;
+}): SyncRunState {
+  const { message, trigger, syncedIssuesCount, createdIssuesCount, skippedIssuesCount, erroredIssuesCount, progress } = params;
+
+  return {
+    status: 'cancelled',
+    message,
+    checkedAt: new Date().toISOString(),
+    syncedIssuesCount,
+    createdIssuesCount,
+    skippedIssuesCount,
+    erroredIssuesCount,
+    lastRunTrigger: trigger,
+    ...(progress ? { progress: normalizeSyncProgress(progress) } : {})
+  };
+}
+
 function formatGitHubIssueCountLabel(count: number): string {
   const normalizedCount = Math.max(0, Math.floor(count));
   return `${normalizedCount} GitHub ${normalizedCount === 1 ? 'issue' : 'issues'}`;
@@ -1603,6 +1648,7 @@ function createRunningSyncState(
     erroredIssuesCount?: number;
     progress?: SyncProgressState;
     message?: string;
+    cancelRequestedAt?: string;
   } = {}
 ): SyncRunState {
   return {
@@ -1614,6 +1660,7 @@ function createRunningSyncState(
     skippedIssuesCount: options.skippedIssuesCount ?? 0,
     erroredIssuesCount: options.erroredIssuesCount ?? 0,
     lastRunTrigger: trigger,
+    ...(options.cancelRequestedAt ? { cancelRequestedAt: options.cancelRequestedAt } : {}),
     ...(options.progress ? { progress: normalizeSyncProgress(options.progress) } : {})
   };
 }
@@ -2336,6 +2383,43 @@ async function saveSettingsSyncState(
   return next;
 }
 
+async function setSyncCancellationRequest(
+  ctx: PluginSetupContext,
+  request: SyncCancellationRequest | null
+): Promise<void> {
+  await ctx.state.set(SYNC_CANCELLATION_SCOPE, request);
+}
+
+async function getSyncCancellationRequest(
+  ctx: PluginSetupContext
+): Promise<SyncCancellationRequest | null> {
+  const activeRequestedAt = activeRunningSyncState?.syncState.cancelRequestedAt?.trim();
+  if (activeRunningSyncState?.syncState.status === 'running' && activeRequestedAt) {
+    return {
+      requestedAt: activeRequestedAt
+    };
+  }
+
+  return normalizeSyncCancellationRequest(await ctx.state.get(SYNC_CANCELLATION_SCOPE));
+}
+
+function buildCancelledSyncMessage(
+  target: ResolvedSyncTarget | undefined,
+  progress: SyncProgressState | undefined
+): string {
+  const completedIssueCount =
+    typeof progress?.completedIssueCount === 'number' ? Math.max(0, progress.completedIssueCount) : undefined;
+  const totalIssueCount =
+    typeof progress?.totalIssueCount === 'number' ? Math.max(0, progress.totalIssueCount) : undefined;
+  const scopeLabel = target ? `GitHub sync for ${target.displayLabel}` : 'GitHub sync';
+  const completionSummary =
+    completedIssueCount !== undefined && totalIssueCount !== undefined
+      ? ` Completed ${Math.min(completedIssueCount, totalIssueCount)} of ${totalIssueCount} issues before stopping.`
+      : '';
+
+  return `${scopeLabel} was cancelled before it finished.${completionSummary}`;
+}
+
 async function createUnexpectedSyncErrorResult(
   ctx: PluginSetupContext,
   trigger: 'manual' | 'schedule' | 'retry',
@@ -2566,6 +2650,19 @@ function normalizePaperclipBoardApiTokenRefs(value: unknown): PaperclipBoardApiT
   return Object.fromEntries(entries);
 }
 
+function normalizeSyncCancellationRequest(value: unknown): SyncCancellationRequest | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const requestedAt =
+    typeof (value as { requestedAt?: unknown }).requestedAt === 'string'
+      ? (value as { requestedAt: string }).requestedAt.trim()
+      : '';
+
+  return requestedAt ? { requestedAt } : null;
+}
+
 function normalizeSyncState(value: unknown): SyncRunState {
   if (!value || typeof value !== 'object') {
     return DEFAULT_SETTINGS.syncState;
@@ -2578,7 +2675,7 @@ function normalizeSyncState(value: unknown): SyncRunState {
   const errorDetails = normalizeSyncErrorDetails(record.errorDetails);
 
   return {
-    status: status === 'running' || status === 'success' || status === 'error' ? status : 'idle',
+    status: status === 'running' || status === 'success' || status === 'error' || status === 'cancelled' ? status : 'idle',
     message: typeof record.message === 'string' ? record.message : undefined,
     checkedAt: typeof record.checkedAt === 'string' ? record.checkedAt : undefined,
     syncedIssuesCount: typeof record.syncedIssuesCount === 'number' ? record.syncedIssuesCount : undefined,
@@ -2586,6 +2683,7 @@ function normalizeSyncState(value: unknown): SyncRunState {
     skippedIssuesCount: typeof record.skippedIssuesCount === 'number' ? record.skippedIssuesCount : undefined,
     erroredIssuesCount: typeof record.erroredIssuesCount === 'number' ? record.erroredIssuesCount : undefined,
     lastRunTrigger: lastRunTrigger === 'manual' || lastRunTrigger === 'schedule' || lastRunTrigger === 'retry' ? lastRunTrigger : undefined,
+    cancelRequestedAt: typeof record.cancelRequestedAt === 'string' ? record.cancelRequestedAt : undefined,
     ...(progress ? { progress } : {}),
     ...(errorDetails ? { errorDetails } : {})
   };
@@ -5914,26 +6012,32 @@ async function createPaperclipIssue(
     createPath = 'sdk';
   }
 
+  const ensuredCreatedIssueId = createdIssueId;
+  if (!ensuredCreatedIssueId) {
+    throw new Error('GitHub sync could not resolve the created Paperclip issue id.');
+  }
+  const normalizedCreatedIssueDescription = createdIssueDescription ?? undefined;
+
   if (createPath !== 'sdk') {
     await applyDefaultAssigneeToPaperclipIssue(ctx, {
       companyId: mapping.companyId,
-      issueId: createdIssueId,
+      issueId: ensuredCreatedIssueId,
       defaultAssigneeAgentId: advancedSettings.defaultAssigneeAgentId
     });
   }
 
-  if (normalizeIssueDescriptionValue(createdIssueDescription) !== description) {
+  if (normalizeIssueDescriptionValue(normalizedCreatedIssueDescription) !== description) {
     logIssueDescriptionDiagnostic(
       ctx,
       'warn',
       'GitHub sync detected a missing or mismatched Paperclip issue description immediately after issue creation.',
       {
         companyId: mapping.companyId,
-        issueId: createdIssueId,
+        issueId: ensuredCreatedIssueId,
         paperclipApiBaseUrl,
         githubIssue: issue,
         linkedPullRequestNumbers: [],
-        currentDescription: createdIssueDescription,
+        currentDescription: normalizedCreatedIssueDescription,
         nextDescription: description,
         reason: 'create_response_mismatch',
         createPath
@@ -5944,8 +6048,8 @@ async function createPaperclipIssue(
       ctx,
       {
         companyId: mapping.companyId,
-        issueId: createdIssueId,
-        currentDescription: createdIssueDescription,
+        issueId: ensuredCreatedIssueId,
+        currentDescription: normalizedCreatedIssueDescription,
         githubIssue: issue,
         linkedPullRequestNumbers: [],
         paperclipApiBaseUrl,
@@ -5954,7 +6058,7 @@ async function createPaperclipIssue(
     );
   }
 
-  await upsertGitHubIssueLinkRecord(ctx, mapping, createdIssueId, issue, []);
+  await upsertGitHubIssueLinkRecord(ctx, mapping, ensuredCreatedIssueId, issue, []);
 
   if (syncFailureContext) {
     updateSyncFailureContext(syncFailureContext, {
@@ -5974,12 +6078,12 @@ async function createPaperclipIssue(
   await applyPaperclipLabelsToIssue(
     ctx,
     mapping.companyId,
-    createdIssueId,
+    ensuredCreatedIssueId,
     labelResolution.labels
   );
 
   return {
-    id: createdIssueId,
+    id: ensuredCreatedIssueId,
     unresolvedGitHubLabels: labelResolution.unresolvedGitHubLabels,
     ...(labelResolution.failure ? { labelResolutionFailure: labelResolution.failure } : {})
   };
@@ -6091,6 +6195,7 @@ async function synchronizePaperclipIssueStatuses(
   repositoryMaintainerCache: Map<string, boolean>,
   syncFailureContext: SyncFailureContext,
   failures: SyncProcessingFailure[],
+  assertNotCancelled?: () => Promise<void>,
   onProgress?: (progress: {
     githubIssueId: number;
     completedIssueCount: number;
@@ -6122,6 +6227,10 @@ async function synchronizePaperclipIssueStatuses(
   const totalIssueCount = importedIssues.length;
 
   for (const importedIssue of importedIssues) {
+      if (assertNotCancelled) {
+        await assertNotCancelled();
+      }
+
       const githubIssue = allIssuesById.get(importedIssue.githubIssueId);
 
       try {
@@ -7189,6 +7298,15 @@ async function performSync(
     progress: currentProgress
   });
 
+  async function throwIfSyncCancelled(): Promise<void> {
+    const cancellationRequest = await getSyncCancellationRequest(ctx);
+    if (!cancellationRequest) {
+      return;
+    }
+
+    throw new SyncCancellationError(cancellationRequest.requestedAt);
+  }
+
   async function persistRunningProgress(force = false): Promise<void> {
     const progress = normalizeSyncProgress(currentProgress);
     const signature = JSON.stringify({
@@ -7239,7 +7357,11 @@ async function performSync(
   const repositoryPlans: RepositorySyncPlan[] = [];
 
   try {
+    await throwIfSyncCancelled();
+
     for (const [mappingIndex, mapping] of mappings.entries()) {
+      await throwIfSyncCancelled();
+
       try {
         const repository = requireRepositoryReference(mapping.repositoryUrl);
         const importedIssueRecords = nextRegistry
@@ -7334,7 +7456,7 @@ async function performSync(
           trackedIssueCount
         });
       } catch (error) {
-        if (isGitHubRateLimitError(error)) {
+        if (error instanceof SyncCancellationError || isGitHubRateLimitError(error)) {
           throw error;
         }
 
@@ -7366,6 +7488,8 @@ async function performSync(
     await persistRunningProgress(true);
 
     for (const plan of repositoryPlans) {
+      await throwIfSyncCancelled();
+
       try {
         const { mapping, advancedSettings, repository, repositoryIndex, allIssuesById, issues } = plan;
         const companyId = mapping.companyId;
@@ -7430,8 +7554,9 @@ async function performSync(
             openLinkedPullRequestNumbers,
             pullRequestStatusCache
           );
+          await throwIfSyncCancelled();
         } catch (error) {
-          if (isGitHubRateLimitError(error)) {
+          if (error instanceof SyncCancellationError || isGitHubRateLimitError(error)) {
             throw error;
           }
 
@@ -7452,6 +7577,8 @@ async function performSync(
         await persistRunningProgress(true);
 
         for (const [issueIndex, issue] of issues.entries()) {
+          await throwIfSyncCancelled();
+
           const createdIssueCountBefore = createdIssueIds.size;
           const skippedIssueCountBefore = skippedIssueIds.size;
 
@@ -7503,6 +7630,7 @@ async function performSync(
           totalIssueCount: totalTrackedIssueCount
         };
         await persistRunningProgress(true);
+        await throwIfSyncCancelled();
 
         const synchronizationResult = await synchronizePaperclipIssueStatuses(
           ctx,
@@ -7521,6 +7649,7 @@ async function performSync(
           repositoryMaintainerCache,
           failureContext,
           recoverableFailures,
+          throwIfSyncCancelled,
           async (progress) => {
             markTrackedIssueProcessed(mapping, progress.githubIssueId);
             currentProgress = {
@@ -7541,7 +7670,7 @@ async function performSync(
         updatedLabelsCount += synchronizationResult.updatedLabelsCount;
         updatedDescriptionsCount += synchronizationResult.updatedDescriptionsCount;
       } catch (error) {
-        if (isGitHubRateLimitError(error)) {
+        if (error instanceof SyncCancellationError || isGitHubRateLimitError(error)) {
           throw error;
         }
 
@@ -7594,6 +7723,25 @@ async function performSync(
     await ctx.state.set(IMPORT_REGISTRY_SCOPE, nextRegistry);
     return next;
   } catch (error) {
+    if (error instanceof SyncCancellationError) {
+      const next = {
+        ...currentSettings,
+        syncState: createCancelledSyncState({
+          message: buildCancelledSyncMessage(options.target, currentProgress),
+          trigger,
+          syncedIssuesCount,
+          createdIssuesCount,
+          skippedIssuesCount,
+          erroredIssuesCount: recoverableFailures.length,
+          progress: currentProgress
+        })
+      };
+      await ctx.state.set(SETTINGS_SCOPE, next);
+      await ctx.state.set(SYNC_STATE_SCOPE, next.syncState);
+      await ctx.state.set(IMPORT_REGISTRY_SCOPE, nextRegistry);
+      return next;
+    }
+
     const errorDetails = buildSyncErrorDetails(error, failureContext);
     const next = {
       ...currentSettings,
@@ -7681,6 +7829,8 @@ async function startSync(
     return currentSettings;
   }
 
+  await setSyncCancellationRequest(ctx, null);
+
   const runningStatePromise = (async () => {
     const syncableMappings = getSyncableMappingsForTarget(currentSettings.mappings, options.target);
     const syncState = createRunningSyncState(currentSettings.syncState, trigger, {
@@ -7711,6 +7861,7 @@ async function startSync(
     } catch (error) {
       return await createUnexpectedSyncErrorResult(ctx, trigger, error);
     } finally {
+      await setSyncCancellationRequest(ctx, null);
       activePaperclipApiAuthTokensByCompanyId = null;
       activeRunningSyncState = null;
       activeSyncPromise = null;
@@ -8725,6 +8876,38 @@ const plugin = definePlugin({
         ...(typeof paperclipApiBaseUrl === 'string' ? { paperclipApiBaseUrl } : {}),
         ...(target ? { target } : {})
       });
+    });
+
+    ctx.actions.register('sync.cancel', async () => {
+      const currentSettings = await getActiveOrCurrentSyncState(ctx);
+      if (currentSettings.syncState.status !== 'running') {
+        return currentSettings;
+      }
+
+      const existingRequest =
+        currentSettings.syncState.cancelRequestedAt?.trim()
+          ? { requestedAt: currentSettings.syncState.cancelRequestedAt.trim() }
+          : await getSyncCancellationRequest(ctx);
+      const cancellationRequest = existingRequest ?? {
+        requestedAt: new Date().toISOString()
+      };
+
+      await setSyncCancellationRequest(ctx, cancellationRequest);
+      const next = await saveSettingsSyncState(
+        ctx,
+        currentSettings,
+        createRunningSyncState(currentSettings.syncState, currentSettings.syncState.lastRunTrigger ?? 'manual', {
+          syncedIssuesCount: currentSettings.syncState.syncedIssuesCount ?? 0,
+          createdIssuesCount: currentSettings.syncState.createdIssuesCount ?? 0,
+          skippedIssuesCount: currentSettings.syncState.skippedIssuesCount ?? 0,
+          erroredIssuesCount: currentSettings.syncState.erroredIssuesCount ?? 0,
+          progress: currentSettings.syncState.progress,
+          message: CANCELLING_SYNC_MESSAGE,
+          cancelRequestedAt: cancellationRequest.requestedAt
+        })
+      );
+      activeRunningSyncState = next;
+      return next;
     });
 
     registerGitHubAgentTools(ctx);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1651,16 +1651,20 @@ function createRunningSyncState(
     cancelRequestedAt?: string;
   } = {}
 ): SyncRunState {
+  const previousRunningState = previous.status === 'running' ? previous : undefined;
+  const nextMessage = options.message ?? previousRunningState?.message ?? RUNNING_SYNC_MESSAGE;
+  const nextCancelRequestedAt = options.cancelRequestedAt ?? previousRunningState?.cancelRequestedAt;
+
   return {
     status: 'running',
-    message: options.message ?? RUNNING_SYNC_MESSAGE,
+    message: nextMessage,
     checkedAt: previous.checkedAt,
     syncedIssuesCount: options.syncedIssuesCount ?? 0,
     createdIssuesCount: options.createdIssuesCount ?? 0,
     skippedIssuesCount: options.skippedIssuesCount ?? 0,
     erroredIssuesCount: options.erroredIssuesCount ?? 0,
     lastRunTrigger: trigger,
-    ...(options.cancelRequestedAt ? { cancelRequestedAt: options.cancelRequestedAt } : {}),
+    ...(nextCancelRequestedAt ? { cancelRequestedAt: nextCancelRequestedAt } : {}),
     ...(options.progress ? { progress: normalizeSyncProgress(options.progress) } : {})
   };
 }

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -8518,6 +8518,137 @@ test('worker returns a running state for long manual syncs and persists the fina
   }
 });
 
+test('worker can cancel a long-running manual sync after it has started', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubTokenRef: 'github-secret-ref'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+
+  await harness.performAction('settings.saveRegistration', {
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (input, init) => {
+    const rawUrl = getRequestUrl(input);
+    const url = new URL(rawUrl);
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues' && ['all', 'open'].includes(url.searchParams.get('state') ?? '')) {
+      await delay(1_200);
+
+      return jsonResponse([
+        {
+          id: 1001,
+          number: 10,
+          title: 'Cancellable sync issue',
+          body: 'Body from GitHub',
+          html_url: 'https://github.com/paperclipai/example-repo/issues/10',
+          state: 'open'
+        }
+      ]);
+    }
+
+    if (url.pathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      const issueNumber = typeof variables.issueNumber === 'number' ? variables.issueNumber : undefined;
+
+      if (query.includes('query GitHubIssueParentRelationships')) {
+        return graphqlIssueParentRelationshipsResponse([
+          {
+            issueNumber: 10
+          }
+        ]);
+      }
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && issueNumber === 10) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: 10,
+              state: 'OPEN',
+              stateReason: null,
+              comments: {
+                totalCount: 0
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: []
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    const runningResult = await harness.performAction('sync.runNow', {}) as {
+      syncState: { status: string; message?: string };
+    };
+    assert.equal(runningResult.syncState.status, 'running');
+
+    const cancelResult = await harness.performAction('sync.cancel', {}) as {
+      syncState: { status: string; message?: string; cancelRequestedAt?: string };
+    };
+    assert.equal(cancelResult.syncState.status, 'running');
+    assert.equal(cancelResult.syncState.message, 'Cancellation requested. GitHub sync will stop after the current step finishes.');
+    assert.ok(cancelResult.syncState.cancelRequestedAt);
+
+    await waitFor(() => {
+      const current = harness.getState({
+        scopeKind: 'instance',
+        stateKey: 'paperclip-github-plugin-settings'
+      }) as {
+        syncState?: { status?: string };
+      } | undefined;
+
+      return current?.syncState?.status === 'cancelled';
+    });
+
+    const cancelledState = harness.getState({
+      scopeKind: 'instance',
+      stateKey: 'paperclip-github-plugin-settings'
+    }) as {
+      syncState: {
+        status: string;
+        createdIssuesCount?: number;
+        skippedIssuesCount?: number;
+        syncedIssuesCount?: number;
+        message?: string;
+      };
+    };
+
+    assert.equal(cancelledState.syncState.status, 'cancelled');
+    assert.equal(cancelledState.syncState.createdIssuesCount, 0);
+    assert.equal(cancelledState.syncState.skippedIssuesCount, 0);
+    assert.equal(cancelledState.syncState.syncedIssuesCount, 1);
+    assert.match(cancelledState.syncState.message ?? '', /was cancelled before it finished/i);
+    assert.match(cancelledState.syncState.message ?? '', /completed 0 of 1 issues/i);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('worker persists live sync progress and imported counts before a long-running sync finishes', async () => {
   const harness = createTestHarness({
     manifest,


### PR DESCRIPTION
## Summary
- add a persisted cancel request and `sync.cancel` action so background syncs stop cooperatively at safe checkpoints
- replace active sync controls with cancel and cancelling states in the settings page, dashboard widget, and toolbar surfaces
- update the README and spec, and add regression coverage for canceling a long-running manual sync

## Testing
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Model Used
- Model ID/version: not exposed in this Codex session's metadata
- Context window: not exposed in this Codex session's metadata
- Capabilities: repository-aware code editing with terminal/tool use