### PR TITLE
Improve sync smoke coverage and issue triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ When the local Paperclip API is available, the plugin also syncs labels by name,
 
 | GitHub condition | Paperclip status |
 | --- | --- |
+| Open issue with no linked pull request, created by a repository maintainer | `todo` on first import |
 | Open issue with no linked pull request | Configured default status, which defaults to `backlog` |
 | Open issue with a linked pull request and unfinished CI | `in_progress` |
 | Open issue with failing CI or unresolved review threads | `todo` |
@@ -137,6 +138,7 @@ When the local Paperclip API is available, the plugin also syncs labels by name,
 
 Additional behavior:
 
+- Open issues with no linked pull request that are created by a verified repository maintainer/admin bypass the default imported status and start in `todo`.
 - Open imported issues that are already in `backlog` stay in `backlog` until someone changes them in Paperclip.
 - If an imported issue is `done` or `cancelled` and GitHub shows it open again with no linked pull request, sync moves it to `todo` so agents can pick it up again.
 - Trusted new GitHub comments from the original issue author or a verified maintainer/admin can move an open imported issue back to `todo`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -73,7 +73,8 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 - Repeated sync runs MUST continue reconciling imported Paperclip issue statuses against the latest GitHub state.
 - When the local Paperclip host API is available, sync-driven Paperclip status transitions SHOULD go through the same issue-update path Paperclip UI uses so timeline activity is recorded for agents and humans.
 - Repeated sync runs MUST continue reconciling imported Paperclip issue labels against the latest mapped GitHub labels, including removing labels that were removed on GitHub.
-- An open GitHub issue without a linked PR MUST map to the configured default Paperclip status when it is first imported, and that default MUST be `backlog` when the company has not chosen another status.
+- An open GitHub issue without a linked PR that was created by a repository maintainer/admin MUST map to Paperclip `todo` when it is first imported.
+- An open GitHub issue without a linked PR MUST otherwise map to the configured default Paperclip status when it is first imported, and that default MUST be `backlog` when the company has not chosen another status.
 - If an imported Paperclip issue is currently `backlog` and its linked GitHub issue is still open, the sync flow MUST preserve `backlog`; only a manual Paperclip transition may move it out of `backlog`.
 - If a Paperclip issue that came from an open GitHub issue without a linked PR is later moved out of `backlog`, the sync flow SHOULD preserve that Paperclip status until another open-issue GitHub rule applies.
 - If that Paperclip issue is currently `done` or `cancelled` while the linked GitHub issue is open with no linked PR, the sync flow MUST move it to `todo` instead of `backlog` so it re-enters the active queue.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dev": "node ./scripts/build.mjs --watch",
     "dev:ui": "paperclip-plugin-dev-server --root . --ui-dir dist/ui --port 4177",
     "prepack": "pnpm build",
-    "test": "tsx --test tests/plugin.spec.ts",
+    "test": "node --test tests/build-script.spec.mjs && tsx --test tests/plugin.spec.ts",
     "test:e2e": "pnpm build && pnpm exec playwright install chromium && node ./scripts/e2e/run-paperclip-smoke.mjs",
     "typecheck": "tsc --noEmit",
     "verify:manual": "pnpm build && pnpm exec playwright install chromium && node ./scripts/e2e/manual-paperclip-verify.mjs"

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -3,8 +3,6 @@ import { mkdir, readFile, rm } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { build, context } from 'esbuild';
-
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(__dirname, '..');
 const outdir = resolve(packageRoot, 'dist');
@@ -14,6 +12,36 @@ const pluginVersion =
   process.env.PLUGIN_VERSION?.trim()
   || (typeof packageJson.version === 'string' && packageJson.version.trim())
   || '0.0.0-dev';
+
+function isMissingDependencyError(error, packageName) {
+  return (
+    error
+    && typeof error === 'object'
+    && 'code' in error
+    && error.code === 'ERR_MODULE_NOT_FOUND'
+    && 'message' in error
+    && typeof error.message === 'string'
+    && error.message.includes(`'${packageName}'`)
+  );
+}
+
+async function loadEsbuild() {
+  try {
+    return await import('esbuild');
+  } catch (error) {
+    if (isMissingDependencyError(error, 'esbuild')) {
+      console.error(
+        '[paperclip-github-plugin] Missing build dependency "esbuild". '
+        + 'Run `pnpm install` in this checkout before running `pnpm build`, `pnpm test:e2e`, or `pnpm verify:manual`.'
+      );
+      process.exit(1);
+    }
+
+    throw error;
+  }
+}
+
+const { build, context } = await loadEsbuild();
 
 await rm(outdir, { recursive: true, force: true });
 await mkdir(resolve(outdir, 'ui'), { recursive: true });

--- a/scripts/e2e/run-paperclip-smoke.mjs
+++ b/scripts/e2e/run-paperclip-smoke.mjs
@@ -15,6 +15,10 @@ const dataDir = join(stateRoot, 'paperclip-data');
 const instanceId = 'paperclip-github-plugin-e2e';
 const seededProjectName = 'Paperclip Github Plugin';
 const seededRepositoryUrl = 'https://github.com/alvarosanchez/paperclip-github-plugin';
+const seededIssueTitle = 'GitHub Sync Smoke Issue';
+const seededGitHubIssueUrl = 'https://github.com/paperclipai/example-repo/issues/999';
+const seededGitHubPullRequestUrl = 'https://github.com/paperclipai/example-repo/pull/1000';
+const issueDetailTabQuery = 'plugin:paperclip-github-plugin:paperclip-github-plugin-issue-detail-tab';
 const requestedPort = process.env.PAPERCLIP_E2E_PORT ? Number(process.env.PAPERCLIP_E2E_PORT) : 3100;
 const requestedDbPort = process.env.PAPERCLIP_E2E_DB_PORT ? Number(process.env.PAPERCLIP_E2E_DB_PORT) : 54329;
 const defaultTimeoutMs = 30000;
@@ -124,12 +128,16 @@ async function readConfiguredBaseUrl(configPath) {
 }
 
 async function fetchJson(url, init = {}) {
+  const headers = new Headers(init.headers);
+  headers.set('accept', 'application/json');
+
+  if (typeof init.body === 'string' && !headers.has('content-type')) {
+    headers.set('content-type', 'application/json');
+  }
+
   const response = await fetch(url, {
-    headers: {
-      'content-type': 'application/json',
-      ...(init.headers ?? {})
-    },
-    ...init
+    ...init,
+    headers
   });
 
   const text = await response.text();
@@ -318,6 +326,91 @@ async function ensureSeedProjectMapped(company) {
   };
 }
 
+function buildSeedIssueDescription() {
+  return [
+    'Smoke coverage for GitHub issue detail fallback rendering.',
+    '',
+    `<!-- paperclip-github-plugin-imported-from: ${seededGitHubIssueUrl} -->`
+  ].join('\n');
+}
+
+function buildSeedIssueCommentBody() {
+  return `See ${seededGitHubIssueUrl} and ${seededGitHubPullRequestUrl}`;
+}
+
+function resolveCompanyIssuePrefix(company, issueIdentifier) {
+  const companyIssuePrefix =
+    company
+    && typeof company === 'object'
+    && typeof company.issuePrefix === 'string'
+    && company.issuePrefix.trim()
+      ? company.issuePrefix.trim()
+      : '';
+
+  if (companyIssuePrefix) {
+    return companyIssuePrefix;
+  }
+
+  if (typeof issueIdentifier === 'string' && issueIdentifier.includes('-')) {
+    return issueIdentifier.split('-', 1)[0];
+  }
+
+  throw new Error('Could not resolve the issue route prefix for the smoke-test issue.');
+}
+
+async function ensureSeedIssueWithGitHubMetadata(company, project) {
+  const companyId = typeof company?.id === 'string' ? company.id : '';
+  if (!companyId) {
+    throw new Error('A seeded company id is required before creating the smoke-test issue.');
+  }
+
+  const projectId = typeof project?.id === 'string' ? project.id : '';
+  if (!projectId) {
+    throw new Error('A seeded project id is required before creating the smoke-test issue.');
+  }
+
+  const createdIssue = await fetchJson(new URL(`/api/companies/${companyId}/issues`, baseUrl).toString(), {
+    method: 'POST',
+    body: JSON.stringify({
+      projectId,
+      title: seededIssueTitle,
+      description: buildSeedIssueDescription()
+    })
+  });
+  const issueId = typeof createdIssue?.id === 'string' ? createdIssue.id : '';
+  const issueIdentifier = typeof createdIssue?.identifier === 'string' ? createdIssue.identifier : '';
+
+  if (!issueId || !issueIdentifier) {
+    throw new Error('Paperclip did not return a usable smoke-test issue record.');
+  }
+
+  const createdComment = await fetchJson(new URL(`/api/issues/${issueId}/comments`, baseUrl).toString(), {
+    method: 'POST',
+    body: JSON.stringify({
+      body: buildSeedIssueCommentBody()
+    })
+  });
+  const commentId = typeof createdComment?.id === 'string' ? createdComment.id : '';
+
+  if (!commentId) {
+    throw new Error('Paperclip did not return a usable smoke-test issue comment.');
+  }
+
+  const companyIssuePrefix = resolveCompanyIssuePrefix(company, issueIdentifier);
+  const issueUrl = new URL(
+    `/${companyIssuePrefix}/issues/${encodeURIComponent(issueIdentifier)}?tab=${encodeURIComponent(issueDetailTabQuery)}`,
+    baseUrl
+  ).toString();
+
+  log(`Seeded issue ${issueIdentifier} with GitHub fallback metadata and comment links.`);
+  return {
+    id: issueId,
+    identifier: issueIdentifier,
+    commentId,
+    url: issueUrl
+  };
+}
+
 async function waitForServerExit(timeoutMs) {
   if (!serverProcess) {
     return;
@@ -417,6 +510,8 @@ async function main() {
   );
   log('Installed local paperclip-github-plugin plugin.');
 
+  const seededIssue = await ensureSeedIssueWithGitHubMetadata(company, seededProject);
+
   const { chromium } = await import('playwright');
   const browser = await chromium.launch({ headless: true });
   const page = await browser.newPage();
@@ -436,6 +531,11 @@ async function main() {
     const settingsUrl = new URL(href, baseUrl).toString();
     await gotoWithTimeout(page, settingsUrl);
     log(`Opened plugin settings detail page: ${settingsUrl}`);
+
+    const installedPluginId = new URL(settingsUrl).pathname.split('/').filter(Boolean).at(-1) ?? '';
+    if (!installedPluginId) {
+      throw new Error(`Could not resolve the installed plugin id from ${settingsUrl}.`);
+    }
 
     await page.getByRole('heading', { name: 'GitHub Sync' }).waitFor({ timeout: 120000 });
     await page.getByText('GitHub Sync settings', { exact: true }).waitFor({ timeout: 120000 });
@@ -469,6 +569,29 @@ async function main() {
     await pullRequestsSidebarLink.click();
     await page.getByRole('heading', { name: 'Open pull requests' }).waitFor({ timeout: 120000 });
     await page.getByText('alvarosanchez/paperclip-github-plugin', { exact: true }).waitFor({ timeout: 120000 });
+    const pullRequestsUrl = page.url();
+
+    await gotoWithTimeout(page, seededIssue.url);
+    log(`Opened smoke-test issue detail page: ${seededIssue.url}`);
+
+    await page.getByRole('heading', { name: seededIssueTitle, exact: true }).waitFor({ timeout: 120000 });
+    const githubDetailTab = page.getByRole('tab', { name: 'GitHub', exact: true });
+    await githubDetailTab.click();
+
+    const issueDetailSurface = page.locator('.ghsync-issue-detail');
+    await issueDetailSurface.getByText('Issue #999', { exact: true }).waitFor({ timeout: 120000 });
+    await issueDetailSurface.getByText('paperclipai/example-repo', { exact: true }).waitFor({ timeout: 120000 });
+    const openOnGitHubLink = issueDetailSurface.getByRole('link', { name: 'Open on GitHub', exact: true });
+    await openOnGitHubLink.waitFor({ timeout: 120000 });
+    const openOnGitHubHref = await openOnGitHubLink.getAttribute('href');
+    if (openOnGitHubHref !== seededGitHubIssueUrl) {
+      throw new Error(`Expected issue detail GitHub link to target ${seededGitHubIssueUrl}, received ${openOnGitHubHref ?? 'null'}.`);
+    }
+
+    await page.getByRole('tab', { name: 'Chat', exact: true }).click();
+    await page.getByText(`See ${seededGitHubIssueUrl} and ${seededGitHubPullRequestUrl}`, { exact: true }).waitFor({
+      timeout: 120000
+    });
 
     await page.screenshot({ path: join(pluginRoot, 'tests/e2e/results/last-run.png'), fullPage: true });
     const bodyText = await page.locator('body').textContent();
@@ -479,7 +602,11 @@ async function main() {
           baseUrl,
           settingsUrl,
           dashboardUrl,
-          pullRequestsUrl: page.url(),
+          pullRequestsUrl,
+          issueUrl: seededIssue.url,
+          installedPluginId,
+          seededIssueIdentifier: seededIssue.identifier,
+          seededIssueCommentId: seededIssue.commentId,
           bodyText
         },
         null,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1076,6 +1076,7 @@ const FAILED_CHECK_RUN_CONCLUSIONS = new Set([
 const SUCCESSFUL_STATUS_CONTEXT_STATES = new Set(['SUCCESS']);
 const FAILED_STATUS_CONTEXT_STATES = new Set(['ERROR', 'FAILURE']);
 const PENDING_STATUS_CONTEXT_STATES = new Set(['EXPECTED', 'PENDING']);
+const GITHUB_REPOSITORY_MAINTAINER_WARMUP_CONCURRENCY = 4;
 const GITHUB_REPOSITORY_MAINTAINER_ROLE_NAMES = new Set(['admin', 'maintain']);
 
 const GITHUB_ISSUE_STATUS_SNAPSHOT_QUERY = `
@@ -5996,6 +5997,42 @@ async function isMaintainerAuthoredGitHubIssue(params: {
     authorLogin,
     params.maintainerCache
   );
+}
+
+async function warmGitHubRepositoryMaintainerCache(params: {
+  octokit: Octokit;
+  repository: ParsedRepositoryReference;
+  githubIssues: GitHubIssueRecord[];
+  maintainerCache: Map<string, boolean>;
+}): Promise<void> {
+  const uniqueAuthorLogins = [...new Set(
+    params.githubIssues
+      .map((issue) => normalizeGitHubUserLogin(issue.authorLogin))
+      .filter((authorLogin): authorLogin is string => Boolean(authorLogin))
+  )].filter((authorLogin) => !params.maintainerCache.has(buildGitHubRepositoryActorCacheKey(params.repository, authorLogin)));
+
+  if (uniqueAuthorLogins.length === 0) {
+    return;
+  }
+
+  await mapWithConcurrency(uniqueAuthorLogins, GITHUB_REPOSITORY_MAINTAINER_WARMUP_CONCURRENCY, async (authorLogin) => {
+    try {
+      await isGitHubUserRepositoryMaintainer(
+        params.octokit,
+        params.repository,
+        authorLogin,
+        params.maintainerCache
+      );
+    } catch (error) {
+      if (isGitHubRateLimitError(error)) {
+        throw error;
+      }
+
+      // Keep non-rate-limit failures recoverable by letting the later
+      // per-issue path retry and attach any resulting failure to the
+      // affected issue instead of failing the whole warmup step.
+    }
+  });
 }
 
 function parseGitHubIssueHtmlUrl(value: string): ParsedGitHubIssueReference | undefined {
@@ -12930,6 +12967,32 @@ async function performSync(
           allIssuesById.has(importedIssue.githubIssueId) &&
           doesImportedIssueMatchTarget(importedIssue, options.target)
         );
+        const newlyImportedIssuesForMaintainerWarmup: GitHubIssueRecord[] =
+          advancedSettings.defaultStatus === 'todo'
+            ? []
+            : importedIssuesForSynchronization
+                .filter((importedIssue) => createdIssueIds.has(importedIssue.githubIssueId))
+                .map((importedIssue) => allIssuesById.get(importedIssue.githubIssueId))
+                .filter(
+                  (githubIssue): githubIssue is GitHubIssueRecord =>
+                    githubIssue !== undefined && githubIssue.state === 'open'
+                )
+                .filter(
+                  (githubIssue) => !(linkedPullRequestsByIssueNumber.get(githubIssue.number) ?? []).some(
+                    (pullRequest) => pullRequest.state === 'OPEN'
+                  )
+                );
+
+        if (newlyImportedIssuesForMaintainerWarmup.length > 0) {
+          await warmGitHubRepositoryMaintainerCache({
+            octokit,
+            repository,
+            githubIssues: newlyImportedIssuesForMaintainerWarmup,
+            maintainerCache: repositoryMaintainerCache
+          });
+          await throwIfSyncCancelled();
+        }
+
         currentProgress = {
           phase: 'syncing',
           totalRepositoryCount: mappings.length,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5201,8 +5201,9 @@ function describeGitHubStatusTransitionReason(params: {
   snapshot: GitHubIssueStatusSnapshot;
   previousCommentCount?: number;
   hasTrustedNewComment?: boolean;
+  maintainerAuthoredImportedIssue?: boolean;
 }): string {
-  const { snapshot, previousCommentCount, hasTrustedNewComment } = params;
+  const { snapshot, previousCommentCount, hasTrustedNewComment, maintainerAuthoredImportedIssue } = params;
 
   if (snapshot.state === 'closed') {
     switch (snapshot.stateReason) {
@@ -5221,6 +5222,10 @@ function describeGitHubStatusTransitionReason(params: {
   }
 
   if (snapshot.linkedPullRequests.length === 0) {
+    if (maintainerAuthoredImportedIssue) {
+      return 'the GitHub issue is open with no linked pull requests and was created by a repository maintainer';
+    }
+
     return 'the GitHub issue is open with no linked pull requests';
   }
 
@@ -5274,15 +5279,25 @@ function buildPaperclipIssueStatusTransitionComment(params: {
   snapshot: GitHubIssueStatusSnapshot;
   previousCommentCount?: number;
   hasTrustedNewComment?: boolean;
+  maintainerAuthoredImportedIssue?: boolean;
 }): {
   body: string;
   annotation: StoredStatusTransitionCommentAnnotation;
 } {
-  const { previousStatus, nextStatus, repository, snapshot, previousCommentCount, hasTrustedNewComment } = params;
+  const {
+    previousStatus,
+    nextStatus,
+    repository,
+    snapshot,
+    previousCommentCount,
+    hasTrustedNewComment,
+    maintainerAuthoredImportedIssue
+  } = params;
   const reason = describeGitHubStatusTransitionReason({
     snapshot,
     previousCommentCount,
-    hasTrustedNewComment
+    hasTrustedNewComment,
+    maintainerAuthoredImportedIssue
   });
 
   return {
@@ -5304,6 +5319,7 @@ function resolvePaperclipIssueStatus(params: {
   hasTrustedNewComment?: boolean;
   wasImportedThisRun: boolean;
   defaultImportedStatus: PaperclipIssueStatus;
+  maintainerAuthoredImportedIssue?: boolean;
 }): PaperclipIssueStatus {
   const {
     currentStatus,
@@ -5311,7 +5327,8 @@ function resolvePaperclipIssueStatus(params: {
     previousCommentCount,
     hasTrustedNewComment,
     wasImportedThisRun,
-    defaultImportedStatus
+    defaultImportedStatus,
+    maintainerAuthoredImportedIssue
   } = params;
 
   if (snapshot.state === 'closed') {
@@ -5334,7 +5351,7 @@ function resolvePaperclipIssueStatus(params: {
   }
 
   if (wasImportedThisRun) {
-    return defaultImportedStatus;
+    return maintainerAuthoredImportedIssue ? 'todo' : defaultImportedStatus;
   }
 
   if (currentStatus === 'done' || currentStatus === 'cancelled') {
@@ -5960,6 +5977,25 @@ async function hasTrustedNewGitHubIssueComment(params: {
   }
 
   return false;
+}
+
+async function isMaintainerAuthoredGitHubIssue(params: {
+  octokit: Octokit;
+  repository: ParsedRepositoryReference;
+  githubIssue: GitHubIssueRecord;
+  maintainerCache: Map<string, boolean>;
+}): Promise<boolean> {
+  const authorLogin = normalizeGitHubUserLogin(params.githubIssue.authorLogin);
+  if (!authorLogin) {
+    return false;
+  }
+
+  return isGitHubUserRepositoryMaintainer(
+    params.octokit,
+    params.repository,
+    authorLogin,
+    params.maintainerCache
+  );
 }
 
 function parseGitHubIssueHtmlUrl(value: string): ParsedGitHubIssueReference | undefined {
@@ -8516,13 +8552,27 @@ async function synchronizePaperclipIssueStatuses(
               currentCommentCount: snapshot.commentCount,
               maintainerCache: repositoryMaintainerCache
             });
+      const wasImportedThisRun = createdIssueIds.has(importedIssue.githubIssueId);
+      const maintainerAuthoredImportedIssue =
+        wasImportedThisRun &&
+        advancedSettings.defaultStatus !== 'todo' &&
+        snapshot.state === 'open' &&
+        snapshot.linkedPullRequests.length === 0
+          ? await isMaintainerAuthoredGitHubIssue({
+              octokit,
+              repository,
+              githubIssue,
+              maintainerCache: repositoryMaintainerCache
+            })
+          : false;
       const nextStatus = resolvePaperclipIssueStatus({
         currentStatus: paperclipIssue.status,
         snapshot,
         previousCommentCount,
         hasTrustedNewComment,
-        wasImportedThisRun: createdIssueIds.has(importedIssue.githubIssueId),
-        defaultImportedStatus: advancedSettings.defaultStatus
+        wasImportedThisRun,
+        defaultImportedStatus: advancedSettings.defaultStatus,
+        maintainerAuthoredImportedIssue
       });
 
       importedIssue.githubIssueNumber = githubIssue.number;
@@ -8538,7 +8588,8 @@ async function synchronizePaperclipIssueStatuses(
         repository,
         snapshot,
         previousCommentCount,
-        hasTrustedNewComment
+        hasTrustedNewComment,
+        maintainerAuthoredImportedIssue
       });
 
       updateSyncFailureContext(syncFailureContext, {

--- a/tests/build-script.spec.mjs
+++ b/tests/build-script.spec.mjs
@@ -1,0 +1,40 @@
+import { execFile } from 'node:child_process';
+import { strict as assert } from 'node:assert';
+import { cp, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+test('build script reports missing local dependencies clearly when node_modules is absent', async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), 'paperclip-github-plugin-build-no-deps-'));
+
+  try {
+    await cp(new URL('../scripts', import.meta.url), join(tempDir, 'scripts'), { recursive: true });
+    await writeFile(join(tempDir, 'package.json'), JSON.stringify({
+      name: 'paperclip-github-plugin-test-fixture',
+      version: '0.0.0-test',
+      type: 'module'
+    }, null, 2));
+
+    let failure = null;
+
+    try {
+      await execFileAsync(process.execPath, [join(tempDir, 'scripts/build.mjs')], {
+        cwd: tempDir
+      });
+    } catch (error) {
+      failure = error;
+    }
+
+    assert.ok(failure, 'expected build.mjs to fail without installed dependencies');
+    const output = `${failure?.stdout ?? ''}\n${failure?.stderr ?? ''}`;
+
+    assert.match(output, /Missing build dependency "esbuild"/);
+    assert.match(output, /Run `pnpm install`/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -6329,6 +6329,159 @@ test('worker keeps deduplicating imported issues when the mapping id changes', a
   }
 });
 
+test('worker imports maintainer-authored open issues without linked pull requests as todo', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubTokenRef: 'github-secret-ref'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+
+  await harness.performAction('settings.saveRegistration', {
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  const statusTransitionComments: Array<{ issueId: string; body: string }> = [];
+  const originalCreateComment = harness.ctx.issues.createComment;
+  harness.ctx.issues.createComment = async (issueId, body, companyId) => {
+    statusTransitionComments.push({ issueId, body });
+    return originalCreateComment(issueId, body, companyId);
+  };
+
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (input, init) => {
+    const rawUrl = getRequestUrl(input);
+    const url = new URL(rawUrl);
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues' && ['all', 'open'].includes(url.searchParams.get('state') ?? '')) {
+      return jsonResponse([
+        {
+          id: 2601,
+          number: 26,
+          title: 'Maintainer-authored issue',
+          body: 'Ship this next',
+          html_url: 'https://github.com/paperclipai/example-repo/issues/26',
+          user: {
+            login: 'repo-maintainer'
+          },
+          state: 'open',
+          comments: 0
+        },
+        {
+          id: 2602,
+          number: 27,
+          title: 'Reporter-authored issue',
+          body: 'Please look into this',
+          html_url: 'https://github.com/paperclipai/example-repo/issues/27',
+          user: {
+            login: 'external-reporter'
+          },
+          state: 'open',
+          comments: 0
+        }
+      ]);
+    }
+
+    if (url.pathname === '/repos/paperclipai/example-repo/collaborators/repo-maintainer/permission') {
+      return jsonResponse({
+        permission: 'admin',
+        role_name: 'maintain',
+        user: {
+          login: 'repo-maintainer'
+        }
+      });
+    }
+
+    if (url.pathname === '/repos/paperclipai/example-repo/collaborators/external-reporter/permission') {
+      return jsonResponse(
+        {
+          message: 'Not Found'
+        },
+        404
+      );
+    }
+
+    if (url.pathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      const issueNumber = typeof variables.issueNumber === 'number' ? variables.issueNumber : undefined;
+
+      if (query.includes('query GitHubIssueParentRelationships')) {
+        return graphqlIssueParentRelationshipsResponse([
+          {
+            issueNumber: 26
+          },
+          {
+            issueNumber: 27
+          }
+        ]);
+      }
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && (issueNumber === 26 || issueNumber === 27)) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: issueNumber,
+              state: 'OPEN',
+              stateReason: null,
+              comments: {
+                totalCount: 0
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: []
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    const sync = await harness.performAction('sync.runNow', {}) as {
+      syncState: { status: string; createdIssuesCount?: number; skippedIssuesCount?: number; syncedIssuesCount?: number };
+    };
+
+    assert.equal(sync.syncState.status, 'success');
+    assert.equal(sync.syncState.createdIssuesCount, 2);
+    assert.equal(sync.syncState.skippedIssuesCount, 0);
+    assert.equal(sync.syncState.syncedIssuesCount, 2);
+
+    const importedIssues = await harness.ctx.issues.list({
+      companyId: 'company-1'
+    });
+
+    assert.equal(importedIssues.find((issue) => issue.title === 'Maintainer-authored issue')?.status, 'todo');
+    assert.equal(importedIssues.find((issue) => issue.title === 'Reporter-authored issue')?.status, 'backlog');
+    assert.equal(statusTransitionComments.length, 1);
+    assert.match(statusTransitionComments[0]?.body ?? '', /from `todo` to `backlog`/);
+    assert.match(
+      statusTransitionComments[0]?.body ?? '',
+      /the GitHub issue is open with no linked pull requests/
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('worker repairs missing import registry entries by reusing existing imported Paperclip issues', async () => {
   const harness = createTestHarness({
     manifest,
@@ -10818,6 +10971,48 @@ test('worker uses the local Paperclip issue PATCH API for status transitions whe
   } finally {
     globalThis.fetch = originalFetch;
   }
+});
+
+test('comment.annotation falls back to GitHub links found in plain issue comments', async () => {
+  const harness = createTestHarness({
+    manifest
+  });
+  await plugin.definition.setup(harness.ctx);
+
+  const issue = await harness.ctx.issues.create({
+    companyId: 'company-1',
+    projectId: 'project-1',
+    title: 'Comment annotation fallback issue',
+    description: 'Body'
+  });
+  const comment = await harness.ctx.issues.createComment(
+    issue.id,
+    'See https://github.com/paperclipai/example-repo/issues/999 and https://github.com/paperclipai/example-repo/pull/1000',
+    'company-1'
+  );
+
+  const annotation = await harness.getData<{
+    source: string;
+    links: Array<{ type: string; label: string; href: string }>;
+  } | null>('comment.annotation', {
+    companyId: 'company-1',
+    parentIssueId: issue.id,
+    commentId: comment.id
+  });
+
+  assert.equal(annotation?.source, 'comment_body');
+  assert.deepEqual(annotation?.links, [
+    {
+      type: 'issue',
+      label: 'Issue #999',
+      href: 'https://github.com/paperclipai/example-repo/issues/999'
+    },
+    {
+      type: 'pull_request',
+      label: 'PR #1000',
+      href: 'https://github.com/paperclipai/example-repo/pull/1000'
+    }
+  ]);
 });
 
 test('worker falls back to the SDK bridge when the local Paperclip status PATCH returns an HTML sign-in page', async () => {


### PR DESCRIPTION
## Summary

- add hosted smoke coverage for the GitHub issue detail tab and seeded comment-link fallback rendering
- harden the build script when `esbuild` is missing, add a dedicated regression test, and run that check from `pnpm test`
- import maintainer-authored open issues without linked pull requests as `todo`, with docs and contract coverage for the new rule

## Why

- The hosted smoke flow was missing issue-detail and comment-annotation coverage in the real Paperclip host.
- The build script previously failed with a generic module error when local dependencies were missing.
- Sync needed an exception so repository maintainers opening no-PR issues can land directly in the active Paperclip queue.

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm build`

## Model Used

- Model ID/version: `gpt-5` via Codex Desktop (the host environment did not expose a more specific backend version string)
- Context window: not exposed by the host environment
- Capability details: tool-using coding agent with shell, git, and web-assisted repository inspection; standard Codex desktop reasoning flow
