### PR TITLE
Enable isolated issue checkouts and GitHub org project tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ GitHub tokens and sync cadence are shared at the plugin instance level, while re
 
 ### Project binding that respects existing work
 
-If a company already has a Paperclip project bound to a GitHub repository workspace, the settings UI can reuse that project instead of creating a duplicate. New mappings can also create and bind a Paperclip project automatically.
+If a company already has a Paperclip project bound to a GitHub repository workspace, the settings UI can reuse that project instead of creating a duplicate. New mappings can also create and bind a Paperclip project automatically, and those newly created projects opt into isolated issue checkouts.
 
 ### Status sync with delivery context
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ With this plugin, you can:
 - configure mappings and import defaults per Paperclip company
 - run sync manually or on a schedule
 - triage open pull requests from mapped Paperclip projects in a hosted queue
-- give Paperclip agents native GitHub tools for issues, pull requests, CI, and review threads
+- give Paperclip agents native GitHub tools for issues, pull requests, CI, review threads, and org-level projects
 
 ## What you get in Paperclip
 
@@ -67,7 +67,7 @@ Paperclip issue linkage on the queue prefers the GitHub issue that the pull requ
 
 ### Agent workflows built in
 
-Paperclip agents can search GitHub for duplicates, read and update issues, post comments, create pull requests, inspect changed files and CI, reply to review threads, resolve or unresolve threads, and request reviewers without leaving the Paperclip plugin surface.
+Paperclip agents can search GitHub for duplicates, read and update issues, post comments, create pull requests, inspect changed files and CI, reply to review threads, resolve or unresolve threads, request reviewers, list org-level GitHub Projects, and associate pull requests with those projects without leaving the Paperclip plugin surface.
 
 ## Requirements
 
@@ -177,6 +177,7 @@ The plugin exposes GitHub workflow tools to Paperclip agents, including:
 - issue reads, comment reads, comment writes, and metadata updates
 - pull request creation, reads, updates, changed-file inspection, and CI-check inspection
 - review-thread reads, replies, resolve and unresolve actions, and reviewer requests
+- organization-level GitHub Project listing and pull-request-to-project association
 
 When an agent posts a GitHub comment or review-thread reply through the plugin, the message includes a footer disclosing that it was created by a Paperclip AI agent and which model was used.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -93,6 +93,7 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 
 - Saving a mapping MUST create or reuse the target Paperclip project.
 - Saving a company-scoped mapping from the settings page MUST create or reuse the target Paperclip project in that same company.
+- When the settings page creates a new target Paperclip project, it MUST set `executionWorkspacePolicy.enabled` to `true` so the project opts into isolated issue checkouts.
 - Saving a mapping for a Paperclip project that is already bound to the GitHub repository MUST reuse that existing project instead of creating a duplicate workspace binding.
 - Saving a mapping MUST bind the GitHub repository URL to the Paperclip project workspace.
 - Once a project has been created and linked, its project name field SHOULD be treated as read-only in the settings UI.

--- a/SPEC.md
+++ b/SPEC.md
@@ -48,7 +48,7 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 - A manual sync requested from a company-scoped settings or dashboard view MUST only sync repository mappings for that company.
 - The worker SHOULD support targeted manual sync requests for a specific mapped Paperclip project or imported Paperclip issue.
 - The plugin MUST declare a scheduled job that ticks every minute and only performs a scheduled sync when the saved frequency is due.
-- The plugin MUST expose agent tools for the GitHub issue and pull request workflow around synced work, including repository-item search, issue reads and updates, issue comment reads and writes, pull request creation and updates, pull request file and CI inspection, review-thread reads and replies, review-thread resolution changes, and pull request reviewer requests.
+- The plugin MUST expose agent tools for the GitHub issue and pull request workflow around synced work, including repository-item search, issue reads and updates, issue comment reads and writes, pull request creation and updates, pull request file and CI inspection, review-thread reads and replies, review-thread resolution changes, pull request reviewer requests, organization-level GitHub Project listing, and associating pull requests with organization-level GitHub Projects.
 - Agent tools that post GitHub comments or review-thread replies MUST require the caller to identify the LLM used and MUST append a footer that discloses that a Paperclip AI agent created the message and which LLM was used.
 - The sync flow MUST fetch open GitHub issues from every configured repository.
 - The sync flow MUST ignore GitHub issues whose author username matches a configured ignored username for that mapping company.

--- a/src/github-agent-tools.ts
+++ b/src/github-agent-tools.ts
@@ -5,6 +5,11 @@ const repositoryProperty = {
   description: 'GitHub repository as owner/repo or https://github.com/owner/repo. Omit when the current Paperclip project has exactly one mapped repository.'
 } as const;
 
+const organizationProperty = {
+  type: 'string',
+  description: 'GitHub organization login that owns the Projects.'
+} as const;
+
 const paperclipIssueIdProperty = {
   type: 'string',
   description: 'Paperclip issue id used to infer the linked GitHub issue and repository when available.'
@@ -20,6 +25,17 @@ const pullRequestNumberProperty = {
   type: 'integer',
   minimum: 1,
   description: 'GitHub pull request number.'
+} as const;
+
+const projectIdProperty = {
+  type: 'string',
+  description: 'GitHub ProjectV2 node id. You can use the id returned by list_organization_projects.'
+} as const;
+
+const projectNumberProperty = {
+  type: 'integer',
+  minimum: 1,
+  description: 'GitHub organization project number. Requires organization when projectId is not provided.'
 } as const;
 
 const llmModelProperty = {
@@ -45,6 +61,17 @@ const pullRequestTargetSchema = {
     },
     {
       required: ['pullRequestNumber']
+    }
+  ]
+} as const;
+
+const organizationProjectTargetSchema = {
+  anyOf: [
+    {
+      required: ['projectId']
+    },
+    {
+      required: ['organization', 'projectNumber']
     }
   ]
 } as const;
@@ -431,6 +458,51 @@ export const GITHUB_AGENT_TOOLS: PluginToolDeclaration[] = [
           required: ['pullRequestNumber', 'teamReviewers']
         }
       ]
+    }
+  },
+  {
+    name: 'list_organization_projects',
+    displayName: 'List Organization Projects',
+    description: 'List GitHub organization-level Projects so an agent can choose where to associate pull requests.',
+    parametersSchema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['organization'],
+      properties: {
+        organization: organizationProperty,
+        includeClosed: {
+          type: 'boolean',
+          description: 'Include closed Projects in the results. Defaults to false.'
+        },
+        query: {
+          type: 'string',
+          description: 'Optional free-text filter matched against project titles and descriptions after loading the organization projects.'
+        },
+        limit: {
+          type: 'integer',
+          minimum: 1,
+          maximum: 100,
+          description: 'Maximum number of projects to return.'
+        }
+      }
+    }
+  },
+  {
+    name: 'add_pull_request_to_project',
+    displayName: 'Add Pull Request To Project',
+    description: 'Associate a GitHub pull request with an organization-level GitHub Project.',
+    parametersSchema: {
+      type: 'object',
+      additionalProperties: false,
+      allOf: [pullRequestTargetSchema, organizationProjectTargetSchema],
+      properties: {
+        repository: repositoryProperty,
+        pullRequestNumber: pullRequestNumberProperty,
+        paperclipIssueId: paperclipIssueIdProperty,
+        projectId: projectIdProperty,
+        organization: organizationProperty,
+        projectNumber: projectNumberProperty
+      }
     }
   }
 ];

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -5745,7 +5745,7 @@ function useResolvedThemeMode(): ThemeMode {
   return themeMode;
 }
 
-async function resolveOrCreateProject(companyId: string, projectName: string): Promise<{ id: string; name: string }> {
+export async function resolveOrCreateProject(companyId: string, projectName: string): Promise<{ id: string; name: string }> {
   const projects = await listCompanyProjects(companyId);
   const existing = projects.find((project) => project.name.trim().toLowerCase() === projectName.trim().toLowerCase());
   if (existing) {
@@ -5756,7 +5756,10 @@ async function resolveOrCreateProject(companyId: string, projectName: string): P
     method: 'POST',
     body: JSON.stringify({
       name: projectName.trim(),
-      status: 'planned'
+      status: 'planned',
+      executionWorkspacePolicy: {
+        enabled: true
+      }
     })
   });
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -831,6 +831,64 @@ interface GitHubReviewThreadRecord {
   totalCommentCount?: number;
 }
 
+interface GitHubProjectV2OwnerRecord {
+  __typename?: string | null;
+  login?: string | null;
+}
+
+interface GitHubProjectV2Node {
+  id?: string | null;
+  number?: number | null;
+  title?: string | null;
+  shortDescription?: string | null;
+  url?: string | null;
+  closed?: boolean | null;
+  updatedAt?: string | null;
+  owner?: GitHubProjectV2OwnerRecord | null;
+}
+
+interface GitHubOrganizationProjectsQueryResult {
+  organization?: {
+    projectsV2?: {
+      pageInfo?: GitHubPageInfo | null;
+      nodes?: Array<GitHubProjectV2Node | null> | null;
+    } | null;
+  } | null;
+}
+
+interface GitHubOrganizationProjectByNumberQueryResult {
+  organization?: {
+    projectV2?: GitHubProjectV2Node | null;
+  } | null;
+}
+
+interface GitHubPullRequestProjectItemsQueryResult {
+  repository?: {
+    pullRequest?: {
+      id?: string | null;
+      number?: number | null;
+      title?: string | null;
+      url?: string | null;
+      projectItems?: {
+        pageInfo?: GitHubPageInfo | null;
+        nodes?: Array<{
+          id?: string | null;
+          project?: GitHubProjectV2Node | null;
+        } | null> | null;
+      } | null;
+    } | null;
+  } | null;
+}
+
+interface GitHubAddPullRequestToProjectMutationResult {
+  addProjectV2ItemById?: {
+    item?: {
+      id?: string | null;
+      project?: GitHubProjectV2Node | null;
+    } | null;
+  } | null;
+}
+
 interface GitHubPullRequestLinkEntityData {
   companyId?: string;
   paperclipProjectId?: string;
@@ -1062,6 +1120,22 @@ interface SyncProcessingFailure {
   error: unknown;
   context: SyncFailureContext;
   occurredAt: string;
+}
+
+interface GitHubProjectRecord {
+  id: string;
+  number: number;
+  title: string;
+  url: string;
+  closed: boolean;
+  shortDescription?: string;
+  updatedAt?: string;
+  ownerLogin?: string;
+}
+
+interface GitHubPullRequestProjectItemRecord {
+  id: string;
+  project: GitHubProjectRecord;
 }
 
 const SUCCESSFUL_CHECK_RUN_CONCLUSIONS = new Set(['SUCCESS', 'NEUTRAL', 'SKIPPED']);
@@ -1506,6 +1580,118 @@ const GITHUB_PULL_REQUEST_REVIEW_THREADS_DETAILED_QUERY = `
                   id
                 }
               }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const GITHUB_ORGANIZATION_PROJECTS_QUERY = `
+  query GitHubOrganizationProjects($organization: String!, $after: String, $first: Int!) {
+    organization(login: $organization) {
+      projectsV2(first: $first, after: $after, orderBy: { field: UPDATED_AT, direction: DESC }) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          number
+          title
+          shortDescription
+          url
+          closed
+          updatedAt
+        }
+      }
+    }
+  }
+`;
+
+const GITHUB_ORGANIZATION_PROJECT_BY_NUMBER_QUERY = `
+  query GitHubOrganizationProjectByNumber($organization: String!, $projectNumber: Int!) {
+    organization(login: $organization) {
+      projectV2(number: $projectNumber) {
+        id
+        number
+        title
+        url
+        closed
+        owner {
+          __typename
+          ... on Organization {
+            login
+          }
+          ... on User {
+            login
+          }
+        }
+      }
+    }
+  }
+`;
+
+const GITHUB_PULL_REQUEST_PROJECT_ITEMS_QUERY = `
+  query GitHubPullRequestProjectItems($owner: String!, $repo: String!, $pullRequestNumber: Int!, $after: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pullRequestNumber) {
+        id
+        number
+        title
+        url
+        projectItems(first: 100, after: $after) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          nodes {
+            id
+            project {
+              id
+              number
+              title
+              url
+              closed
+              owner {
+                __typename
+                ... on Organization {
+                  login
+                }
+                ... on User {
+                  login
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const GITHUB_ADD_PULL_REQUEST_TO_PROJECT_MUTATION = `
+  mutation GitHubAddPullRequestToProject($projectId: ID!, $contentId: ID!) {
+    addProjectV2ItemById(input: {
+      projectId: $projectId
+      contentId: $contentId
+    }) {
+      item {
+        id
+        project {
+          id
+          number
+          title
+          url
+          closed
+          owner {
+            __typename
+            ... on Organization {
+              login
+            }
+            ... on User {
+              login
             }
           }
         }
@@ -9390,6 +9576,240 @@ async function resolveGitHubPullRequestToolTarget(
   };
 }
 
+function normalizeGitHubProjectRecord(
+  project: GitHubProjectV2Node | null | undefined,
+  fallbackOwnerLogin?: string
+): GitHubProjectRecord | null {
+  const id = normalizeOptionalString(project?.id);
+  const title = normalizeOptionalString(project?.title);
+  const url = normalizeOptionalString(project?.url);
+  const number =
+    typeof project?.number === 'number' && Number.isInteger(project.number) && project.number > 0
+      ? Math.floor(project.number)
+      : null;
+
+  if (!id || !title || !url || number === null) {
+    return null;
+  }
+
+  const shortDescription = normalizeOptionalString(project?.shortDescription);
+  const updatedAt = normalizeOptionalString(project?.updatedAt);
+  const ownerLogin = normalizeOptionalString(project?.owner?.login) ?? fallbackOwnerLogin;
+
+  return {
+    id,
+    number,
+    title,
+    url,
+    closed: project?.closed === true,
+    ...(shortDescription ? { shortDescription } : {}),
+    ...(updatedAt ? { updatedAt } : {}),
+    ...(ownerLogin ? { ownerLogin } : {})
+  };
+}
+
+function buildGitHubProjectToolData(
+  project: GitHubProjectRecord,
+  options?: {
+    includeOwnerLogin?: boolean;
+  }
+): Record<string, unknown> {
+  return {
+    id: project.id,
+    number: project.number,
+    title: project.title,
+    ...(project.shortDescription ? { shortDescription: project.shortDescription } : {}),
+    url: project.url,
+    closed: project.closed,
+    ...(project.updatedAt ? { updatedAt: project.updatedAt } : {}),
+    ...(options?.includeOwnerLogin && project.ownerLogin ? { ownerLogin: project.ownerLogin } : {})
+  };
+}
+
+function matchesGitHubProjectFilter(project: GitHubProjectRecord, query?: string): boolean {
+  const normalizedQuery = normalizeOptionalString(query)?.toLowerCase();
+  if (!normalizedQuery) {
+    return true;
+  }
+
+  return [project.title, project.shortDescription]
+    .filter((value): value is string => Boolean(value))
+    .some((value) => value.toLowerCase().includes(normalizedQuery));
+}
+
+async function listGitHubOrganizationProjects(
+  octokit: Octokit,
+  organization: string,
+  options?: {
+    includeClosed?: boolean;
+    query?: string;
+    limit?: number;
+  }
+): Promise<GitHubProjectRecord[]> {
+  const normalizedOrganization = normalizeOptionalString(organization);
+  if (!normalizedOrganization) {
+    throw new Error('organization is required.');
+  }
+
+  const includeClosed = options?.includeClosed === true;
+  const limit = Math.min(normalizeToolPositiveInteger(options?.limit) ?? 20, 100);
+  const projects: GitHubProjectRecord[] = [];
+  let after: string | undefined;
+
+  do {
+    const response = await octokit.graphql<GitHubOrganizationProjectsQueryResult>(
+      GITHUB_ORGANIZATION_PROJECTS_QUERY,
+      {
+        organization: normalizedOrganization,
+        first: Math.min(50, Math.max(1, limit)),
+        after
+      }
+    );
+
+    if (!response.organization) {
+      throw new Error(`GitHub organization ${normalizedOrganization} was not found or is not visible to the configured token.`);
+    }
+
+    const connection = response.organization.projectsV2;
+    for (const node of connection?.nodes ?? []) {
+      const project = normalizeGitHubProjectRecord(node, normalizedOrganization);
+      if (!project) {
+        continue;
+      }
+
+      if (!includeClosed && project.closed) {
+        continue;
+      }
+
+      if (!matchesGitHubProjectFilter(project, options?.query)) {
+        continue;
+      }
+
+      projects.push(project);
+      if (projects.length >= limit) {
+        return projects;
+      }
+    }
+
+    after = getPageCursor(connection?.pageInfo);
+  } while (after);
+
+  return projects;
+}
+
+async function resolveGitHubProjectToolTarget(
+  octokit: Octokit,
+  input: Record<string, unknown>
+): Promise<{
+  projectId: string;
+  project?: GitHubProjectRecord;
+}> {
+  const explicitProjectId = normalizeOptionalString(input.projectId);
+  if (explicitProjectId) {
+    return {
+      projectId: explicitProjectId
+    };
+  }
+
+  const organization = normalizeOptionalToolString(input.organization);
+  const projectNumber = normalizeToolPositiveInteger(input.projectNumber);
+  if (!organization || projectNumber === undefined) {
+    throw new Error('Provide either projectId or both organization and projectNumber.');
+  }
+
+  const response = await octokit.graphql<GitHubOrganizationProjectByNumberQueryResult>(
+    GITHUB_ORGANIZATION_PROJECT_BY_NUMBER_QUERY,
+    {
+      organization,
+      projectNumber
+    }
+  );
+  const project = normalizeGitHubProjectRecord(response.organization?.projectV2, organization);
+  if (!project) {
+    throw new Error(`GitHub organization project #${projectNumber} was not found in ${organization}.`);
+  }
+
+  return {
+    projectId: project.id,
+    project
+  };
+}
+
+async function getGitHubPullRequestProjectItems(
+  octokit: Octokit,
+  repository: ParsedRepositoryReference,
+  pullRequestNumber: number
+): Promise<{
+  pullRequestId: string;
+  pullRequest: {
+    number: number;
+    title: string;
+    url: string;
+  };
+  projectItems: GitHubPullRequestProjectItemRecord[];
+}> {
+  const projectItems: GitHubPullRequestProjectItemRecord[] = [];
+  let after: string | undefined;
+  let pullRequestId: string | undefined;
+  let pullRequestTitle: string | undefined;
+  let pullRequestUrl: string | undefined;
+
+  do {
+    const response = await octokit.graphql<GitHubPullRequestProjectItemsQueryResult>(
+      GITHUB_PULL_REQUEST_PROJECT_ITEMS_QUERY,
+      {
+        owner: repository.owner,
+        repo: repository.repo,
+        pullRequestNumber,
+        after
+      }
+    );
+
+    const pullRequest = response.repository?.pullRequest;
+    const currentPullRequestId = normalizeOptionalString(pullRequest?.id);
+    const currentPullRequestTitle = normalizeOptionalString(pullRequest?.title);
+    const currentPullRequestUrl = normalizeOptionalString(pullRequest?.url);
+
+    if (!currentPullRequestId || !currentPullRequestTitle || !currentPullRequestUrl) {
+      throw new Error(`GitHub pull request #${pullRequestNumber} was not found in ${formatRepositoryLabel(repository)}.`);
+    }
+
+    pullRequestId ??= currentPullRequestId;
+    pullRequestTitle ??= currentPullRequestTitle;
+    pullRequestUrl ??= currentPullRequestUrl;
+
+    const connection = response.repository?.pullRequest?.projectItems;
+    for (const node of connection?.nodes ?? []) {
+      const itemId = normalizeOptionalString(node?.id);
+      const project = normalizeGitHubProjectRecord(node?.project);
+      if (!itemId || !project) {
+        continue;
+      }
+
+      projectItems.push({
+        id: itemId,
+        project
+      });
+    }
+
+    after = getPageCursor(connection?.pageInfo);
+  } while (after);
+
+  if (!pullRequestId || !pullRequestTitle || !pullRequestUrl) {
+    throw new Error(`GitHub pull request #${pullRequestNumber} was not found in ${formatRepositoryLabel(repository)}.`);
+  }
+
+  return {
+    pullRequestId,
+    pullRequest: {
+      number: pullRequestNumber,
+      title: pullRequestTitle,
+      url: pullRequestUrl
+    },
+    projectItems
+  };
+}
+
 function formatAiAuthorshipFooter(llmModel: string): string {
   return `\n\n---\n${AI_AUTHORED_COMMENT_FOOTER_PREFIX}${llmModel.trim()}.`;
 }
@@ -14012,6 +14432,100 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
           pullRequestNumber: target.pullRequestNumber,
           requestedReviewers: (response.data.requested_reviewers ?? []).map((reviewer) => reviewer?.login ?? '').filter(Boolean),
           requestedTeams: (response.data.requested_teams ?? []).map((team) => team?.slug ?? '').filter(Boolean)
+        }
+      );
+    })
+  );
+
+  ctx.tools.register(
+    'list_organization_projects',
+    getGitHubAgentToolDeclaration('list_organization_projects'),
+    async (params) => executeGitHubTool(async () => {
+      const input = getToolInputRecord(params);
+      const organization = normalizeOptionalToolString(input.organization);
+      if (!organization) {
+        throw new Error('organization is required.');
+      }
+
+      const octokit = await createGitHubToolOctokit(ctx);
+      const projects = await listGitHubOrganizationProjects(octokit, organization, {
+        includeClosed: input.includeClosed === true,
+        query: normalizeOptionalToolString(input.query),
+        limit: normalizeToolPositiveInteger(input.limit)
+      });
+
+      return buildToolSuccessResult(
+        `Loaded ${projects.length} GitHub organization ${projects.length === 1 ? 'project' : 'projects'} from ${organization}.`,
+        {
+          organization,
+          projects: projects.map((project) => buildGitHubProjectToolData(project))
+        }
+      );
+    })
+  );
+
+  ctx.tools.register(
+    'add_pull_request_to_project',
+    getGitHubAgentToolDeclaration('add_pull_request_to_project'),
+    async (params, runCtx) => executeGitHubTool(async () => {
+      const input = getToolInputRecord(params);
+      const target = await resolveGitHubPullRequestToolTarget(ctx, runCtx, input);
+      const octokit = await createGitHubToolOctokit(ctx);
+      const projectTarget = await resolveGitHubProjectToolTarget(octokit, input);
+      const pullRequest = await getGitHubPullRequestProjectItems(
+        octokit,
+        target.repository,
+        target.pullRequestNumber
+      );
+      const existingProjectItem = pullRequest.projectItems.find((item) => item.project.id === projectTarget.projectId);
+
+      if (existingProjectItem) {
+        return buildToolSuccessResult(
+          `Pull request #${target.pullRequestNumber} is already associated with GitHub project #${existingProjectItem.project.number}.`,
+          {
+            repository: target.repository.url,
+            pullRequest: pullRequest.pullRequest,
+            project: buildGitHubProjectToolData(existingProjectItem.project, {
+              includeOwnerLogin: true
+            }),
+            projectItem: {
+              id: existingProjectItem.id
+            },
+            alreadyAssociated: true
+          }
+        );
+      }
+
+      const response = await octokit.graphql<GitHubAddPullRequestToProjectMutationResult>(
+        GITHUB_ADD_PULL_REQUEST_TO_PROJECT_MUTATION,
+        {
+          projectId: projectTarget.projectId,
+          contentId: pullRequest.pullRequestId
+        }
+      );
+      const projectItemId = normalizeOptionalString(response.addProjectV2ItemById?.item?.id);
+      const project =
+        normalizeGitHubProjectRecord(
+          response.addProjectV2ItemById?.item?.project,
+          projectTarget.project?.ownerLogin
+        ) ?? projectTarget.project;
+
+      if (!projectItemId || !project) {
+        throw new Error('GitHub did not return the created project item.');
+      }
+
+      return buildToolSuccessResult(
+        `Added pull request #${target.pullRequestNumber} to GitHub project #${project.number}.`,
+        {
+          repository: target.repository.url,
+          pullRequest: pullRequest.pullRequest,
+          project: buildGitHubProjectToolData(project, {
+            includeOwnerLogin: true
+          }),
+          projectItem: {
+            id: projectItemId
+          },
+          alreadyAssociated: false
         }
       );
     })

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -21,6 +21,7 @@ import {
 
 let plugin!: typeof import('../src/worker.ts').default;
 let workerImportSerial = 0;
+let uiImportSerial = 0;
 
 async function importFreshWorkerModule() {
   workerImportSerial += 1;
@@ -30,6 +31,12 @@ async function importFreshWorkerModule() {
 
 async function importFreshWorker(): Promise<typeof import('../src/worker.ts').default> {
   return (await importFreshWorkerModule()).default;
+}
+
+async function importFreshUiModule() {
+  uiImportSerial += 1;
+  const uiModuleUrl = new URL(`../src/ui/index.tsx?ui-test=${uiImportSerial}`, import.meta.url);
+  return await import(uiModuleUrl.href);
 }
 
 test.beforeEach(async () => {
@@ -482,6 +489,60 @@ test('filterExistingProjectSyncCandidates hides projects already enabled in plug
       sourceType: 'git_repo'
     }
   ]);
+});
+
+test('resolveOrCreateProject enables isolated issue checkouts for new company projects', async () => {
+  const uiModule = await importFreshUiModule() as {
+    resolveOrCreateProject?: unknown;
+  };
+
+  assert.equal(typeof uiModule.resolveOrCreateProject, 'function');
+
+  const resolveOrCreateProject = uiModule.resolveOrCreateProject as (
+    companyId: string,
+    projectName: string
+  ) => Promise<{ id: string; name: string }>;
+  const originalFetch = globalThis.fetch;
+  const requestBodies: Record<string, unknown>[] = [];
+
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = getRequestUrl(input);
+    const method = (init?.method ?? 'GET').toUpperCase();
+
+    if (url === '/api/companies/company-1/projects' && method === 'GET') {
+      return jsonResponse([]);
+    }
+
+    if (url === '/api/companies/company-1/projects' && method === 'POST') {
+      requestBodies.push(getJsonRequestBody(init) ?? {});
+      return jsonResponse({
+        id: 'project-1',
+        name: 'Engineering'
+      });
+    }
+
+    throw new Error(`Unexpected fetch request: ${method} ${url}`);
+  };
+
+  try {
+    const project = await resolveOrCreateProject('company-1', ' Engineering ');
+
+    assert.deepEqual(project, {
+      id: 'project-1',
+      name: 'Engineering'
+    });
+    assert.deepEqual(requestBodies, [
+      {
+        name: 'Engineering',
+        status: 'planned',
+        executionWorkspacePolicy: {
+          enabled: true
+        }
+      }
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 test('resolveInstalledGitHubSyncPluginId finds the GitHub Sync installation id from plugin listings', () => {

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -859,7 +859,9 @@ test('manifest declares the GitHub agent tools and capability', () => {
       'reply_to_review_thread',
       'resolve_review_thread',
       'unresolve_review_thread',
-      'request_pull_request_reviewers'
+      'request_pull_request_reviewers',
+      'list_organization_projects',
+      'add_pull_request_to_project'
     ]
   );
   assert.match(
@@ -1415,6 +1417,334 @@ test('request_pull_request_reviewers sends user and team reviewers to GitHub', a
       team_reviewers: ['platform']
     });
     assert.equal((result.data as { requestedReviewers: string[] }).requestedReviewers[0], 'octocat');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('list_organization_projects returns visible GitHub organization projects', async () => {
+  const harness = await createGitHubAgentToolHarness();
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (input, init) => {
+    const requestUrl = getRequestUrl(input);
+    if (requestUrl === 'https://api.github.com/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      if (query.includes('query GitHubOrganizationProjects')) {
+        assert.equal(variables.organization, 'paperclipai');
+        assert.equal(variables.first, 5);
+
+        return graphqlResponse({
+          organization: {
+            projectsV2: {
+              pageInfo: {
+                hasNextPage: false,
+                endCursor: null
+              },
+              nodes: [
+                {
+                  id: 'PVT_kwDOB_project_1',
+                  number: 12,
+                  title: 'Q2 roadmap',
+                  shortDescription: 'Track platform delivery',
+                  url: 'https://github.com/orgs/paperclipai/projects/12',
+                  closed: false,
+                  updatedAt: '2026-04-17T10:15:00Z'
+                },
+                {
+                  id: 'PVT_kwDOB_project_2',
+                  number: 15,
+                  title: 'Bug backlog',
+                  shortDescription: null,
+                  url: 'https://github.com/orgs/paperclipai/projects/15',
+                  closed: false,
+                  updatedAt: '2026-04-16T08:00:00Z'
+                }
+              ]
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected GitHub request: ${requestUrl}`);
+  };
+
+  try {
+    const result = await harness.executeTool('list_organization_projects', {
+      organization: 'paperclipai',
+      limit: 5
+    }, {
+      companyId: 'company-1',
+      projectId: 'project-1'
+    });
+
+    assert.ok(!result.error);
+    assert.equal((result.data as { organization: string }).organization, 'paperclipai');
+    assert.deepEqual(
+      (result.data as {
+        projects: Array<{ number: number; title: string; shortDescription?: string; url: string }>;
+      }).projects,
+      [
+        {
+          id: 'PVT_kwDOB_project_1',
+          number: 12,
+          title: 'Q2 roadmap',
+          shortDescription: 'Track platform delivery',
+          url: 'https://github.com/orgs/paperclipai/projects/12',
+          closed: false,
+          updatedAt: '2026-04-17T10:15:00Z'
+        },
+        {
+          id: 'PVT_kwDOB_project_2',
+          number: 15,
+          title: 'Bug backlog',
+          url: 'https://github.com/orgs/paperclipai/projects/15',
+          closed: false,
+          updatedAt: '2026-04-16T08:00:00Z'
+        }
+      ]
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('add_pull_request_to_project associates a pull request with a GitHub organization project', async () => {
+  const harness = await createGitHubAgentToolHarness();
+  const originalFetch = globalThis.fetch;
+  let mutationVariables: Record<string, unknown> | null = null;
+
+  globalThis.fetch = async (input, init) => {
+    const requestUrl = getRequestUrl(input);
+    if (requestUrl === 'https://api.github.com/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+
+      if (query.includes('query GitHubOrganizationProjectByNumber')) {
+        assert.equal(variables.organization, 'paperclipai');
+        assert.equal(variables.projectNumber, 12);
+
+        return graphqlResponse({
+          organization: {
+            projectV2: {
+              id: 'PVT_kwDOB_project_12',
+              number: 12,
+              title: 'Q2 roadmap',
+              url: 'https://github.com/orgs/paperclipai/projects/12',
+              closed: false,
+              owner: {
+                __typename: 'Organization',
+                login: 'paperclipai'
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubPullRequestProjectItems')) {
+        assert.equal(variables.owner, 'paperclipai');
+        assert.equal(variables.repo, 'example-repo');
+        assert.equal(variables.pullRequestNumber, 7);
+
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              id: 'PR_kwDOB_example_7',
+              number: 7,
+              title: 'Fix the importer',
+              url: 'https://github.com/paperclipai/example-repo/pull/7',
+              projectItems: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: []
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('mutation GitHubAddPullRequestToProject')) {
+        mutationVariables = variables;
+
+        return graphqlResponse({
+          addProjectV2ItemById: {
+            item: {
+              id: 'PVTIT_kwDOB_item_1',
+              project: {
+                id: 'PVT_kwDOB_project_12',
+                number: 12,
+                title: 'Q2 roadmap',
+                url: 'https://github.com/orgs/paperclipai/projects/12',
+                closed: false,
+                owner: {
+                  __typename: 'Organization',
+                  login: 'paperclipai'
+                }
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected GitHub request: ${requestUrl}`);
+  };
+
+  try {
+    const result = await harness.executeTool('add_pull_request_to_project', {
+      pullRequestNumber: 7,
+      organization: 'paperclipai',
+      projectNumber: 12
+    }, {
+      companyId: 'company-1',
+      projectId: 'project-1'
+    });
+
+    assert.ok(!result.error);
+    assert.deepEqual(mutationVariables, {
+      projectId: 'PVT_kwDOB_project_12',
+      contentId: 'PR_kwDOB_example_7'
+    });
+    assert.equal((result.data as { alreadyAssociated: boolean }).alreadyAssociated, false);
+    assert.deepEqual(
+      result.data,
+      {
+        repository: 'https://github.com/paperclipai/example-repo',
+        pullRequest: {
+          number: 7,
+          title: 'Fix the importer',
+          url: 'https://github.com/paperclipai/example-repo/pull/7'
+        },
+        project: {
+          id: 'PVT_kwDOB_project_12',
+          number: 12,
+          title: 'Q2 roadmap',
+          url: 'https://github.com/orgs/paperclipai/projects/12',
+          closed: false,
+          ownerLogin: 'paperclipai'
+        },
+        projectItem: {
+          id: 'PVTIT_kwDOB_item_1'
+        },
+        alreadyAssociated: false
+      }
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('add_pull_request_to_project returns the existing project item when the pull request is already associated', async () => {
+  const harness = await createGitHubAgentToolHarness();
+  const originalFetch = globalThis.fetch;
+  let addMutationCalls = 0;
+
+  globalThis.fetch = async (input, init) => {
+    const requestUrl = getRequestUrl(input);
+    if (requestUrl === 'https://api.github.com/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+
+      if (query.includes('query GitHubOrganizationProjectByNumber')) {
+        return graphqlResponse({
+          organization: {
+            projectV2: {
+              id: 'PVT_kwDOB_project_12',
+              number: 12,
+              title: 'Q2 roadmap',
+              url: 'https://github.com/orgs/paperclipai/projects/12',
+              closed: false,
+              owner: {
+                __typename: 'Organization',
+                login: 'paperclipai'
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubPullRequestProjectItems')) {
+        assert.equal(variables.pullRequestNumber, 7);
+
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              id: 'PR_kwDOB_example_7',
+              number: 7,
+              title: 'Fix the importer',
+              url: 'https://github.com/paperclipai/example-repo/pull/7',
+              projectItems: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: [
+                  {
+                    id: 'PVTIT_kwDOB_existing_1',
+                    project: {
+                      id: 'PVT_kwDOB_project_12',
+                      number: 12,
+                      title: 'Q2 roadmap',
+                      url: 'https://github.com/orgs/paperclipai/projects/12',
+                      closed: false,
+                      owner: {
+                        __typename: 'Organization',
+                        login: 'paperclipai'
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('mutation GitHubAddPullRequestToProject')) {
+        addMutationCalls += 1;
+      }
+    }
+
+    throw new Error(`Unexpected GitHub request: ${requestUrl}`);
+  };
+
+  try {
+    const result = await harness.executeTool('add_pull_request_to_project', {
+      pullRequestNumber: 7,
+      organization: 'paperclipai',
+      projectNumber: 12
+    }, {
+      companyId: 'company-1',
+      projectId: 'project-1'
+    });
+
+    assert.ok(!result.error);
+    assert.equal(addMutationCalls, 0);
+    assert.equal((result.data as { alreadyAssociated: boolean }).alreadyAssociated, true);
+    assert.deepEqual(
+      result.data,
+      {
+        repository: 'https://github.com/paperclipai/example-repo',
+        pullRequest: {
+          number: 7,
+          title: 'Fix the importer',
+          url: 'https://github.com/paperclipai/example-repo/pull/7'
+        },
+        project: {
+          id: 'PVT_kwDOB_project_12',
+          number: 12,
+          title: 'Q2 roadmap',
+          url: 'https://github.com/orgs/paperclipai/projects/12',
+          closed: false,
+          ownerLogin: 'paperclipai'
+        },
+        projectItem: {
+          id: 'PVTIT_kwDOB_existing_1'
+        },
+        alreadyAssociated: true
+      }
+    );
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
## Summary
- enable isolated issue checkouts when the settings UI creates a new Paperclip project by sending `executionWorkspacePolicy.enabled: true`
- expose GitHub org-level project tools so agents can list visible organization Projects and associate pull requests with them
- add focused contract coverage and keep the plugin docs/spec aligned with both agent-tool and project-creation behavior

## Why
Paperclip v2026.416.0 models isolated issue checkouts through `project.executionWorkspacePolicy.enabled`, so newly created projects needed to opt into that host behavior. Separately, agents could already work with issues, pull requests, CI, and review threads, but they could not see organization-level GitHub Projects or add pull requests to them.

## Impact
New GitHub Sync-created Paperclip projects now opt into isolated issue checkouts automatically. Agents can also list org-level GitHub Projects and add PRs to them through the plugin's exposed tool surface, with idempotent handling when a PR is already associated.

## Validation
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Model Used
- Model: GPT-5 Codex (Codex desktop agent; exact deployed runtime variant/version is not surfaced in-session)
- Context window: not surfaced in-session
- Capabilities used: repository editing, terminal tooling, git operations, GitHub CLI PR updates, and verification via local build/test commands
