### PR TITLE
fix: handle symlinked worker entrypoints during plugin startup

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,10 +1,12 @@
+import { realpathSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Octokit } from '@octokit/rest';
 import {
   definePlugin,
-  runWorker,
+  startWorkerRpcHost,
   type Agent,
   type Issue,
   type IssueComment,
@@ -13739,6 +13741,20 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
   );
 }
 
+export function shouldStartWorkerHost(moduleUrl: string, entry = process.argv[1]): boolean {
+  if (typeof entry !== 'string' || !entry.trim()) {
+    return false;
+  }
+
+  const modulePath = fileURLToPath(moduleUrl);
+
+  try {
+    return realpathSync(entry) === realpathSync(modulePath);
+  } catch {
+    return resolve(entry) === resolve(modulePath);
+  }
+}
+
 const plugin = definePlugin({
   async setup(ctx) {
     ctx.data.register('settings.registration', async (input) => {
@@ -14098,4 +14114,7 @@ const plugin = definePlugin({
 });
 
 export default plugin;
-runWorker(plugin, import.meta.url);
+
+if (shouldStartWorkerHost(import.meta.url)) {
+  startWorkerRpcHost({ plugin });
+}

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -1,7 +1,8 @@
 import { strict as assert } from 'node:assert';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import test from 'node:test';
 
 import type { Agent, Project } from '@paperclipai/plugin-sdk';
@@ -21,10 +22,14 @@ import {
 let plugin!: typeof import('../src/worker.ts').default;
 let workerImportSerial = 0;
 
-async function importFreshWorker(): Promise<typeof import('../src/worker.ts').default> {
+async function importFreshWorkerModule() {
   workerImportSerial += 1;
   const workerModuleUrl = new URL(`../src/worker.ts?worker-test=${workerImportSerial}`, import.meta.url);
-  return (await import(workerModuleUrl.href)).default;
+  return await import(workerModuleUrl.href);
+}
+
+async function importFreshWorker(): Promise<typeof import('../src/worker.ts').default> {
+  return (await importFreshWorkerModule()).default;
 }
 
 test.beforeEach(async () => {
@@ -220,6 +225,44 @@ test(
     assert.equal(resolvedManifest.version, '9.9.9-test');
   }
 );
+
+test('shouldStartWorkerHost matches symlinked entrypoints to the real worker file', async () => {
+  const workerModule = await importFreshWorkerModule();
+  const tempDir = await mkdtemp(join(tmpdir(), 'paperclip-github-plugin-worker-path-'));
+  const realWorkerPath = join(tempDir, 'worker.js');
+  const symlinkWorkerPath = join(tempDir, 'worker-symlink.js');
+
+  try {
+    await writeFile(realWorkerPath, '// test worker entrypoint\n');
+    await symlink(realWorkerPath, symlinkWorkerPath);
+
+    assert.equal(
+      workerModule.shouldStartWorkerHost(pathToFileURL(realWorkerPath).href, symlinkWorkerPath),
+      true
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('shouldStartWorkerHost rejects unrelated entrypoints', async () => {
+  const workerModule = await importFreshWorkerModule();
+  const tempDir = await mkdtemp(join(tmpdir(), 'paperclip-github-plugin-worker-path-'));
+  const realWorkerPath = join(tempDir, 'worker.js');
+  const otherWorkerPath = join(tempDir, 'different-worker.js');
+
+  try {
+    await writeFile(realWorkerPath, '// test worker entrypoint\n');
+    await writeFile(otherWorkerPath, '// different worker entrypoint\n');
+
+    assert.equal(
+      workerModule.shouldStartWorkerHost(pathToFileURL(realWorkerPath).href, otherWorkerPath),
+      false
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
 
 async function createGitHubAgentToolHarness() {
   const harness = createTestHarness({


### PR DESCRIPTION
## Summary
- replace the direct `runWorker(plugin, import.meta.url)` bootstrap with a symlink-safe main-module check
- start the RPC host with `startWorkerRpcHost({ plugin })` when the resolved entrypoint matches the worker file
- add regression tests covering symlinked and unrelated entrypoint paths

## Root cause
Paperclip can install plugins under paths that resolve through symlinks / mounted aliases. In that layout, `runWorker(plugin, import.meta.url)` can compare two different path strings for the same file and decide the worker module is not the process entrypoint, so the RPC host never starts and the worker exits with code 0.

## Verification
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- manual repro: forking the built worker from a symlinked path now returns a successful `initialize` response instead of exiting immediately

Closes #33.
