### PR TITLE
Sync package.json version back to the release branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,14 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
 
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
 
       - name: Set up pnpm
         uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
@@ -66,3 +68,33 @@ jobs:
         env:
           PLUGIN_VERSION: ${{ steps.release_version.outputs.version }}
         run: npm publish --access public --provenance
+
+      - name: Sync checked-in package version to release branch
+        env:
+          RELEASE_VERSION: ${{ steps.release_version.outputs.version }}
+          RELEASE_TARGET_BRANCH: ${{ github.event.release.target_commitish }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+
+          TARGET_BRANCH="${RELEASE_TARGET_BRANCH:-$DEFAULT_BRANCH}"
+
+          if ! git ls-remote --exit-code --heads origin "$TARGET_BRANCH" >/dev/null 2>&1; then
+            echo "Release target '$TARGET_BRANCH' is not a branch on origin; skipping package.json sync."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin "$TARGET_BRANCH"
+          git switch --create "release-version-sync-$RELEASE_VERSION" "origin/$TARGET_BRANCH"
+          npm pkg set version="$RELEASE_VERSION"
+
+          if git diff --quiet -- package.json; then
+            echo "package.json already matches $RELEASE_VERSION on $TARGET_BRANCH."
+            exit 0
+          fi
+
+          git add package.json
+          git commit -m "chore: sync package version to $RELEASE_VERSION"
+          git push origin HEAD:"$TARGET_BRANCH"

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ If you want the seeded `CEO` agent used in manual verification to opt into Codex
 - The published version is derived from the GitHub release tag rather than the committed `package.json` version.
 - Tags may be either `1.2.3` or `v1.2.3`; the workflow normalizes both to `1.2.3`.
 - During release, the package version is stamped from the tag before build and publish, and the built plugin manifest uses that same resolved version.
+- After a successful publish, the workflow also commits that resolved version back into the checked-in `package.json` on the release target branch so the repository metadata stays in sync with npm.
 - The workflow is intended for npm trusted publishing through GitHub Actions OIDC, so no long-lived `NPM_TOKEN` secret is required when trusted publishing is configured correctly.
 
 ## License

--- a/SPEC.md
+++ b/SPEC.md
@@ -133,4 +133,5 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 - Local development SHOULD provide a watch-mode build and a local UI dev server for hosted-UI iteration.
 - The build pipeline MUST stamp the plugin manifest version from build-time package metadata rather than keeping a separately hardcoded manifest version.
 - The release workflow MUST derive the published version from the GitHub release tag and stamp that version into publishable package metadata before build and publish.
+- After a successful publish, the release workflow MUST sync that resolved release version back into the checked-in `package.json` on the release target branch so repository metadata reflects the latest published release.
 - The release workflow MUST run on a Node.js version that already satisfies npm trusted publishing requirements instead of relying on an in-job npm self-upgrade step.


### PR DESCRIPTION
## Summary
- Update the release workflow so it can push changes back to the repository after publish.
- After npm publish, resolve the release target branch, stamp `package.json` with the release tag version, and commit/push only when the file changed.
- Document the new release behavior in `README.md` and `SPEC.md` so the checked-in package metadata is expected to match the latest published version.

## Testing
- `pnpm test`
- `pnpm build`

## Model Used
- `gpt-5.4`
- Context window size: not exposed by the runtime metadata in this environment
- Capabilities: medium reasoning, terminal tool use, file diff analysis