### PR TITLE
fix: respect PAPERCLIP_HOME for local config fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The plugin is designed to avoid persisting raw credentials in plugin state.
 
 ### Optional worker-local token file
 
-If Paperclip-managed secrets are not available, the worker can read a local fallback file at `~/.paperclip/plugins/github-sync/config.json`:
+If Paperclip-managed secrets are not available, the worker can read a local fallback file at `${PAPERCLIP_HOME:-~/.paperclip}/plugins/github-sync/config.json`:
 
 ```json
 {
@@ -177,7 +177,7 @@ When an agent posts a GitHub comment or review-thread reply through the plugin, 
 
 ## Troubleshooting
 
-- If setup is reported as incomplete, confirm that a GitHub token has been saved or that `~/.paperclip/plugins/github-sync/config.json` contains `githubToken`, and make sure at least one mapping has a created Paperclip project.
+- If setup is reported as incomplete, confirm that a GitHub token has been saved or that `${PAPERCLIP_HOME:-~/.paperclip}/plugins/github-sync/config.json` contains `githubToken`, and make sure at least one mapping has a created Paperclip project.
 - If Paperclip says board access is required, open plugin settings inside the affected company and complete the Paperclip board access flow before retrying sync.
 - If the worker reaches an authenticated HTML page instead of the Paperclip API JSON responses it expects, connect Paperclip board access for that company or set `PAPERCLIP_API_URL` to a worker-accessible Paperclip API origin.
 - If a sync run finishes with partial failures, open the saved troubleshooting panel in GitHub Sync to inspect the repository, issue number, raw error, and suggested fix for each recorded failure.

--- a/SPEC.md
+++ b/SPEC.md
@@ -7,7 +7,7 @@ GitHub Sync is a Paperclip plugin for registering one or more GitHub repositorie
 The plugin MUST provide a settings page inside Paperclip where an operator can configure:
 
 - a GitHub token stored as a Paperclip secret reference
-- an optional external config file at `~/.paperclip/plugins/github-sync/config.json` for worker-only global values such as a raw `githubToken`
+- an optional external config file at `${PAPERCLIP_HOME:-~/.paperclip}/plugins/github-sync/config.json` for worker-only global values such as a raw `githubToken`
 - Paperclip board access, which is optional on unauthenticated deployments and required when the Paperclip deployment reports `deploymentMode: "authenticated"`
 - one or more GitHub repository mappings
 - company-scoped advanced defaults for imported issues: default assignee, default Paperclip status, and ignored GitHub issue authors, where a saved username such as `renovate` also matches GitHub bot logins such as `renovate[bot]`
@@ -31,7 +31,7 @@ The settings page MUST allow saving mappings and triggering a manual sync.
 - Saving a token from the settings UI MUST create or reuse a company secret through the Paperclip host API.
 - The plugin MUST persist only the resulting secret UUID in plugin instance config.
 - The worker MUST resolve that secret UUID at runtime via `ctx.secrets.resolve(...)`.
-- If `~/.paperclip/plugins/github-sync/config.json` exists and contains a string `githubToken`, the worker MUST treat it as a worker-only fallback source for the GitHub token without persisting or returning that raw token.
+- If `${PAPERCLIP_HOME:-~/.paperclip}/plugins/github-sync/config.json` exists and contains a string `githubToken`, the worker MUST treat it as a worker-only fallback source for the GitHub token without persisting or returning that raw token.
 - The raw Paperclip board API token MUST NOT be persisted in plugin state.
 - Connecting Paperclip board access from the settings UI MUST create or reuse a company secret through the Paperclip host API and MUST persist only the resulting secret UUID, keyed by company in plugin state and mirrored into plugin instance config so the worker can resolve it.
 - The worker MUST resolve the saved Paperclip board token secret at runtime via `ctx.secrets.resolve(...)` before making direct Paperclip REST calls for that company, and MUST treat plugin config as the worker-readable source of truth for those secret refs.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -63,7 +63,7 @@ const MAX_SYNC_FAILURE_LOG_ENTRIES = 25;
 const GITHUB_SECONDARY_RATE_LIMIT_FALLBACK_MS = 60_000;
 const MISSING_GITHUB_TOKEN_SYNC_MESSAGE = 'Configure a GitHub token before running sync.';
 const MISSING_GITHUB_TOKEN_SYNC_ACTION =
-  'Open settings and save a GitHub token secret, or create ~/.paperclip/plugins/github-sync/config.json with a "githubToken" value, and then run sync again.';
+  'Open settings and save a GitHub token secret, or create $PAPERCLIP_HOME/plugins/github-sync/config.json (or ~/.paperclip/plugins/github-sync/config.json when PAPERCLIP_HOME is unset) with a "githubToken" value, and then run sync again.';
 const MISSING_MAPPING_SYNC_MESSAGE = 'Save at least one mapping with a created Paperclip project before running sync.';
 const MISSING_MAPPING_SYNC_ACTION =
   'Open settings, add a repository mapping, let Paperclip create the target project, and then retry sync.';
@@ -74,7 +74,6 @@ const MISSING_BOARD_ACCESS_SYNC_ACTION =
 const ISSUE_LINK_ENTITY_TYPE = 'paperclip-github-plugin.issue-link';
 const PULL_REQUEST_LINK_ENTITY_TYPE = 'paperclip-github-plugin.pull-request-link';
 const COMMENT_ANNOTATION_ENTITY_TYPE = 'paperclip-github-plugin.comment-annotation';
-const EXTERNAL_CONFIG_FILE_PATH_SEGMENTS = ['.paperclip', 'plugins', 'github-sync', 'config.json'] as const;
 const AI_AUTHORED_COMMENT_FOOTER_PREFIX = 'Created by a Paperclip AI agent using ';
 
 type PluginSetupContext = Parameters<Parameters<typeof definePlugin>[0]['setup']>[0];
@@ -3876,15 +3875,20 @@ function normalizeGitHubToken(value: unknown): string | undefined {
 }
 
 function getExternalConfigFilePath(): string | undefined {
-  const homeDirectory = getHomeDirectory();
-  return homeDirectory ? join(homeDirectory, ...EXTERNAL_CONFIG_FILE_PATH_SEGMENTS) : undefined;
+  const paperclipHomeDirectory = getPaperclipHomeDirectory();
+  return paperclipHomeDirectory ? join(paperclipHomeDirectory, 'plugins', 'github-sync', 'config.json') : undefined;
 }
 
-function getHomeDirectory(): string | undefined {
+function getPaperclipHomeDirectory(): string | undefined {
+  const configuredPaperclipHome = process.env.PAPERCLIP_HOME?.trim();
+  if (configuredPaperclipHome) {
+    return resolve(configuredPaperclipHome);
+  }
+
   try {
     const resolvedHomeDirectory = homedir();
     return typeof resolvedHomeDirectory === 'string' && resolvedHomeDirectory.trim()
-      ? resolvedHomeDirectory
+      ? join(resolvedHomeDirectory, '.paperclip')
       : undefined;
   } catch {
     return undefined;

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -11055,7 +11055,7 @@ test('worker stores repository and issue diagnostics when a sync fails mid-run',
   }
 });
 
-test('worker reports sync error when configuration is incomplete', async () => {
+test('worker reports sync error when configuration is incomplete', { concurrency: false }, async () => {
   await withExternalPluginConfig({}, async () => {
     const harness = createTestHarness({ manifest });
     await plugin.definition.setup(harness.ctx);

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -576,17 +576,27 @@ function createAgentFixture(params: {
 
 async function withExternalPluginConfig<T>(
   config: Record<string, unknown>,
-  run: () => Promise<T>
+  run: () => Promise<T>,
+  options: { usePaperclipHome?: boolean } = {}
 ): Promise<T> {
   const temporaryHomeDirectory = await mkdtemp(join(tmpdir(), 'paperclip-github-plugin-'));
-  const configDirectory = join(temporaryHomeDirectory, '.paperclip', 'plugins', 'github-sync');
+  const paperclipHomeDirectory = options.usePaperclipHome
+    ? join(temporaryHomeDirectory, 'paperclip-home')
+    : join(temporaryHomeDirectory, '.paperclip');
+  const configDirectory = join(paperclipHomeDirectory, 'plugins', 'github-sync');
   const configFilePath = join(configDirectory, 'config.json');
   const previousHome = process.env.HOME;
+  const previousPaperclipHome = process.env.PAPERCLIP_HOME;
 
   await mkdir(configDirectory, { recursive: true });
   await writeFile(configFilePath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
 
   process.env.HOME = temporaryHomeDirectory;
+  if (options.usePaperclipHome) {
+    process.env.PAPERCLIP_HOME = paperclipHomeDirectory;
+  } else {
+    delete process.env.PAPERCLIP_HOME;
+  }
 
   try {
     return await run();
@@ -595,6 +605,12 @@ async function withExternalPluginConfig<T>(
       delete process.env.HOME;
     } else {
       process.env.HOME = previousHome;
+    }
+
+    if (previousPaperclipHome === undefined) {
+      delete process.env.PAPERCLIP_HOME;
+    } else {
+      process.env.PAPERCLIP_HOME = previousPaperclipHome;
     }
 
     await rm(temporaryHomeDirectory, { recursive: true, force: true });
@@ -5655,6 +5671,34 @@ test('settings.registration reports a configured token from the external config 
       assert.equal(result.syncState?.status, 'idle');
       assert.equal(resolveCount, 0);
     }
+  );
+});
+
+test('settings.registration reports a configured token from the external config file inside PAPERCLIP_HOME', { concurrency: false }, async () => {
+  await withExternalPluginConfig(
+    {
+      githubToken: 'ghp_external_token'
+    },
+    async () => {
+      const harness = createTestHarness({ manifest });
+      await plugin.definition.setup(harness.ctx);
+
+      let resolveCount = 0;
+      harness.ctx.secrets.resolve = async () => {
+        resolveCount += 1;
+        throw new Error('Secret resolution should not happen for settings data.');
+      };
+
+      const result = await harness.getData<{
+        githubTokenConfigured?: boolean;
+        syncState?: { status?: string };
+      }>('settings.registration');
+
+      assert.equal(result.githubTokenConfigured, true);
+      assert.equal(result.syncState?.status, 'idle');
+      assert.equal(resolveCount, 0);
+    },
+    { usePaperclipHome: true }
   );
 });
 
@@ -11228,7 +11272,7 @@ test('settings registration clears legacy setup errors once the missing token is
         errorDetails: {
           phase: 'configuration',
           suggestedAction:
-            'Open settings and save a GitHub token secret, or create ~/.paperclip/plugins/github-sync/config.json with a "githubToken" value, and then run sync again.'
+            'Open settings and save a GitHub token secret, or create $PAPERCLIP_HOME/plugins/github-sync/config.json (or ~/.paperclip/plugins/github-sync/config.json when PAPERCLIP_HOME is unset) with a "githubToken" value, and then run sync again.'
         }
       },
       scheduleFrequencyMinutes: 15
@@ -11296,7 +11340,7 @@ test('saving setup clears stale setup errors instead of resaving them from the U
         errorDetails: {
           phase: 'configuration',
           suggestedAction:
-            'Open settings and save a GitHub token secret, or create ~/.paperclip/plugins/github-sync/config.json with a "githubToken" value, and then run sync again.'
+            'Open settings and save a GitHub token secret, or create $PAPERCLIP_HOME/plugins/github-sync/config.json (or ~/.paperclip/plugins/github-sync/config.json when PAPERCLIP_HOME is unset) with a "githubToken" value, and then run sync again.'
         }
       },
       scheduleFrequencyMinutes: 15
@@ -11321,7 +11365,7 @@ test('saving setup clears stale setup errors instead of resaving them from the U
       errorDetails: {
         phase: 'configuration',
         suggestedAction:
-          'Open settings and save a GitHub token secret, or create ~/.paperclip/plugins/github-sync/config.json with a "githubToken" value, and then run sync again.'
+          'Open settings and save a GitHub token secret, or create $PAPERCLIP_HOME/plugins/github-sync/config.json (or ~/.paperclip/plugins/github-sync/config.json when PAPERCLIP_HOME is unset) with a "githubToken" value, and then run sync again.'
       }
     }
   }) as {


### PR DESCRIPTION
## Summary
- resolve the worker-local fallback config from `PAPERCLIP_HOME` when it is set
- keep `~/.paperclip` as the fallback only when `PAPERCLIP_HOME` is unset
- update the README and SPEC to document the correct path
- add a regression test covering a fallback token file located inside `PAPERCLIP_HOME`

## Why
On local/self-hosted installs that move Paperclip state with `PAPERCLIP_HOME`, the plugin could miss its worker-local fallback config if there was no compatibility symlink at `~/.paperclip`.

## Verification
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

Closes #35.
