### PR TITLE
Fix GitHub issue imports by stripping NUL bytes from synced content

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1635,6 +1635,10 @@ function normalizeOptionalString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
 
+function stripNullBytes(value: string): string {
+  return value.replace(/\u0000/g, '');
+}
+
 function getErrorStatus(error: unknown): number | undefined {
   if (!error || typeof error !== 'object' || !('status' in error)) {
     return undefined;
@@ -2061,7 +2065,12 @@ function normalizeSecretRef(value: unknown): string | undefined {
 }
 
 function normalizeGitHubUserLogin(value: unknown): string | undefined {
-  return typeof value === 'string' && value.trim() ? value.trim().toLowerCase() : undefined;
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = stripNullBytes(value).trim();
+  return trimmed ? trimmed.toLowerCase() : undefined;
 }
 
 function normalizeGitHubTokenRef(value: unknown): string | undefined {
@@ -4050,7 +4059,7 @@ function normalizeGitHubUsername(value: unknown): string | undefined {
     return undefined;
   }
 
-  const trimmed = value.trim().replace(/^@+/, '');
+  const trimmed = stripNullBytes(value).trim().replace(/^@+/, '');
   return trimmed ? trimmed.toLowerCase() : undefined;
 }
 
@@ -4474,9 +4483,9 @@ function normalizeGitHubIssueLabels(value: GitHubApiIssueRecord['labels']): GitH
   for (const entry of value) {
     const name =
       typeof entry === 'string'
-        ? entry.trim()
+        ? stripNullBytes(entry).trim()
         : entry && typeof entry === 'object' && typeof entry.name === 'string'
-          ? entry.name.trim()
+          ? stripNullBytes(entry.name).trim()
           : '';
 
     if (!name) {
@@ -4503,8 +4512,8 @@ function normalizeGitHubIssueRecord(issue: GitHubApiIssueRecord): GitHubIssueRec
   return {
     id: issue.id,
     number: issue.number,
-    title: issue.title,
-    body: issue.body ?? null,
+    title: stripNullBytes(issue.title),
+    body: typeof issue.body === 'string' ? stripNullBytes(issue.body) : null,
     htmlUrl: issue.html_url,
     ...(normalizeGitHubUsername(issue.user?.login) ? { authorLogin: normalizeGitHubUsername(issue.user?.login) } : {}),
     labels: normalizeGitHubIssueLabels(issue.labels),
@@ -5778,7 +5787,7 @@ async function listNewGitHubIssueCommentsSinceCount(
     for (const comment of response.data.slice(remainingOffset)) {
       comments.push({
         id: comment.id,
-        body: comment.body ?? '',
+        body: typeof comment.body === 'string' ? stripNullBytes(comment.body) : '',
         url: comment.html_url ?? undefined,
         authorLogin: normalizeGitHubUserLogin(comment.user?.login),
         createdAt: comment.created_at ?? undefined,
@@ -6105,7 +6114,7 @@ function normalizeGitHubIssueBodyForPaperclip(body: string | null | undefined): 
     return undefined;
   }
 
-  const trimmed = body.trim();
+  const trimmed = stripNullBytes(body).trim();
   if (!trimmed) {
     return undefined;
   }
@@ -9197,7 +9206,7 @@ async function listAllGitHubIssueComments(
     for (const comment of response.data) {
       comments.push({
         id: comment.id,
-        body: comment.body ?? '',
+        body: typeof comment.body === 'string' ? stripNullBytes(comment.body) : '',
         url: comment.html_url ?? undefined,
         authorLogin: normalizeGitHubUserLogin(comment.user?.login),
         authorUrl: comment.user?.html_url ?? undefined,

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -6615,6 +6615,123 @@ test('worker maps GitHub labels onto existing Paperclip labels, creates missing 
   }
 });
 
+test('worker strips NUL bytes from GitHub issue text before creating imported Paperclip issues', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubTokenRef: 'github-secret-ref'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+  harness.ctx.secrets.resolve = async () => 'github-token';
+
+  await harness.performAction('settings.saveRegistration', {
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  const originalCreate = harness.ctx.issues.create;
+  let createdIssueInput: Parameters<typeof originalCreate>[0] | undefined;
+  harness.ctx.issues.create = async (input) => {
+    createdIssueInput = input;
+
+    if (input.title.includes('\u0000') || input.description?.includes('\u0000')) {
+      throw new Error('invalid byte sequence for encoding "UTF8": 0x00');
+    }
+
+    return originalCreate(input);
+  };
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    const rawUrl = getRequestUrl(input);
+    const url = new URL(rawUrl);
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues' && ['all', 'open'].includes(url.searchParams.get('state') ?? '')) {
+      return jsonResponse([
+        {
+          id: 2718,
+          number: 718,
+          title: 'Import survives \u0000 NUL bytes',
+          body: 'First line\u0000\n\nSecond line after the hidden byte.',
+          html_url: 'https://github.com/paperclipai/example-repo/issues/718',
+          state: 'open',
+          labels: []
+        }
+      ]);
+    }
+
+    if (url.pathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      const issueNumber = typeof variables.issueNumber === 'number' ? variables.issueNumber : undefined;
+
+      if (query.includes('query GitHubIssueParentRelationships')) {
+        return graphqlIssueParentRelationshipsResponse([
+          {
+            issueNumber: 718
+          }
+        ]);
+      }
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && issueNumber === 718) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: 718,
+              state: 'OPEN',
+              stateReason: null,
+              comments: {
+                totalCount: 0
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: []
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    const sync = await harness.performAction('sync.runNow', {}) as {
+      syncState: { status: string; createdIssuesCount?: number };
+    };
+
+    assert.equal(sync.syncState.status, 'success');
+    assert.equal(sync.syncState.createdIssuesCount, 1);
+    assert.ok(createdIssueInput);
+    assert.doesNotMatch(createdIssueInput?.title ?? '', /\u0000/);
+    assert.doesNotMatch(createdIssueInput?.description ?? '', /\u0000/);
+
+    const importedIssues = await harness.ctx.issues.list({
+      companyId: 'company-1'
+    });
+    const importedIssue = importedIssues.find((issue) => issue.title === 'Import survives  NUL bytes');
+
+    assert.ok(importedIssue);
+    assert.equal(importedIssue?.description, 'First line\n\nSecond line after the hidden byte.');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('worker authenticates direct Paperclip REST label and issue sync calls with the configured board token', async () => {
   const harness = createTestHarness({
     manifest,


### PR DESCRIPTION
## Summary
- Strip embedded NUL bytes from GitHub issue titles, bodies, labels, usernames, and comment bodies before persisting imported data
- Prevent UTF-8 storage failures during issue import when GitHub payloads contain `\u0000`
- Add a regression test covering issue import with NUL bytes in the GitHub title and body

## Testing
- Not run (not requested)

## Model Used
- OpenAI Codex, GPT-5 family; exact model ID/version and context window size were not exposed in this environment
- Capability details: tool-assisted code editing and regression test authoring