### PR TITLE
Fix reopened GitHub issue sync to move completed work back to todo

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ When the local Paperclip API is available, the plugin also syncs labels by name,
 Additional behavior:
 
 - Open imported issues that are already in `backlog` stay in `backlog` until someone changes them in Paperclip.
+- If an imported issue is `done` or `cancelled` and GitHub shows it open again with no linked pull request, sync moves it to `todo` so agents can pick it up again.
 - Trusted new GitHub comments from the original issue author or a verified maintainer/admin can move an open imported issue back to `todo`.
 - When the sync changes a Paperclip issue status, it adds a Paperclip comment explaining what changed and why.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -75,6 +75,7 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 - An open GitHub issue without a linked PR MUST map to the configured default Paperclip status when it is first imported, and that default MUST be `backlog` when the company has not chosen another status.
 - If an imported Paperclip issue is currently `backlog` and its linked GitHub issue is still open, the sync flow MUST preserve `backlog`; only a manual Paperclip transition may move it out of `backlog`.
 - If a Paperclip issue that came from an open GitHub issue without a linked PR is later moved out of `backlog`, the sync flow SHOULD preserve that Paperclip status until another open-issue GitHub rule applies.
+- If that Paperclip issue is currently `done` or `cancelled` while the linked GitHub issue is open with no linked PR, the sync flow MUST move it to `todo` instead of `backlog` so it re-enters the active queue.
 - An open GitHub issue with a linked PR that still has unfinished CI jobs MUST map to Paperclip `in_progress`.
 - An open GitHub issue with a linked PR that has red CI jobs or unresolved review threads MUST map to Paperclip `todo`.
 - An open GitHub issue with a linked PR that has green CI and all review threads resolved MUST map to Paperclip `in_review`.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5243,7 +5243,7 @@ function resolvePaperclipIssueStatus(params: {
   }
 
   if (currentStatus === 'done' || currentStatus === 'cancelled') {
-    return 'backlog';
+    return 'todo';
   }
 
   return currentStatus;

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -10795,6 +10795,146 @@ test('worker falls back to the SDK bridge when the local Paperclip status PATCH 
   }
 });
 
+test('worker moves reopened imported issues with no linked pull requests from done back to todo', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubTokenRef: 'github-secret-ref'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+  harness.ctx.secrets.resolve = async () => 'github-token';
+
+  await harness.performAction('settings.saveRegistration', {
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  const originalUpdate = harness.ctx.issues.update;
+  const originalCreateComment = harness.ctx.issues.createComment;
+
+  const importedIssue = await harness.ctx.issues.create({
+    companyId: 'company-1',
+    projectId: 'project-1',
+    title: 'Reopened issue should re-enter the queue',
+    description: '* GitHub issue: [#45](https://github.com/paperclipai/example-repo/issues/45)\n\n---\n\nBody'
+  });
+  await originalUpdate(importedIssue.id, { status: 'done' }, 'company-1');
+
+  await harness.ctx.state.set(
+    {
+      scopeKind: 'instance',
+      stateKey: 'paperclip-github-plugin-import-registry'
+    },
+    [
+      {
+        mappingId: 'mapping-a',
+        githubIssueId: 4501,
+        githubIssueNumber: 45,
+        paperclipIssueId: importedIssue.id,
+        importedAt: '2026-04-09T09:00:00.000Z',
+        lastSeenCommentCount: 0,
+        repositoryUrl: 'https://github.com/paperclipai/example-repo',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ]
+  );
+
+  const transitionComments: Array<{ issueId: string; body: string }> = [];
+  harness.ctx.issues.createComment = async (issueId, body, companyId) => {
+    transitionComments.push({ issueId, body });
+    return originalCreateComment(issueId, body, companyId);
+  };
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    const rawUrl = getRequestUrl(input);
+    const url = new URL(rawUrl);
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues' && ['all', 'open'].includes(url.searchParams.get('state') ?? '')) {
+      return jsonResponse([
+        {
+          id: 4501,
+          number: 45,
+          title: 'Reopened issue should re-enter the queue',
+          body: 'Body',
+          html_url: 'https://github.com/paperclipai/example-repo/issues/45',
+          state: 'open',
+          comments: 0
+        }
+      ]);
+    }
+
+    if (url.pathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      const issueNumber = typeof variables.issueNumber === 'number' ? variables.issueNumber : undefined;
+
+      if (query.includes('query GitHubIssueParentRelationships')) {
+        return graphqlIssueParentRelationshipsResponse([
+          {
+            issueNumber: 45
+          }
+        ]);
+      }
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && issueNumber === 45) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: 45,
+              state: 'OPEN',
+              stateReason: null,
+              comments: {
+                totalCount: 0
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: []
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    const sync = await harness.performAction('sync.runNow', {
+      waitForCompletion: true
+    }) as {
+      syncState: { status: string };
+    };
+
+    assert.equal(sync.syncState.status, 'success');
+    assert.equal((await harness.ctx.issues.get(importedIssue.id, 'company-1'))?.status, 'todo');
+    assert.equal(transitionComments.length, 1);
+    assert.equal(transitionComments[0]?.issueId, importedIssue.id);
+    assert.match(transitionComments[0]?.body ?? '', /from `done` to `todo`/);
+    assert.match(
+      transitionComments[0]?.body ?? '',
+      /the GitHub issue is open with no linked pull requests/
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('worker only resets imported issues to todo for new comments from the issue author or repository maintainers', async () => {
   const harness = createTestHarness({
     manifest,


### PR DESCRIPTION
## Summary
- Change GitHub Sync to move imported issues from `done` or `cancelled` to `todo` when GitHub shows them open with no linked pull request
- Keep existing `backlog` behavior for newly imported issues and issues that are already manually kept in `backlog`
- Add a regression test for the reopened-issue path and update the documented status-mapping contract

## Testing
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`

## Model Used
- Runtime: Codex, GPT-5-based coding assistant
- Exact model ID/version: Not exposed by the runtime in this session
- Context window size: Not exposed by the runtime in this session
- Capabilities: tool-assisted local code editing and verification