### PR TITLE
Fix imported GitHub issue recovery for agent context

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ When a token is saved, the settings page audits the mapped repositories for the 
 
 Imported issues keep the original GitHub title and use the normalized GitHub body as the Paperclip description. The worker also normalizes GitHub HTML that Paperclip descriptions do not render cleanly, including elements such as `<br>`, `<hr>`, `<details>`, `<summary>`, and inline images.
 
+To keep imported issues recognizable without cluttering the visible description, the plugin appends a hidden HTML comment footer with the source GitHub issue URL. Agents and repair flows use that marker when the plugin-owned link entity or import registry is missing.
+
 Repeated syncs keep existing imports current instead of creating duplicates again. If the plugin's import registry is stale, the worker can repair deduplication by reusing existing Paperclip issues when durable GitHub link metadata is already present.
 
 When the local Paperclip API is available, the plugin also syncs labels by name, prefers exact color matches when multiple Paperclip labels share the same name, and creates missing Paperclip labels when needed.

--- a/SPEC.md
+++ b/SPEC.md
@@ -56,6 +56,7 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 - When the mapping company has a configured default assignee, the sync flow MUST assign newly created imported Paperclip issues to that Paperclip agent.
 - Imported Paperclip issues MUST keep the original GitHub issue title without adding a `[GitHub]` prefix.
 - Imported issue descriptions SHOULD contain the normalized GitHub body when present and MUST normalize the GitHub raw HTML constructs that Paperclip cannot render in multiline descriptions.
+- Imported issue descriptions MUST also retain a machine-readable hidden marker for the source GitHub issue URL so agents and repair paths can still recognize imported issues when plugin-owned entity or registry state is missing.
 - GitHub repository, issue, PR, label, and sync metadata SHOULD move into a dedicated issue detail surface instead of being prepended into the issue description.
 - Repeated sync runs MUST continue reconciling imported Paperclip issue descriptions against the latest GitHub issue body.
 - Saving setup MUST persist the current Paperclip host origin so scheduled sync runs can call the local Paperclip label API later.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -75,6 +75,8 @@ const ISSUE_LINK_ENTITY_TYPE = 'paperclip-github-plugin.issue-link';
 const PULL_REQUEST_LINK_ENTITY_TYPE = 'paperclip-github-plugin.pull-request-link';
 const COMMENT_ANNOTATION_ENTITY_TYPE = 'paperclip-github-plugin.comment-annotation';
 const AI_AUTHORED_COMMENT_FOOTER_PREFIX = 'Created by a Paperclip AI agent using ';
+const HIDDEN_GITHUB_IMPORT_MARKER_PREFIX = '<!-- paperclip-github-plugin-imported-from: ';
+const HIDDEN_GITHUB_IMPORT_MARKER_SUFFIX = ' -->';
 
 type PluginSetupContext = Parameters<Parameters<typeof definePlugin>[0]['setup']>[0];
 type PaperclipIssueStatus = Issue['status'];
@@ -2955,7 +2957,7 @@ async function resolvePaperclipIssueGitHubLink(
       registryMatch.githubIssueNumber
     );
     if (githubIssueUrl) {
-      return {
+      const fallbackLink = {
         source: 'import_registry',
         companyId: registryMatch.companyId,
         paperclipProjectId: registryMatch.paperclipProjectId,
@@ -2964,7 +2966,9 @@ async function resolvePaperclipIssueGitHubLink(
         githubIssueNumber: registryMatch.githubIssueNumber,
         githubIssueUrl,
         linkedPullRequestNumbers: []
-      };
+      } satisfies ResolvedPaperclipIssueGitHubLink;
+
+      return await hydrateRecoveredPaperclipIssueGitHubLink(ctx, issueId, fallbackLink) ?? fallbackLink;
     }
   }
 
@@ -2975,7 +2979,7 @@ async function resolvePaperclipIssueGitHubLink(
     return null;
   }
 
-  return {
+  const fallbackLink = {
     source: 'description',
     companyId,
     paperclipProjectId: issue?.projectId ?? undefined,
@@ -2983,7 +2987,75 @@ async function resolvePaperclipIssueGitHubLink(
     githubIssueNumber: githubIssueReference.issueNumber,
     githubIssueUrl: githubIssueReference.issueUrl,
     linkedPullRequestNumbers: []
-  };
+  } satisfies ResolvedPaperclipIssueGitHubLink;
+
+  return await hydrateRecoveredPaperclipIssueGitHubLink(ctx, issueId, fallbackLink) ?? fallbackLink;
+}
+
+async function hydrateRecoveredPaperclipIssueGitHubLink(
+  ctx: PluginSetupContext,
+  issueId: string,
+  fallbackLink: ResolvedPaperclipIssueGitHubLink
+): Promise<ResolvedPaperclipIssueGitHubLink | null> {
+  const repository = parseRepositoryReference(fallbackLink.repositoryUrl);
+  if (!repository) {
+    return null;
+  }
+
+  let octokit: Octokit;
+  try {
+    octokit = await createGitHubToolOctokit(ctx);
+  } catch {
+    return null;
+  }
+
+  try {
+    const response = await octokit.rest.issues.get({
+      owner: repository.owner,
+      repo: repository.repo,
+      issue_number: fallbackLink.githubIssueNumber,
+      headers: {
+        'X-GitHub-Api-Version': GITHUB_API_VERSION
+      }
+    });
+    const githubIssue = normalizeGitHubIssueRecord(response.data as GitHubApiIssueRecord);
+    const linkedPullRequests = await listLinkedPullRequestsForIssue(octokit, repository, githubIssue.number);
+    const linkedPullRequestNumbers = linkedPullRequests.map((pullRequest) => pullRequest.number);
+
+    await upsertGitHubIssueLinkRecord(
+      ctx,
+      {
+        id: `recovered:${issueId}`,
+        repositoryUrl: fallbackLink.repositoryUrl,
+        paperclipProjectName: '',
+        paperclipProjectId: fallbackLink.paperclipProjectId,
+        companyId: fallbackLink.companyId
+      },
+      issueId,
+      githubIssue,
+      linkedPullRequestNumbers
+    );
+
+    return {
+      source: 'entity',
+      companyId: fallbackLink.companyId,
+      paperclipProjectId: fallbackLink.paperclipProjectId,
+      repositoryUrl: fallbackLink.repositoryUrl,
+      githubIssueId: githubIssue.id,
+      githubIssueNumber: githubIssue.number,
+      githubIssueUrl: normalizeGitHubIssueHtmlUrl(githubIssue.htmlUrl) ?? githubIssue.htmlUrl,
+      linkedPullRequestNumbers
+    };
+  } catch (error) {
+    ctx.logger.warn('Unable to hydrate recovered GitHub issue metadata for a Paperclip issue fallback link.', {
+      issueId,
+      companyId: fallbackLink.companyId,
+      repositoryUrl: fallbackLink.repositoryUrl,
+      githubIssueNumber: fallbackLink.githubIssueNumber,
+      error: getErrorMessage(error)
+    });
+    return null;
+  }
 }
 
 async function resolveManualSyncTarget(
@@ -3264,6 +3336,26 @@ async function buildIssueGitHubDetails(
   const fallbackLink = await resolvePaperclipIssueGitHubLink(ctx, issueId, companyId);
   if (!fallbackLink) {
     return null;
+  }
+
+  const hydratedLinkRecords = await listGitHubIssueLinkRecords(ctx, {
+    paperclipIssueId: issueId
+  });
+  const hydratedEntityMatch = hydratedLinkRecords.find((record) => !record.data.companyId || record.data.companyId === companyId);
+  if (hydratedEntityMatch) {
+    return {
+      paperclipIssueId: issueId,
+      source: 'entity',
+      githubIssueNumber: hydratedEntityMatch.data.githubIssueNumber,
+      githubIssueUrl: hydratedEntityMatch.data.githubIssueUrl,
+      repositoryUrl: hydratedEntityMatch.data.repositoryUrl,
+      githubIssueState: hydratedEntityMatch.data.githubIssueState,
+      githubIssueStateReason: hydratedEntityMatch.data.githubIssueStateReason,
+      commentsCount: hydratedEntityMatch.data.commentsCount,
+      linkedPullRequestNumbers: hydratedEntityMatch.data.linkedPullRequestNumbers,
+      labels: hydratedEntityMatch.data.labels,
+      syncedAt: hydratedEntityMatch.data.syncedAt
+    };
   }
 
   return {
@@ -5952,6 +6044,11 @@ function extractImportedGitHubIssueUrlFromDescription(description: string | null
     return undefined;
   }
 
+  const hiddenMarkerMatch = description.match(/<!--\s*paperclip-github-plugin-imported-from:\s*(\S+?)\s*-->/i);
+  if (hiddenMarkerMatch) {
+    return normalizeGitHubIssueHtmlUrl(hiddenMarkerMatch[1]);
+  }
+
   const markdownMetadataMatch = description.match(/^\*\s+GitHub issue:\s+\[[^\]]+\]\(([^)]+)\)/m);
   if (markdownMetadataMatch) {
     return normalizeGitHubIssueHtmlUrl(markdownMetadataMatch[1]);
@@ -6145,8 +6242,30 @@ function normalizeGitHubIssueBodyForPaperclip(body: string | null | undefined): 
 
 function buildPaperclipIssueDescription(issue: GitHubIssueRecord, linkedPullRequestNumbers: number[] = []): string {
   const normalizedBody = normalizeGitHubIssueBodyForPaperclip(issue.body);
+  const hiddenImportMarker = buildHiddenGitHubImportMarker(issue.htmlUrl);
   void linkedPullRequestNumbers;
-  return normalizedBody ?? '';
+  if (!hiddenImportMarker) {
+    return normalizedBody ?? '';
+  }
+
+  if (!normalizedBody) {
+    return hiddenImportMarker;
+  }
+
+  return `${normalizedBody}\n\n${hiddenImportMarker}`;
+}
+
+function buildHiddenGitHubImportMarker(githubIssueUrl: string | null | undefined): string | undefined {
+  if (typeof githubIssueUrl !== 'string') {
+    return undefined;
+  }
+
+  const normalizedIssueUrl = normalizeGitHubIssueHtmlUrl(githubIssueUrl);
+  if (!normalizedIssueUrl) {
+    return undefined;
+  }
+
+  return `${HIDDEN_GITHUB_IMPORT_MARKER_PREFIX}${normalizedIssueUrl}${HIDDEN_GITHUB_IMPORT_MARKER_SUFFIX}`;
 }
 
 function normalizeIssueDescriptionValue(value: string | null | undefined): string {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -277,6 +277,12 @@ interface GitHubIssueLinkRecord {
   data: GitHubIssueLinkEntityData;
 }
 
+interface GitHubIssueLinkTarget {
+  companyId?: string;
+  paperclipProjectId?: string;
+  repositoryUrl: string;
+}
+
 interface ResolvedPaperclipIssueGitHubLink {
   source: 'entity' | 'import_registry' | 'description';
   companyId?: string;
@@ -286,6 +292,7 @@ interface ResolvedPaperclipIssueGitHubLink {
   githubIssueNumber: number;
   githubIssueUrl: string;
   linkedPullRequestNumbers: number[];
+  entityRecord?: GitHubIssueLinkRecord;
 }
 
 interface StoredStatusTransitionCommentAnnotation {
@@ -2925,9 +2932,13 @@ function doesImportedIssueMatchTarget(
 async function resolvePaperclipIssueGitHubLink(
   ctx: PluginSetupContext,
   issueId: string,
-  companyId: string
+  companyId: string,
+  options: {
+    linkRecords?: GitHubIssueLinkRecord[];
+    paperclipIssue?: Issue | null;
+  } = {}
 ): Promise<ResolvedPaperclipIssueGitHubLink | null> {
-  const linkRecords = await listGitHubIssueLinkRecords(ctx, {
+  const linkRecords = options.linkRecords ?? await listGitHubIssueLinkRecords(ctx, {
     paperclipIssueId: issueId
   });
   const entityMatch = linkRecords.find((record) => !record.data.companyId || record.data.companyId === companyId);
@@ -2940,7 +2951,8 @@ async function resolvePaperclipIssueGitHubLink(
       githubIssueId: entityMatch.data.githubIssueId,
       githubIssueNumber: entityMatch.data.githubIssueNumber,
       githubIssueUrl: entityMatch.data.githubIssueUrl,
-      linkedPullRequestNumbers: entityMatch.data.linkedPullRequestNumbers
+      linkedPullRequestNumbers: entityMatch.data.linkedPullRequestNumbers,
+      entityRecord: entityMatch
     };
   }
 
@@ -2972,7 +2984,7 @@ async function resolvePaperclipIssueGitHubLink(
     }
   }
 
-  const issue = await ctx.issues.get(issueId, companyId);
+  const issue = options.paperclipIssue ?? await ctx.issues.get(issueId, companyId);
   const githubIssueUrl = extractImportedGitHubIssueUrlFromDescription(issue?.description);
   const githubIssueReference = githubIssueUrl ? parseGitHubIssueHtmlUrl(githubIssueUrl) : null;
   if (!githubIssueReference) {
@@ -3022,14 +3034,22 @@ async function hydrateRecoveredPaperclipIssueGitHubLink(
     const linkedPullRequests = await listLinkedPullRequestsForIssue(octokit, repository, githubIssue.number);
     const linkedPullRequestNumbers = linkedPullRequests.map((pullRequest) => pullRequest.number);
 
+    const entityRecord = buildGitHubIssueLinkRecord(
+      {
+        companyId: fallbackLink.companyId,
+        paperclipProjectId: fallbackLink.paperclipProjectId,
+        repositoryUrl: fallbackLink.repositoryUrl
+      },
+      issueId,
+      githubIssue,
+      linkedPullRequestNumbers
+    );
     await upsertGitHubIssueLinkRecord(
       ctx,
       {
-        id: `recovered:${issueId}`,
-        repositoryUrl: fallbackLink.repositoryUrl,
-        paperclipProjectName: '',
+        companyId: fallbackLink.companyId,
         paperclipProjectId: fallbackLink.paperclipProjectId,
-        companyId: fallbackLink.companyId
+        repositoryUrl: fallbackLink.repositoryUrl
       },
       issueId,
       githubIssue,
@@ -3044,7 +3064,8 @@ async function hydrateRecoveredPaperclipIssueGitHubLink(
       githubIssueId: githubIssue.id,
       githubIssueNumber: githubIssue.number,
       githubIssueUrl: normalizeGitHubIssueHtmlUrl(githubIssue.htmlUrl) ?? githubIssue.htmlUrl,
-      linkedPullRequestNumbers
+      linkedPullRequestNumbers,
+      entityRecord
     };
   } catch (error) {
     ctx.logger.warn('Unable to hydrate recovered GitHub issue metadata for a Paperclip issue fallback link.', {
@@ -3316,7 +3337,14 @@ async function buildIssueGitHubDetails(
   const linkRecords = await listGitHubIssueLinkRecords(ctx, {
     paperclipIssueId: issueId
   });
-  const entityMatch = linkRecords.find((record) => !record.data.companyId || record.data.companyId === companyId);
+  const link = await resolvePaperclipIssueGitHubLink(ctx, issueId, companyId, {
+    linkRecords
+  });
+  if (!link) {
+    return null;
+  }
+
+  const entityMatch = link.entityRecord;
   if (entityMatch) {
     return {
       paperclipIssueId: issueId,
@@ -3333,38 +3361,13 @@ async function buildIssueGitHubDetails(
     };
   }
 
-  const fallbackLink = await resolvePaperclipIssueGitHubLink(ctx, issueId, companyId);
-  if (!fallbackLink) {
-    return null;
-  }
-
-  const hydratedLinkRecords = await listGitHubIssueLinkRecords(ctx, {
-    paperclipIssueId: issueId
-  });
-  const hydratedEntityMatch = hydratedLinkRecords.find((record) => !record.data.companyId || record.data.companyId === companyId);
-  if (hydratedEntityMatch) {
-    return {
-      paperclipIssueId: issueId,
-      source: 'entity',
-      githubIssueNumber: hydratedEntityMatch.data.githubIssueNumber,
-      githubIssueUrl: hydratedEntityMatch.data.githubIssueUrl,
-      repositoryUrl: hydratedEntityMatch.data.repositoryUrl,
-      githubIssueState: hydratedEntityMatch.data.githubIssueState,
-      githubIssueStateReason: hydratedEntityMatch.data.githubIssueStateReason,
-      commentsCount: hydratedEntityMatch.data.commentsCount,
-      linkedPullRequestNumbers: hydratedEntityMatch.data.linkedPullRequestNumbers,
-      labels: hydratedEntityMatch.data.labels,
-      syncedAt: hydratedEntityMatch.data.syncedAt
-    };
-  }
-
   return {
     paperclipIssueId: issueId,
-    source: fallbackLink.source,
-    githubIssueNumber: fallbackLink.githubIssueNumber,
-    githubIssueUrl: fallbackLink.githubIssueUrl,
-    repositoryUrl: fallbackLink.repositoryUrl,
-    linkedPullRequestNumbers: fallbackLink.linkedPullRequestNumbers
+    source: link.source,
+    githubIssueNumber: link.githubIssueNumber,
+    githubIssueUrl: link.githubIssueUrl,
+    repositoryUrl: link.repositoryUrl,
+    linkedPullRequestNumbers: link.linkedPullRequestNumbers
   };
 }
 
@@ -5988,6 +5991,17 @@ function normalizeGitHubIssueHtmlUrl(value: string): string | undefined {
   return parseGitHubIssueHtmlUrl(value)?.issueUrl;
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function getHiddenGitHubImportMarkerPattern(): RegExp {
+  return new RegExp(
+    `${escapeRegExp(HIDDEN_GITHUB_IMPORT_MARKER_PREFIX)}(\\S+?)${escapeRegExp(HIDDEN_GITHUB_IMPORT_MARKER_SUFFIX)}`,
+    'i'
+  );
+}
+
 function buildGitHubIssueMarkdownLink(issueReference: ParsedGitHubIssueReference): string {
   return `[#${issueReference.issueNumber}](${issueReference.issueUrl})`;
 }
@@ -6044,7 +6058,7 @@ function extractImportedGitHubIssueUrlFromDescription(description: string | null
     return undefined;
   }
 
-  const hiddenMarkerMatch = description.match(/<!--\s*paperclip-github-plugin-imported-from:\s*(\S+?)\s*-->/i);
+  const hiddenMarkerMatch = description.match(getHiddenGitHubImportMarkerPattern());
   if (hiddenMarkerMatch) {
     return normalizeGitHubIssueHtmlUrl(hiddenMarkerMatch[1]);
   }
@@ -6624,26 +6638,23 @@ async function findStoredStatusTransitionCommentAnnotation(
   return null;
 }
 
-async function upsertGitHubIssueLinkRecord(
-  ctx: PluginSetupContext,
-  mapping: RepositoryMapping,
+function buildGitHubIssueLinkRecord(
+  target: GitHubIssueLinkTarget,
   issueId: string,
   githubIssue: GitHubIssueRecord,
   linkedPullRequestNumbers: number[]
-): Promise<void> {
+): GitHubIssueLinkRecord {
   const githubIssueUrl = normalizeGitHubIssueHtmlUrl(githubIssue.htmlUrl) ?? githubIssue.htmlUrl;
+  const repositoryUrl = parseRepositoryReference(target.repositoryUrl)?.url ?? target.repositoryUrl.trim();
 
-  await ctx.entities.upsert({
-    entityType: ISSUE_LINK_ENTITY_TYPE,
-    scopeKind: 'issue',
-    scopeId: issueId,
-    externalId: githubIssueUrl,
+  return {
+    paperclipIssueId: issueId,
     title: `GitHub issue #${githubIssue.number}`,
     status: githubIssue.state,
     data: {
-      ...(mapping.companyId ? { companyId: mapping.companyId } : {}),
-      ...(mapping.paperclipProjectId ? { paperclipProjectId: mapping.paperclipProjectId } : {}),
-      repositoryUrl: getNormalizedMappingRepositoryUrl(mapping),
+      ...(target.companyId ? { companyId: target.companyId } : {}),
+      ...(target.paperclipProjectId ? { paperclipProjectId: target.paperclipProjectId } : {}),
+      repositoryUrl,
       githubIssueId: githubIssue.id,
       githubIssueNumber: githubIssue.number,
       githubIssueUrl,
@@ -6654,6 +6665,26 @@ async function upsertGitHubIssueLinkRecord(
       labels: githubIssue.labels,
       syncedAt: new Date().toISOString()
     }
+  };
+}
+
+async function upsertGitHubIssueLinkRecord(
+  ctx: PluginSetupContext,
+  target: GitHubIssueLinkTarget,
+  issueId: string,
+  githubIssue: GitHubIssueRecord,
+  linkedPullRequestNumbers: number[]
+): Promise<void> {
+  const record = buildGitHubIssueLinkRecord(target, issueId, githubIssue, linkedPullRequestNumbers);
+
+  await ctx.entities.upsert({
+    entityType: ISSUE_LINK_ENTITY_TYPE,
+    scopeKind: 'issue',
+    scopeId: issueId,
+    externalId: record.data.githubIssueUrl,
+    ...(record.title ? { title: record.title } : {}),
+    ...(record.status ? { status: record.status } : {}),
+    data: record.data as unknown as Record<string, unknown>
   });
 }
 

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -719,17 +719,25 @@ async function waitFor(condition: () => boolean, timeoutMs = 2_000, intervalMs =
   throw new Error(`Timed out after ${timeoutMs}ms waiting for a background sync result.`);
 }
 
+function stripHiddenGitHubImportMarker(description: string): string {
+  return description
+    .replace(/\n*\s*<!--\s*paperclip-github-plugin-imported-from:\s*\S+?\s*-->\s*$/i, '')
+    .trimEnd();
+}
+
 function assertNormalizedPublicGitHubIssueDescription(description: string): void {
-  assert.doesNotMatch(description, /^\*\s+GitHub issue:/m);
-  assert.match(description, /This issue lists Renovate updates and detected dependencies\./);
-  assert.match(description, /## PR Edited \(Blocked\)/);
-  assert.match(description, /## Detected Dependencies/);
-  assert.match(description, /\n\n---\n\n/);
-  assert.doesNotMatch(description, /<!--/);
-  assert.doesNotMatch(description, /<br\s*\/?>/i);
-  assert.doesNotMatch(description, /<\/?details\b/i);
-  assert.doesNotMatch(description, /<\/?summary\b/i);
-  assert.doesNotMatch(description, /<img\b/i);
+  const visibleDescription = stripHiddenGitHubImportMarker(description);
+  assert.doesNotMatch(visibleDescription, /^\*\s+GitHub issue:/m);
+  assert.match(visibleDescription, /This issue lists Renovate updates and detected dependencies\./);
+  assert.match(visibleDescription, /## PR Edited \(Blocked\)/);
+  assert.match(visibleDescription, /## Detected Dependencies/);
+  assert.match(visibleDescription, /\n\n---\n\n/);
+  assert.doesNotMatch(visibleDescription, /<!--/);
+  assert.doesNotMatch(visibleDescription, /<br\s*\/?>/i);
+  assert.doesNotMatch(visibleDescription, /<\/?details\b/i);
+  assert.doesNotMatch(visibleDescription, /<\/?summary\b/i);
+  assert.doesNotMatch(visibleDescription, /<img\b/i);
+  assert.match(description, /<!-- paperclip-github-plugin-imported-from: https:\/\/github\.com\//);
 }
 
 test('resolveCliAuthPollUrl prefixes the Paperclip API base path for challenge polling', () => {
@@ -6726,7 +6734,10 @@ test('worker strips NUL bytes from GitHub issue text before creating imported Pa
     const importedIssue = importedIssues.find((issue) => issue.title === 'Import survives  NUL bytes');
 
     assert.ok(importedIssue);
-    assert.equal(importedIssue?.description, 'First line\n\nSecond line after the hidden byte.');
+    assert.equal(
+      stripHiddenGitHubImportMarker(importedIssue?.description ?? ''),
+      'First line\n\nSecond line after the hidden byte.'
+    );
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -7740,6 +7751,209 @@ test('worker resyncs imported issue descriptions when the GitHub body changes la
   }
 });
 
+test('get_issue resolves imported Paperclip issues from the hidden description marker when registry and entities are missing', async () => {
+  const harness = await createGitHubAgentToolHarness();
+  const originalFetch = globalThis.fetch;
+  const originalEntityList = harness.ctx.entities.list.bind(harness.ctx.entities);
+
+  const importedIssue = await harness.ctx.issues.create({
+    companyId: 'company-1',
+    projectId: 'project-1',
+    title: 'Fallback marker import',
+    description: 'Body imported from GitHub.\n\n<!-- paperclip-github-plugin-imported-from: https://github.com/paperclipai/example-repo/issues/31 -->'
+  });
+
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(getRequestUrl(input));
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues/31') {
+      return jsonResponse({
+        id: 3101,
+        number: 31,
+        title: 'Fallback marker import',
+        body: 'Body imported from GitHub.',
+        html_url: 'https://github.com/paperclipai/example-repo/issues/31',
+        state: 'open',
+        comments: 0,
+        user: {
+          login: 'octocat'
+        },
+        assignees: [],
+        labels: [],
+        milestone: null
+      });
+    }
+
+    if (url.pathname === '/repos/paperclipai/example-repo/pulls/311') {
+      return jsonResponse({
+        number: 311,
+        title: 'Linked PR from fallback issue metadata',
+        body: 'Fixes the imported issue.',
+        html_url: 'https://github.com/paperclipai/example-repo/pull/311',
+        state: 'open',
+        draft: false,
+        merged: false,
+        mergeable: true,
+        mergeable_state: 'clean',
+        head: {
+          ref: 'feature/fallback-link',
+          sha: 'abc123'
+        },
+        base: {
+          ref: 'main'
+        },
+        user: {
+          login: 'octocat'
+        },
+        requested_reviewers: [],
+        requested_teams: []
+      });
+    }
+
+    if (url.pathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      const issueNumber = typeof variables.issueNumber === 'number' ? variables.issueNumber : undefined;
+      const pullRequestNumber = typeof variables.pullRequestNumber === 'number' ? variables.pullRequestNumber : undefined;
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && issueNumber === 31) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: 31,
+              state: 'OPEN',
+              stateReason: null,
+              comments: {
+                totalCount: 0
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: [
+                  {
+                    number: 311,
+                    state: 'OPEN',
+                    repository: {
+                      owner: {
+                        login: 'paperclipai'
+                      },
+                      name: 'example-repo'
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubPullRequestReviewThreads') && pullRequestNumber === 311) {
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: []
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubPullRequestCiContexts') && pullRequestNumber === 311) {
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              statusCheckRollup: {
+                contexts: {
+                  pageInfo: {
+                    hasNextPage: false,
+                    endCursor: null
+                  },
+                  nodes: []
+                }
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    await harness.ctx.state.set(
+      {
+        scopeKind: 'instance',
+        stateKey: 'paperclip-github-plugin-import-registry'
+      },
+      []
+    );
+
+    harness.ctx.entities.list = async (input) => {
+      if (
+        input &&
+        typeof input === 'object' &&
+        'entityType' in input &&
+        (input as { entityType?: unknown }).entityType === 'paperclip-github-plugin.issue-link'
+      ) {
+        return [];
+      }
+
+      return originalEntityList(input);
+    };
+
+    const result = await harness.executeTool('get_issue', {
+      paperclipIssueId: importedIssue.id
+    }, {
+      companyId: 'company-1',
+      projectId: 'project-1'
+    });
+
+    assert.ok(!result.error);
+    assert.equal((result.data as { repository: string }).repository, 'https://github.com/paperclipai/example-repo');
+    assert.equal((result.data as { issue: { number: number } }).issue.number, 31);
+    assert.equal(
+      (result.data as { issue: { url: string } }).issue.url,
+      'https://github.com/paperclipai/example-repo/issues/31'
+    );
+
+    const details = await harness.getData<{
+      source: string;
+      linkedPullRequestNumbers: number[];
+      githubIssueNumber: number;
+    } | null>('issue.githubDetails', {
+      companyId: 'company-1',
+      issueId: importedIssue.id
+    });
+
+    assert.equal(details?.source, 'entity');
+    assert.equal(details?.githubIssueNumber, 31);
+    assert.deepEqual(details?.linkedPullRequestNumbers, [311]);
+
+    const inferredPullRequest = await harness.executeTool('get_pull_request', {
+      paperclipIssueId: importedIssue.id
+    }, {
+      companyId: 'company-1',
+      projectId: 'project-1'
+    });
+
+    assert.ok(!inferredPullRequest.error);
+    assert.equal(
+      (inferredPullRequest.data as { pullRequest: { number: number } }).pullRequest.number,
+      311
+    );
+  } finally {
+    harness.ctx.entities.list = originalEntityList;
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('worker repairs missing descriptions for newly created issues through the local Paperclip issue PATCH API', async () => {
   const harness = createTestHarness({
     manifest,
@@ -7894,14 +8108,17 @@ test('worker repairs missing descriptions for newly created issues through the l
     const descriptionPatchRequests = patchRequests.filter((request) => typeof request.body?.description === 'string');
     assert.equal(descriptionPatchRequests.length, 1);
     assert.equal(directDescriptionUpdateCalls.length, 0);
-    assert.equal(String(descriptionPatchRequests[0]?.body?.description ?? ''), 'Imported body');
+    assert.equal(
+      stripHiddenGitHubImportMarker(String(descriptionPatchRequests[0]?.body?.description ?? '')),
+      'Imported body'
+    );
 
     const importedIssue = (await harness.ctx.issues.list({
       companyId: 'company-1'
     })).find((issue) => issue.title === 'Description repaired after create');
 
     assert.ok(importedIssue);
-    assert.equal(importedIssue?.description ?? '', 'Imported body');
+    assert.equal(stripHiddenGitHubImportMarker(importedIssue?.description ?? ''), 'Imported body');
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -8555,15 +8772,17 @@ test('worker normalizes GitHub raw HTML that Paperclip issue descriptions cannot
     assert.ok(importedIssue);
 
     const description = importedIssue?.description ?? '';
-    assert.doesNotMatch(description, /^\*\s+GitHub issue:/m);
-    assert.match(description, /First line\nSecond line/);
-    assert.match(description, /\n\n### Preview\n\nInside details/);
-    assert.match(description, /!\[Diagram\]\(https:\/\/example\.com\/diagram\.png\)/);
-    assert.doesNotMatch(description, /<!--/);
-    assert.doesNotMatch(description, /<br\s*\/?>/i);
-    assert.doesNotMatch(description, /<\/?details\b/i);
-    assert.doesNotMatch(description, /<\/?summary\b/i);
-    assert.doesNotMatch(description, /<img\b/i);
+    const visibleDescription = stripHiddenGitHubImportMarker(description);
+    assert.doesNotMatch(visibleDescription, /^\*\s+GitHub issue:/m);
+    assert.match(visibleDescription, /First line\nSecond line/);
+    assert.match(visibleDescription, /\n\n### Preview\n\nInside details/);
+    assert.match(visibleDescription, /!\[Diagram\]\(https:\/\/example\.com\/diagram\.png\)/);
+    assert.doesNotMatch(visibleDescription, /<!--/);
+    assert.doesNotMatch(visibleDescription, /<br\s*\/?>/i);
+    assert.doesNotMatch(visibleDescription, /<\/?details\b/i);
+    assert.doesNotMatch(visibleDescription, /<\/?summary\b/i);
+    assert.doesNotMatch(visibleDescription, /<img\b/i);
+    assert.match(description, /<!-- paperclip-github-plugin-imported-from: https:\/\/github\.com\/paperclipai\/example-repo\/issues\/10 -->/);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -10561,7 +10780,10 @@ test('worker uses the local Paperclip issue PATCH API for status transitions whe
     assert.equal(statusPatchRequests[0]?.issueId, importedIssue.id);
     assert.equal(statusPatchRequests[0]?.body?.status, 'todo');
     assert.equal(statusPatchRequests[0]?.body?.comment, undefined);
-    assert.equal(String(descriptionPatchRequests[0]?.body?.description ?? ''), 'Body');
+    assert.equal(
+      stripHiddenGitHubImportMarker(String(descriptionPatchRequests[0]?.body?.description ?? '')),
+      'Body'
+    );
     assert.equal(directStatusUpdateCalls.length, 0);
     assert.equal(directCommentCalls.length, 1);
     assert.equal(apiTransitionComments.length, 0);


### PR DESCRIPTION
## Summary
- Add a hidden HTML comment marker to imported issue descriptions so GitHub-origin issues remain machine-identifiable without visible metadata noise
- Hydrate recovered GitHub issue links from fallback metadata, including linked PR numbers, and backfill the durable issue-link entity for future agent/tool lookups
- Address review feedback by removing redundant issue-link entity reads, sharing the hidden-marker parser/writer contract, and decoupling recovered link upserts from the full mapping shape

## Testing
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Model Used
- Exact model ID/version: unavailable from runtime metadata
- Context window size: unavailable from runtime metadata
- Capability details: Codex coding agent with terminal/tool use and patch-based file editing
