### PR TITLE
Use SDK issue creation to avoid board attribution on imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The plugin adds a full in-host workflow instead of a one-off import script:
 
 During sync, the plugin imports one top-level Paperclip issue per GitHub issue, updates already imported issues instead of recreating them, maps GitHub labels into Paperclip labels, and keeps GitHub-specific metadata in dedicated Paperclip surfaces rather than stuffing everything into the issue description.
 
+When the host exposes plugin issue creation, imported GitHub issues are created through the Paperclip plugin SDK path so they are not attributed to the connected board user. The worker still uses direct local Paperclip REST calls for label sync and for description or status repair paths when those routes are available.
+
 Long-running syncs continue in the background, so quick actions do not have to wait for the whole import to finish. Once a sync has started, the settings page, dashboard widget, and toolbar actions can request cancellation; the worker stops cooperatively after the current repository or issue step finishes.
 
 ## Highlights

--- a/SPEC.md
+++ b/SPEC.md
@@ -53,6 +53,7 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 - The sync flow MUST fetch open GitHub issues from every configured repository.
 - The sync flow MUST ignore GitHub issues whose author username matches a configured ignored username for that mapping company.
 - The sync flow MUST create one top-level Paperclip issue per imported GitHub issue when the target mapping has a resolved Paperclip project identifier.
+- When the Paperclip runtime exposes plugin issue creation, the sync flow SHOULD prefer `ctx.issues.create(...)` for imported issue creation and reserve direct Paperclip REST issue calls for repair or update paths so imported issues are not attributed to the connected board user.
 - When the mapping company has a configured default assignee, the sync flow MUST assign newly created imported Paperclip issues to that Paperclip agent.
 - Imported Paperclip issues MUST keep the original GitHub issue title without adding a `[GitHub]` prefix.
 - Imported issue descriptions SHOULD contain the normalized GitHub body when present and MUST normalize the GitHub raw HTML constructs that Paperclip cannot render in multiline descriptions.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -7089,10 +7089,6 @@ function getPaperclipLabelsEndpoint(baseUrl: string, companyId: string): string 
   return new URL(`/api/companies/${companyId}/labels`, baseUrl).toString();
 }
 
-function getPaperclipIssuesEndpoint(baseUrl: string, companyId: string): string {
-  return new URL(`/api/companies/${companyId}/issues`, baseUrl).toString();
-}
-
 function getPaperclipIssueEndpoint(baseUrl: string, issueId: string): string {
   return new URL(`/api/issues/${issueId}`, baseUrl).toString();
 }
@@ -7163,20 +7159,6 @@ async function detectPaperclipBoardAccessRequirement(paperclipApiBaseUrl?: strin
   } catch {
     return false;
   }
-}
-
-function parsePaperclipIssueId(value: unknown): string | null {
-  if (!value || typeof value !== 'object') {
-    return null;
-  }
-
-  const id = (value as { id?: unknown }).id;
-  if (typeof id !== 'string') {
-    return null;
-  }
-
-  const trimmedId = id.trim();
-  return trimmedId || null;
 }
 
 function parsePaperclipIssueDescription(value: unknown): string | null | undefined {
@@ -8331,31 +8313,6 @@ function shouldIgnoreGitHubIssue(
   );
 }
 
-async function applyDefaultAssigneeToPaperclipIssue(
-  ctx: PluginSetupContext,
-  params: {
-    companyId: string;
-    issueId: string;
-    defaultAssigneeAgentId?: string;
-  }
-): Promise<void> {
-  const { companyId, issueId, defaultAssigneeAgentId } = params;
-  if (!defaultAssigneeAgentId) {
-    return;
-  }
-
-  try {
-    await ctx.issues.update(issueId, { assigneeAgentId: defaultAssigneeAgentId }, companyId);
-  } catch (error) {
-    ctx.logger.warn('Unable to apply the default assignee to an imported GitHub issue.', {
-      companyId,
-      issueId,
-      assigneeAgentId: defaultAssigneeAgentId,
-      error: getErrorMessage(error)
-    });
-  }
-}
-
 async function createPaperclipIssue(
   ctx: PluginSetupContext,
   mapping: RepositoryMapping,
@@ -8368,77 +8325,24 @@ async function createPaperclipIssue(
   if (!mapping.companyId || !mapping.paperclipProjectId) {
     throw new Error(`Mapping ${mapping.id} is missing resolved Paperclip project identifiers.`);
   }
+  if (!ctx.issues || typeof ctx.issues.create !== 'function') {
+    throw new Error('This Paperclip runtime does not expose plugin issue creation yet.');
+  }
 
   const title = issue.title;
   const description = buildPaperclipIssueDescription(issue);
-  let createdIssueId: string | null = null;
-  let createdIssueDescription: string | null | undefined;
-  let createPath: IssueDescriptionUpdatePath = 'sdk';
-
-  if (paperclipApiBaseUrl) {
-    try {
-      const response = await fetchPaperclipApi(
-        getPaperclipIssuesEndpoint(paperclipApiBaseUrl, mapping.companyId),
-        {
-          method: 'POST',
-          headers: {
-            accept: 'application/json',
-            'content-type': 'application/json'
-          },
-          body: JSON.stringify({
-            projectId: mapping.paperclipProjectId,
-            title,
-            ...(description ? { description } : {})
-          })
-        },
-        {
-          companyId: mapping.companyId
-        }
-      );
-
-      const payloadResult = await readPaperclipApiJsonResponse<unknown>(response, {
-        operationLabel: 'issue create'
-      });
-
-      if (!payloadResult.failure) {
-        const createdIssue = payloadResult.data;
-        createdIssueId = parsePaperclipIssueId(createdIssue);
-        createdIssueDescription = parsePaperclipIssueDescription(createdIssue);
-        createPath = 'local_api';
-      }
-    } catch {
-      // Fall back to the SDK bridge when the local REST API is unavailable.
-    }
-  }
-
-  if (!createdIssueId) {
-    const createdIssue = await ctx.issues.create({
-      companyId: mapping.companyId,
-      projectId: mapping.paperclipProjectId,
-      title,
-      ...(description ? { description } : {}),
-      ...(advancedSettings.defaultAssigneeAgentId
-        ? { assigneeAgentId: advancedSettings.defaultAssigneeAgentId }
-        : {})
-    });
-    createdIssueId = createdIssue.id;
-    createdIssueDescription = createdIssue.description;
-    createPath = 'sdk';
-  }
-
-  const ensuredCreatedIssueId = createdIssueId;
-  if (!ensuredCreatedIssueId) {
-    throw new Error('GitHub sync could not resolve the created Paperclip issue id.');
-  }
-  const normalizedCreatedIssueDescription = createdIssueDescription ?? undefined;
-
-  if (createPath !== 'sdk') {
-    await applyDefaultAssigneeToPaperclipIssue(ctx, {
-      companyId: mapping.companyId,
-      issueId: ensuredCreatedIssueId,
-      defaultAssigneeAgentId: advancedSettings.defaultAssigneeAgentId
-    });
-  }
+  const createdIssue = await ctx.issues.create({
+    companyId: mapping.companyId,
+    projectId: mapping.paperclipProjectId,
+    title,
+    ...(description ? { description } : {}),
+    ...(advancedSettings.defaultAssigneeAgentId
+      ? { assigneeAgentId: advancedSettings.defaultAssigneeAgentId }
+      : {})
+  });
+  const ensuredCreatedIssueId = createdIssue.id;
+  const normalizedCreatedIssueDescription = createdIssue.description ?? undefined;
+  const createPath: IssueDescriptionUpdatePath = 'sdk';
 
   if (normalizeIssueDescriptionValue(normalizedCreatedIssueDescription) !== description) {
     logIssueDescriptionDiagnostic(

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8325,9 +8325,6 @@ async function createPaperclipIssue(
   if (!mapping.companyId || !mapping.paperclipProjectId) {
     throw new Error(`Mapping ${mapping.id} is missing resolved Paperclip project identifiers.`);
   }
-  if (!ctx.issues || typeof ctx.issues.create !== 'function') {
-    throw new Error('This Paperclip runtime does not expose plugin issue creation yet.');
-  }
 
   const title = issue.title;
   const description = buildPaperclipIssueDescription(issue);

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -12347,6 +12347,87 @@ test('worker blocks sync when the Paperclip deployment is authenticated and boar
   }
 });
 
+test('sync.runNow returns a configuration error when plugin issue creation is unavailable', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubTokenRef: 'github-secret-ref'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+
+  await harness.performAction('settings.saveRegistration', {
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  harness.ctx.secrets.resolve = async (secretRef) => {
+    assert.equal(secretRef, 'github-secret-ref');
+    return 'github-token';
+  };
+  (harness.ctx.issues as { create?: unknown }).create = undefined;
+
+  const result = await harness.performAction('sync.runNow', {
+    waitForCompletion: true
+  }) as {
+    syncState: {
+      status: string;
+      message?: string;
+      lastRunTrigger?: string;
+      errorDetails?: {
+        phase?: string;
+        suggestedAction?: string;
+      };
+      recentFailures?: Array<{
+        message?: string;
+        phase?: string;
+      }>;
+    };
+  };
+
+  assert.equal(result.syncState.status, 'error');
+  assert.equal(result.syncState.message, 'This Paperclip runtime does not expose plugin issue creation yet.');
+  assert.equal(result.syncState.lastRunTrigger, 'manual');
+  assert.equal(result.syncState.errorDetails?.phase, 'configuration');
+  assert.match(result.syncState.errorDetails?.suggestedAction ?? '', /supports plugin issue creation/i);
+  assert.equal(result.syncState.recentFailures?.length, 1);
+  assert.equal(result.syncState.recentFailures?.[0]?.message, 'This Paperclip runtime does not expose plugin issue creation yet.');
+  assert.equal(result.syncState.recentFailures?.[0]?.phase, 'configuration');
+
+  const savedState = harness.getState({
+    scopeKind: 'instance',
+    stateKey: 'paperclip-github-plugin-settings'
+  }) as {
+    syncState: {
+      status: string;
+      message?: string;
+      errorDetails?: {
+        phase?: string;
+        suggestedAction?: string;
+      };
+      recentFailures?: Array<{
+        message?: string;
+      }>;
+    };
+  };
+
+  assert.equal(savedState.syncState.status, 'error');
+  assert.equal(savedState.syncState.message, 'This Paperclip runtime does not expose plugin issue creation yet.');
+  assert.equal(savedState.syncState.errorDetails?.phase, 'configuration');
+  assert.match(savedState.syncState.errorDetails?.suggestedAction ?? '', /supports plugin issue creation/i);
+  assert.equal(savedState.syncState.recentFailures?.[0]?.message, 'This Paperclip runtime does not expose plugin issue creation yet.');
+});
+
 test('settings registration clears legacy setup errors once the missing token is saved', async () => {
   const harness = createTestHarness({
     manifest,

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -7288,7 +7288,7 @@ test('worker strips NUL bytes from GitHub issue text before creating imported Pa
   }
 });
 
-test('worker authenticates direct Paperclip REST label and issue sync calls with the configured board token', async () => {
+test('worker authenticates direct Paperclip REST label and issue update sync calls with the configured board token', async () => {
   const harness = createTestHarness({
     manifest,
     config: {
@@ -7460,7 +7460,7 @@ test('worker authenticates direct Paperclip REST label and issue sync calls with
 
     assert.equal(sync.syncState.status, 'success');
     assert.ok(paperclipApiAuthHeaders.some((entry) => entry.path === '/api/companies/company-1/labels'));
-    assert.ok(paperclipApiAuthHeaders.some((entry) => entry.path === '/api/companies/company-1/issues'));
+    assert.ok(!paperclipApiAuthHeaders.some((entry) => entry.path === '/api/companies/company-1/issues'));
     assert.ok(paperclipApiAuthHeaders.some((entry) => entry.path.startsWith('/api/issues/')));
     assert.ok(
       paperclipApiAuthHeaders.every((entry) => entry.authorization === 'Bearer paperclip-board-token'),
@@ -8850,7 +8850,7 @@ test('worker repairs missing descriptions for the reported public issue case', a
   }
 });
 
-test('worker prefers local Paperclip issue creation for the reported public issue case when it is available', async () => {
+test('worker prefers SDK Paperclip issue creation for the reported public issue case when the local API is available', async () => {
   const harness = createTestHarness({
     manifest,
     config: {
@@ -9003,10 +9003,27 @@ test('worker prefers local Paperclip issue creation for the reported public issu
     };
 
     assert.equal(sync.syncState.status, 'success');
-    assert.equal(directSdkCreateCalls, 0);
-    assert.equal(issueCreateRequests.length, 1);
-    assert.equal(descriptionPatchRequests.length, 0);
-    assertNormalizedPublicGitHubIssueDescription(String(issueCreateRequests[0]?.description ?? ''));
+    assert.equal(directSdkCreateCalls, 1);
+    assert.equal(issueCreateRequests.length, 0);
+    assert.equal(descriptionPatchRequests.length, 1);
+    assert.ok(
+      harness.logs.find((entry) =>
+        entry.level === 'warn'
+        && entry.message === 'GitHub sync detected a missing or mismatched Paperclip issue description immediately after issue creation.'
+        && entry.meta?.createPath === 'sdk'
+        && entry.meta?.githubIssueNumber === 3
+      )
+    );
+    assert.ok(
+      harness.logs.find((entry) =>
+        entry.level === 'info'
+        && entry.message === 'GitHub sync repaired a Paperclip issue description through the local Paperclip API.'
+        && entry.meta?.updatePath === 'local_api'
+        && entry.meta?.reason === 'create_response_mismatch'
+        && entry.meta?.githubIssueNumber === 3
+      )
+    );
+    assertNormalizedPublicGitHubIssueDescription(String(descriptionPatchRequests[0]?.body?.description ?? ''));
 
     const importedIssue = (await harness.ctx.issues.list({
       companyId: 'company-1'
@@ -9019,7 +9036,7 @@ test('worker prefers local Paperclip issue creation for the reported public issu
   }
 });
 
-test('worker immediately repairs empty descriptions when the local Paperclip create response stores the reported public issue without one', async () => {
+test('worker immediately repairs empty descriptions from SDK issue creation even when the local Paperclip create API is available', async () => {
   const harness = createTestHarness({
     manifest,
     config: {
@@ -9064,7 +9081,9 @@ test('worker immediately repairs empty descriptions when the local Paperclip cre
   let directSdkCreateCalls = 0;
   harness.ctx.issues.create = async (input) => {
     directSdkCreateCalls += 1;
-    return originalCreate(input);
+    const payload = input as Parameters<typeof originalCreate>[0] & { description?: string };
+    const { description: _description, ...rest } = payload;
+    return originalCreate(rest as Parameters<typeof originalCreate>[0]);
   };
 
   const issueCreateRequests: Array<Record<string, unknown> | null> = [];
@@ -9169,14 +9188,14 @@ test('worker immediately repairs empty descriptions when the local Paperclip cre
     };
 
     assert.equal(sync.syncState.status, 'success');
-    assert.equal(directSdkCreateCalls, 0);
-    assert.equal(issueCreateRequests.length, 1);
+    assert.equal(directSdkCreateCalls, 1);
+    assert.equal(issueCreateRequests.length, 0);
     assert.equal(descriptionPatchRequests.length, 1);
     assert.ok(
       harness.logs.find((entry) =>
         entry.level === 'warn'
         && entry.message === 'GitHub sync detected a missing or mismatched Paperclip issue description immediately after issue creation.'
-        && entry.meta?.createPath === 'local_api'
+        && entry.meta?.createPath === 'sdk'
         && entry.meta?.githubIssueNumber === 3
       )
     );
@@ -9377,10 +9396,20 @@ test('worker falls back to the SDK bridge when the local Paperclip description P
     return originalUpdate(issueId, patch, companyId);
   };
 
+  let directSdkCreateCalls = 0;
   let createdIssueId: string | null = null;
   const issueCreateRequests: Array<Record<string, unknown> | null> = [];
   const descriptionPatchRequests: Array<{ issueId: string; body: Record<string, unknown> | null }> = [];
   const originalFetch = globalThis.fetch;
+
+  harness.ctx.issues.create = async (input) => {
+    directSdkCreateCalls += 1;
+    const payload = input as Parameters<typeof originalCreate>[0] & { description?: string };
+    const { description: _description, ...rest } = payload;
+    const created = await originalCreate(rest as Parameters<typeof originalCreate>[0]);
+    createdIssueId = created.id;
+    return created;
+  };
 
   globalThis.fetch = async (input, init) => {
     const rawUrl = getRequestUrl(input);
@@ -9479,7 +9508,8 @@ test('worker falls back to the SDK bridge when the local Paperclip description P
     };
 
     assert.equal(sync.syncState.status, 'success');
-    assert.equal(issueCreateRequests.length, 1);
+    assert.equal(directSdkCreateCalls, 1);
+    assert.equal(issueCreateRequests.length, 0);
     assert.equal(descriptionPatchRequests.length >= 1, true);
     assert.equal(directDescriptionUpdateCalls.length >= 1, true);
     assert.ok(
@@ -9561,9 +9591,19 @@ test('worker falls back to the SDK bridge when the local Paperclip description P
     return originalUpdate(issueId, patch, companyId);
   };
 
+  let directSdkCreateCalls = 0;
   let createdIssueId: string | null = null;
   const loginPage = '<!doctype html><html><body><h1>Sign in</h1></body></html>';
   const originalFetch = globalThis.fetch;
+
+  harness.ctx.issues.create = async (input) => {
+    directSdkCreateCalls += 1;
+    const payload = input as Parameters<typeof originalCreate>[0] & { description?: string };
+    const { description: _description, ...rest } = payload;
+    const created = await originalCreate(rest as Parameters<typeof originalCreate>[0]);
+    createdIssueId = created.id;
+    return created;
+  };
 
   globalThis.fetch = async (input, init) => {
     const rawUrl = getRequestUrl(input);
@@ -9645,6 +9685,7 @@ test('worker falls back to the SDK bridge when the local Paperclip description P
     };
 
     assert.equal(sync.syncState.status, 'success');
+    assert.equal(directSdkCreateCalls, 1);
     assert.equal(directDescriptionUpdateCalls.length >= 1, true);
     assert.ok(
       directDescriptionUpdateCalls.some((call) =>
@@ -9730,9 +9771,7 @@ test('worker uses the live Paperclip API URL passed to sync.runNow instead of a 
 
   harness.ctx.issues.create = async (input) => {
     directSdkCreateCalls += 1;
-    const payload = input as Parameters<typeof originalCreate>[0] & { description?: string };
-    const { description: _description, ...rest } = payload;
-    return originalCreate(rest as Parameters<typeof originalCreate>[0]);
+    return originalCreate(input);
   };
 
   globalThis.fetch = async (input, init) => {
@@ -9851,7 +9890,7 @@ test('worker uses the live Paperclip API URL passed to sync.runNow instead of a 
     };
 
     assert.equal(sync.syncState.status, 'success');
-    assert.equal(directSdkCreateCalls, 0);
+    assert.equal(directSdkCreateCalls, 1);
     assert.equal(sync.paperclipApiBaseUrl, 'http://127.0.0.1:63675');
 
     const persistedSettings = harness.getState({


### PR DESCRIPTION
## Summary
- Create imported GitHub issues through `ctx.issues.create(...)` when available so they are not attributed to the connected board user.
- Keep direct Paperclip REST calls for label sync and description/status repair paths.
- Update docs and tests to cover the SDK-first create path and the runtime guard for older Paperclip hosts.
- `pnpm build` still passes.

## Testing
- `pnpm test`

## Model Used
- `gpt-5.3-codex`, medium reasoning, workspace tool use; context window size not surfaced in this thread.