### PR TITLE
Fix maintainer-authored issue imports

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2269,6 +2269,15 @@ function normalizeGitHubUserLogin(value: unknown): string | undefined {
   return trimmed ? trimmed.toLowerCase() : undefined;
 }
 
+function normalizeGitHubRepositoryPermissionLevel(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = stripNullBytes(value).trim();
+  return trimmed ? trimmed.toLowerCase() : undefined;
+}
+
 function normalizeGitHubTokenRef(value: unknown): string | undefined {
   return normalizeSecretRef(value);
 }
@@ -6030,11 +6039,17 @@ async function isGitHubUserRepositoryMaintainer(
         'X-GitHub-Api-Version': GITHUB_API_VERSION
       }
     });
+    const permission =
+      response.data && typeof response.data === 'object' && 'permission' in response.data
+        ? normalizeGitHubRepositoryPermissionLevel((response.data as { permission?: unknown }).permission)
+        : undefined;
     const roleName =
       response.data && typeof response.data === 'object' && 'role_name' in response.data
-        ? normalizeGitHubUserLogin((response.data as { role_name?: unknown }).role_name)
+        ? normalizeGitHubRepositoryPermissionLevel((response.data as { role_name?: unknown }).role_name)
         : undefined;
-    const isMaintainer = roleName ? GITHUB_REPOSITORY_MAINTAINER_ROLE_NAMES.has(roleName) : false;
+    const isMaintainer =
+      (permission ? GITHUB_REPOSITORY_MAINTAINER_ROLE_NAMES.has(permission) : false)
+      || (roleName ? GITHUB_REPOSITORY_MAINTAINER_ROLE_NAMES.has(roleName) : false);
     cache.set(cacheKey, isMaintainer);
     return isMaintainer;
   } catch (error) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2260,7 +2260,7 @@ function normalizeSecretRef(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
 
-function normalizeGitHubUserLogin(value: unknown): string | undefined {
+function normalizeGitHubLowercaseString(value: unknown): string | undefined {
   if (typeof value !== 'string') {
     return undefined;
   }
@@ -2269,13 +2269,8 @@ function normalizeGitHubUserLogin(value: unknown): string | undefined {
   return trimmed ? trimmed.toLowerCase() : undefined;
 }
 
-function normalizeGitHubRepositoryPermissionLevel(value: unknown): string | undefined {
-  if (typeof value !== 'string') {
-    return undefined;
-  }
-
-  const trimmed = stripNullBytes(value).trim();
-  return trimmed ? trimmed.toLowerCase() : undefined;
+function normalizeGitHubUserLogin(value: unknown): string | undefined {
+  return normalizeGitHubLowercaseString(value);
 }
 
 function normalizeGitHubTokenRef(value: unknown): string | undefined {
@@ -6041,11 +6036,11 @@ async function isGitHubUserRepositoryMaintainer(
     });
     const permission =
       response.data && typeof response.data === 'object' && 'permission' in response.data
-        ? normalizeGitHubRepositoryPermissionLevel((response.data as { permission?: unknown }).permission)
+        ? normalizeGitHubLowercaseString((response.data as { permission?: unknown }).permission)
         : undefined;
     const roleName =
       response.data && typeof response.data === 'object' && 'role_name' in response.data
-        ? normalizeGitHubRepositoryPermissionLevel((response.data as { role_name?: unknown }).role_name)
+        ? normalizeGitHubLowercaseString((response.data as { role_name?: unknown }).role_name)
         : undefined;
     const isMaintainer =
       (permission ? GITHUB_REPOSITORY_MAINTAINER_ROLE_NAMES.has(permission) : false)

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -6873,6 +6873,128 @@ test('worker imports maintainer-authored open issues without linked pull request
   }
 });
 
+test('worker imports admin-authored open issues as todo when collaborator permission omits role_name', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubTokenRef: 'github-secret-ref'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+
+  await harness.performAction('settings.saveRegistration', {
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  const statusTransitionComments: Array<{ issueId: string; body: string }> = [];
+  const originalCreateComment = harness.ctx.issues.createComment;
+  harness.ctx.issues.createComment = async (issueId, body, companyId) => {
+    statusTransitionComments.push({ issueId, body });
+    return originalCreateComment(issueId, body, companyId);
+  };
+
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (input, init) => {
+    const rawUrl = getRequestUrl(input);
+    const url = new URL(rawUrl);
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues' && ['all', 'open'].includes(url.searchParams.get('state') ?? '')) {
+      return jsonResponse([
+        {
+          id: 2611,
+          number: 28,
+          title: 'Admin-authored issue',
+          body: 'Ship this now',
+          html_url: 'https://github.com/paperclipai/example-repo/issues/28',
+          user: {
+            login: 'repo-admin'
+          },
+          state: 'open',
+          comments: 0
+        }
+      ]);
+    }
+
+    if (url.pathname === '/repos/paperclipai/example-repo/collaborators/repo-admin/permission') {
+      return jsonResponse({
+        permission: 'admin',
+        user: {
+          login: 'repo-admin'
+        }
+      });
+    }
+
+    if (url.pathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      const issueNumber = typeof variables.issueNumber === 'number' ? variables.issueNumber : undefined;
+
+      if (query.includes('query GitHubIssueParentRelationships')) {
+        return graphqlIssueParentRelationshipsResponse([
+          {
+            issueNumber: 28
+          }
+        ]);
+      }
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && issueNumber === 28) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: 28,
+              state: 'OPEN',
+              stateReason: null,
+              comments: {
+                totalCount: 0
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: []
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    const sync = await harness.performAction('sync.runNow', {}) as {
+      syncState: { status: string; createdIssuesCount?: number; skippedIssuesCount?: number; syncedIssuesCount?: number };
+    };
+
+    assert.equal(sync.syncState.status, 'success');
+    assert.equal(sync.syncState.createdIssuesCount, 1);
+    assert.equal(sync.syncState.skippedIssuesCount, 0);
+    assert.equal(sync.syncState.syncedIssuesCount, 1);
+
+    const importedIssues = await harness.ctx.issues.list({
+      companyId: 'company-1'
+    });
+
+    assert.equal(importedIssues.find((issue) => issue.title === 'Admin-authored issue')?.status, 'todo');
+    assert.equal(statusTransitionComments.length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('worker repairs missing import registry entries by reusing existing imported Paperclip issues', async () => {
   const harness = createTestHarness({
     manifest,


### PR DESCRIPTION
## Summary
- Honor GitHub collaborator `permission` when `role_name` is missing during maintainer checks.
- Keep admin-authored open issues on the `todo` import path.
- Add a regression test for the `permission`-only collaborator payload.

## Testing
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`

## Model Used
- GPT-5.3-codex, medium reasoning, tool use enabled.
- Context window size: not disclosed in this thread.