### PR TITLE
[codex] Improve authenticated GitHub sync setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ With this plugin, you can:
 - import open GitHub issues into Paperclip without adding title prefixes or duplicate issues
 - keep descriptions, labels, and status aligned with GitHub over time
 - configure mappings and import defaults per Paperclip company
+- on authenticated Paperclip deployments, choose exactly which company agents should receive the saved GitHub token as `GITHUB_TOKEN`
 - run sync manually or on a schedule
 - triage open pull requests from mapped Paperclip projects in a hosted queue
 - give Paperclip agents native GitHub tools for issues, pull requests, CI, review threads, and org-level projects
@@ -28,6 +29,7 @@ With this plugin, you can:
 The plugin adds a full in-host workflow instead of a one-off import script:
 
 - a hosted settings page for GitHub auth, repository mappings, company defaults, and sync controls
+- authenticated-only setup controls for Paperclip board access and company-scoped agent token propagation
 - a dashboard widget that shows readiness, sync status, and last-run results
 - saved sync diagnostics that let operators inspect the latest per-issue failures, raw errors, and suggested next steps
 - a project sidebar item that opens a live project-scoped Pull Requests page for the mapped repository and can show the open PR count through a lightweight badge read
@@ -103,13 +105,14 @@ npx paperclipai plugin install --local "$PWD"
 
 1. Open the plugin settings for **GitHub Sync** from inside the Paperclip company you want to configure.
 2. Paste a GitHub token, validate it, and save it.
-3. If the deployment requires authenticated Paperclip board access, connect it from the same settings page and complete the approval flow.
-4. Add one or more repository mappings for the current company.
-5. For each mapping, either choose an existing GitHub-linked Paperclip project or enter the project name that should receive synced issues.
-6. Optionally configure company-wide defaults for imported issues, including the default assignee, the default Paperclip status, and ignored GitHub usernames. Bot aliases such as `renovate[bot]` are matched when you save `renovate`.
-7. Choose the automatic sync interval in minutes.
-8. Save the settings and run the first manual sync.
-9. Repeat inside other companies if they need their own mappings, defaults, or board access.
+3. If the deployment is authenticated, connect Paperclip board access from the same settings page and complete the approval flow.
+4. If the deployment is authenticated, choose which agents in the current company should receive the saved GitHub token as `GITHUB_TOKEN`.
+5. Add one or more repository mappings for the current company.
+6. For each mapping, either choose an existing GitHub-linked Paperclip project or enter the project name that should receive synced issues.
+7. Optionally configure company-wide defaults for imported issues, including the default assignee, the default Paperclip status, and ignored GitHub usernames. Bot aliases such as `renovate[bot]` are matched when you save `renovate`.
+8. Choose the automatic sync interval in minutes.
+9. Save the settings and run the first manual sync.
+10. Repeat inside other companies if they need their own mappings, defaults, board access, or agent token propagation.
 
 Repository input accepts either `owner/repo` or `https://github.com/owner/repo`.
 When a token is saved, the settings page audits the mapped repositories for the permissions needed by pull request actions and warns when permissions are missing or GitHub cannot verify them yet.
@@ -150,6 +153,8 @@ The plugin is designed to avoid persisting raw credentials in plugin state.
 
 - GitHub tokens saved through the UI are stored as Paperclip secret references.
 - Paperclip board access tokens are also stored as per-company secret references.
+- The settings UI also keeps lightweight non-secret identity labels for those saved connections, so later visits can still show who the shared GitHub token and company board access are connected as.
+- On authenticated deployments, any selected propagation agents receive `GITHUB_TOKEN` as an agent env secret-ref binding that points at the same saved GitHub token secret instead of a copied raw token.
 - The worker resolves those secret references at runtime instead of storing raw tokens in plugin state.
 - On authenticated Paperclip deployments, sync is blocked until the relevant company has connected Paperclip board access.
 
@@ -181,10 +186,13 @@ The plugin exposes GitHub workflow tools to Paperclip agents, including:
 
 When an agent posts a GitHub comment or review-thread reply through the plugin, the message includes a footer disclosing that it was created by a Paperclip AI agent and which model was used.
 
+Current host caveat: on authenticated Paperclip deployments, the Paperclip host currently guards `GET /api/plugins/tools` and `POST /api/plugins/tools/execute` with board authentication before dispatching to any plugin worker. If an agent run does not have board access for the target company, GitHub Sync tool discovery and execution fail with `403 {"error":"Board access required"}` before this plugin's worker code runs.
+
 ## Troubleshooting
 
 - If setup is reported as incomplete, confirm that a GitHub token has been saved or that `${PAPERCLIP_HOME:-~/.paperclip}/plugins/github-sync/config.json` contains `githubToken`, and make sure at least one mapping has a created Paperclip project.
 - If Paperclip says board access is required, open plugin settings inside the affected company and complete the Paperclip board access flow before retrying sync.
+- If GitHub Sync agent tools fail with `403 {"error":"Board access required"}` on `/api/plugins/tools` or `/api/plugins/tools/execute`, the current Paperclip host rejected the request before the plugin worker ran. Re-run from a board-authenticated session or agent run that has board access to the target company.
 - If the worker reaches an authenticated HTML page instead of the Paperclip API JSON responses it expects, connect Paperclip board access for that company or set `PAPERCLIP_API_URL` to a worker-accessible Paperclip API origin.
 - If a sync run finishes with partial failures, open the saved troubleshooting panel in GitHub Sync to inspect the repository, issue number, raw error, and suggested fix for each recorded failure.
 - If sync says the Paperclip API URL is not trusted, reopen the plugin from the current Paperclip host so the settings UI can refresh the saved origin, or set `PAPERCLIP_API_URL` for the worker.

--- a/SPEC.md
+++ b/SPEC.md
@@ -9,6 +9,7 @@ The plugin MUST provide a settings page inside Paperclip where an operator can c
 - a GitHub token stored as a Paperclip secret reference
 - an optional external config file at `${PAPERCLIP_HOME:-~/.paperclip}/plugins/github-sync/config.json` for worker-only global values such as a raw `githubToken`
 - Paperclip board access, which is optional on unauthenticated deployments and required when the Paperclip deployment reports `deploymentMode: "authenticated"`
+- on authenticated deployments, a company-scoped multi-select of agents that should receive `GITHUB_TOKEN` propagation from the saved GitHub token secret
 - one or more GitHub repository mappings
 - company-scoped advanced defaults for imported issues: default assignee, default Paperclip status, and ignored GitHub issue authors, where a saved username such as `renovate` also matches GitHub bot logins such as `renovate[bot]`
 - the frequency for automatic scheduled sync runs
@@ -20,6 +21,9 @@ The settings page MUST allow saving mappings and triggering a manual sync.
 - The settings page SHOULD clearly label company-scoped setup versus plugin-instance-wide setup when both are shown together.
 - When a company context is present, the settings page SHOULD show the active company name prominently using a human-friendly label instead of a raw identifier.
 - When a company already has Paperclip projects bound to GitHub repository workspaces, the settings page SHOULD surface those projects so an operator can enable sync without recreating the project.
+- The settings page MUST only render the Paperclip board-access connect controls and the agent token-propagation selector when the current Paperclip deployment reports `deploymentMode: "authenticated"`.
+- When the settings page successfully validates a saved GitHub token, it SHOULD persist the validated GitHub login as non-secret display metadata so later visits can continue showing `Authenticated as ...` instead of falling back to a generic ready state.
+- When the settings page successfully connects Paperclip board access for a company, it SHOULD persist a company-scoped non-secret identity label so later visits can continue showing `Connected as ...` instead of falling back to a generic connected state.
 - The plugin SHOULD also expose manual sync entry points from Paperclip toolbar surfaces when the SDK supports them.
 - When a manual sync will outlive a quick action response, the worker MUST persist a `running` sync state immediately and complete the sync asynchronously.
 - Once a sync is running, the settings page, dashboard widget, and toolbar sync entry points MUST provide a way to request cancellation, and the worker MUST stop cooperatively after the current repository or issue step finishes.
@@ -31,9 +35,13 @@ The settings page MUST allow saving mappings and triggering a manual sync.
 - Saving a token from the settings UI MUST create or reuse a company secret through the Paperclip host API.
 - The plugin MUST persist only the resulting secret UUID in plugin instance config.
 - The worker MUST resolve that secret UUID at runtime via `ctx.secrets.resolve(...)`.
+- The plugin MAY persist lightweight non-secret display metadata such as the validated GitHub login alongside the saved GitHub token secret ref so hosted UI can keep connected-state copy consistent across refreshes without resolving the secret.
+- When authenticated deployment settings select agents for GitHub token propagation, the hosted settings UI MUST patch those agents through the host API so `adapterConfig.env.GITHUB_TOKEN` points at that same secret UUID instead of copying the raw token value.
+- When an authenticated deployment settings save removes an agent from that propagation allowlist, the hosted settings UI SHOULD remove `adapterConfig.env.GITHUB_TOKEN` only when that binding still points at the plugin-managed secret UUID, so unrelated manual agent env settings are not clobbered.
 - If `${PAPERCLIP_HOME:-~/.paperclip}/plugins/github-sync/config.json` exists and contains a string `githubToken`, the worker MUST treat it as a worker-only fallback source for the GitHub token without persisting or returning that raw token.
 - The raw Paperclip board API token MUST NOT be persisted in plugin state.
 - Connecting Paperclip board access from the settings UI MUST create or reuse a company secret through the Paperclip host API and MUST persist only the resulting secret UUID, keyed by company in plugin state and mirrored into plugin instance config so the worker can resolve it.
+- The plugin MAY persist lightweight company-scoped non-secret display metadata such as the connected board identity label alongside the saved board token secret ref so hosted UI can keep connected-state copy consistent across refreshes without resolving the secret.
 - The worker MUST resolve the saved Paperclip board token secret at runtime via `ctx.secrets.resolve(...)` before making direct Paperclip REST calls for that company, and MUST treat plugin config as the worker-readable source of truth for those secret refs.
 
 ## Synchronization behavior

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -223,6 +223,7 @@ interface GitHubSyncAdvancedSettings {
   defaultAssigneeAgentId?: string;
   defaultStatus: PaperclipIssueStatus;
   ignoredIssueAuthorUsernames: string[];
+  githubTokenPropagationAgentIds?: string[];
 }
 
 interface GitHubSyncSettings {
@@ -233,7 +234,9 @@ interface GitHubSyncSettings {
   availableAssignees?: GitHubSyncAssigneeOption[];
   paperclipApiBaseUrl?: string;
   githubTokenConfigured?: boolean;
+  githubTokenLogin?: string;
   paperclipBoardAccessConfigured?: boolean;
+  paperclipBoardAccessIdentity?: string;
   paperclipBoardAccessNeedsConfigSync?: boolean;
   paperclipBoardAccessConfigSyncRef?: string;
   totalSyncedIssuesCount?: number;
@@ -4390,7 +4393,7 @@ function normalizeGitHubUsername(value: string): string | null {
 function normalizeIgnoredIssueAuthorUsernames(value: unknown): string[] {
   const rawEntries = Array.isArray(value)
     ? value
-    : typeof value === 'string'
+      : typeof value === 'string'
       ? value.split(/[\s,]+/g)
       : [];
 
@@ -4399,6 +4402,16 @@ function normalizeIgnoredIssueAuthorUsernames(value: unknown): string[] {
       .map((entry) => typeof entry === 'string' ? normalizeGitHubUsername(entry) : null)
       .filter((entry): entry is string => Boolean(entry))
   )];
+}
+
+function normalizeAgentIds(value: unknown): string[] {
+  const rawEntries = Array.isArray(value) ? value : [];
+
+  return [...new Set(
+    rawEntries
+      .map((entry) => typeof entry === 'string' && entry.trim() ? entry.trim() : null)
+      .filter((entry): entry is string => Boolean(entry))
+  )].sort((left, right) => left.localeCompare(right));
 }
 
 function normalizeAdvancedSettings(value: unknown): GitHubSyncAdvancedSettings {
@@ -4418,7 +4431,10 @@ function normalizeAdvancedSettings(value: unknown): GitHubSyncAdvancedSettings {
     ignoredIssueAuthorUsernames:
       'ignoredIssueAuthorUsernames' in record
         ? normalizeIgnoredIssueAuthorUsernames(record.ignoredIssueAuthorUsernames)
-        : DEFAULT_ADVANCED_SETTINGS.ignoredIssueAuthorUsernames
+        : DEFAULT_ADVANCED_SETTINGS.ignoredIssueAuthorUsernames,
+    ...(normalizeAgentIds(record.githubTokenPropagationAgentIds).length > 0
+      ? { githubTokenPropagationAgentIds: normalizeAgentIds(record.githubTokenPropagationAgentIds) }
+      : {})
   };
 }
 
@@ -4440,7 +4456,10 @@ function getComparableAdvancedSettings(value: GitHubSyncAdvancedSettings | null 
   return {
     ...(settings.defaultAssigneeAgentId ? { defaultAssigneeAgentId: settings.defaultAssigneeAgentId } : {}),
     defaultStatus: settings.defaultStatus,
-    ignoredIssueAuthorUsernames: [...settings.ignoredIssueAuthorUsernames].sort((left, right) => left.localeCompare(right))
+    ignoredIssueAuthorUsernames: [...settings.ignoredIssueAuthorUsernames].sort((left, right) => left.localeCompare(right)),
+    ...(settings.githubTokenPropagationAgentIds?.length
+      ? { githubTokenPropagationAgentIds: [...settings.githubTokenPropagationAgentIds].sort((left, right) => left.localeCompare(right)) }
+      : {})
   };
 }
 
@@ -4466,9 +4485,29 @@ function getAvailableAssigneeOptions(
   return normalizedOptions;
 }
 
+function getAvailablePropagationAgentOptions(
+  options: GitHubSyncAssigneeOption[] | null | undefined,
+  selectedAgentIds: string[] | null | undefined
+): GitHubSyncAssigneeOption[] {
+  const normalizedOptions = [...(options ?? [])];
+  const selectedIds = normalizeAgentIds(selectedAgentIds);
+
+  for (const selectedAgentId of selectedIds) {
+    if (!normalizedOptions.some((option) => option.id === selectedAgentId)) {
+      normalizedOptions.push({
+        id: selectedAgentId,
+        name: 'Unavailable agent'
+      });
+    }
+  }
+
+  return normalizedOptions.sort((left, right) => left.name.localeCompare(right.name));
+}
+
 function formatAdvancedSettingsSummary(
   advancedSettings: GitHubSyncAdvancedSettings,
-  availableAssignees: GitHubSyncAssigneeOption[]
+  availableAssignees: GitHubSyncAssigneeOption[],
+  options?: { includePropagation?: boolean }
 ): string {
   const assigneeLabel = advancedSettings.defaultAssigneeAgentId
     ? formatAssigneeOptionLabel(
@@ -4486,8 +4525,36 @@ function formatAdvancedSettingsSummary(
     advancedSettings.ignoredIssueAuthorUsernames.length > 0
       ? advancedSettings.ignoredIssueAuthorUsernames.join(', ')
       : 'none';
+  if (options?.includePropagation) {
+    const propagatedAgentsLabel =
+      advancedSettings.githubTokenPropagationAgentIds?.length
+        ? `${advancedSettings.githubTokenPropagationAgentIds.length} selected`
+        : 'none';
+
+    return `Assignee: ${assigneeLabel} · Status: ${statusLabel} · Ignore: ${ignoredAuthorsLabel} · Propagate: ${propagatedAgentsLabel}`;
+  }
 
   return `Assignee: ${assigneeLabel} · Status: ${statusLabel} · Ignore: ${ignoredAuthorsLabel}`;
+}
+
+function formatAgentMultiSelectionLabel(values: string[], options: SettingsSelectOption[]): string {
+  if (values.length === 0) {
+    return 'No agents selected';
+  }
+
+  const labels = values
+    .map((value) => options.find((option) => option.value === value)?.label ?? 'Unavailable agent')
+    .filter((label) => label.trim().length > 0);
+
+  if (labels.length === 0) {
+    return 'No agents selected';
+  }
+
+  if (labels.length <= 2) {
+    return labels.join(', ');
+  }
+
+  return `${labels.length} agents selected`;
 }
 
 interface SettingsSelectOption {
@@ -4684,6 +4751,159 @@ function SettingsAssigneePicker(props: {
               })
             ) : (
               <div className="ghsync__picker-empty">No assignees match.</div>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function SettingsAgentMultiPicker(props: {
+  id: string;
+  values: string[];
+  options: SettingsSelectOption[];
+  disabled?: boolean;
+  onChange: (values: string[]) => void;
+}): React.JSX.Element {
+  const { id, values, options, disabled, onChange } = props;
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const selectedValues = normalizeAgentIds(values);
+  const selectedValueSet = new Set(selectedValues);
+  const normalizedQuery = query.trim().toLowerCase();
+  const filteredOptions = normalizedQuery
+    ? options.filter((option) => option.label.toLowerCase().includes(normalizedQuery))
+    : options;
+  const selectedLabel = formatAgentMultiSelectionLabel(selectedValues, options);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery('');
+      return;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (target instanceof Node && rootRef.current?.contains(target)) {
+        return;
+      }
+
+      setOpen(false);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+
+    globalThis.setTimeout(() => {
+      searchInputRef.current?.focus();
+      searchInputRef.current?.select();
+    }, 0);
+
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (disabled && open) {
+      setOpen(false);
+    }
+  }, [disabled, open]);
+
+  return (
+    <div className="ghsync__picker" ref={rootRef}>
+      <button
+        id={id}
+        type="button"
+        className="ghsync__picker-trigger ghsync__picker-trigger--assignee"
+        disabled={disabled}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={() => {
+          if (disabled) {
+            return;
+          }
+
+          setOpen((current) => !current);
+        }}
+      >
+        <span className="ghsync__picker-trigger-main">
+          <span className="ghsync__picker-agent-icon" aria-hidden="true">
+            <AgentIcon />
+          </span>
+          <span className="ghsync__picker-trigger-label">{selectedLabel}</span>
+        </span>
+        <span className="ghsync__picker-trigger-icon">
+          <PickerChevronIcon />
+        </span>
+      </button>
+
+      {open ? (
+        <div className="ghsync__picker-panel ghsync__picker-panel--assignee" role="dialog" aria-label="Choose agents">
+          <div className="ghsync__picker-search">
+            <input
+              ref={searchInputRef}
+              type="text"
+              className="ghsync__picker-search-input"
+              placeholder="Search agents..."
+              value={query}
+              onChange={(event) => {
+                setQuery(event.currentTarget.value);
+              }}
+              onKeyDown={(event) => {
+                if (event.key === 'Escape') {
+                  event.preventDefault();
+                  setOpen(false);
+                }
+              }}
+            />
+          </div>
+
+          <div className="ghsync__picker-list" role="listbox" aria-labelledby={id} aria-multiselectable="true">
+            {filteredOptions.length > 0 ? (
+              filteredOptions.map((option) => {
+                const selected = selectedValueSet.has(option.value);
+
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    role="option"
+                    aria-selected={selected}
+                    className={`ghsync__picker-option${selected ? ' ghsync__picker-option--selected' : ''}`}
+                    onClick={() => {
+                      const nextValues = selected
+                        ? selectedValues.filter((value) => value !== option.value)
+                        : normalizeAgentIds([...selectedValues, option.value]);
+                      onChange(nextValues);
+                    }}
+                  >
+                    <span className="ghsync__picker-trigger-main">
+                      {option.icon === 'agent' ? (
+                        <span className="ghsync__picker-agent-icon" aria-hidden="true">
+                          <AgentIcon />
+                        </span>
+                      ) : null}
+                      <span className="ghsync__picker-option-label">{option.label}</span>
+                    </span>
+                    <span className="ghsync__picker-option-check" aria-hidden="true">
+                      {selected ? <PickerCheckIcon /> : null}
+                    </span>
+                  </button>
+                );
+              })
+            ) : (
+              <div className="ghsync__picker-empty">No agents match.</div>
             )}
           </div>
         </div>
@@ -5899,6 +6119,143 @@ async function patchPluginConfig(pluginId: string, patch: Record<string, unknown
       configJson: nextConfig
     })
   });
+}
+
+function normalizeAgentAdapterConfig(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? { ...(value as Record<string, unknown>) }
+    : {};
+}
+
+function normalizeAgentEnvBindings(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? { ...(value as Record<string, unknown>) }
+    : {};
+}
+
+function isMatchingSecretRefEnvBinding(value: unknown, secretId: string): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return record.type === 'secret_ref' && record.secretId === secretId;
+}
+
+function getAgentPropagationPatch(params: {
+  adapterConfig: unknown;
+  githubTokenSecretRef: string;
+  mode: 'ensure' | 'remove';
+}): Record<string, unknown> | null {
+  const adapterConfig = normalizeAgentAdapterConfig(params.adapterConfig);
+  const currentEnv = normalizeAgentEnvBindings(adapterConfig.env);
+
+  if (params.mode === 'ensure') {
+    const nextEnv = {
+      ...currentEnv,
+      GITHUB_TOKEN: {
+        type: 'secret_ref',
+        secretId: params.githubTokenSecretRef
+      }
+    };
+
+    if (JSON.stringify(nextEnv) === JSON.stringify(currentEnv)) {
+      return null;
+    }
+
+    return {
+      ...adapterConfig,
+      env: nextEnv
+    };
+  }
+
+  if (!isMatchingSecretRefEnvBinding(currentEnv.GITHUB_TOKEN, params.githubTokenSecretRef)) {
+    return null;
+  }
+
+  const nextEnv = { ...currentEnv };
+  delete nextEnv.GITHUB_TOKEN;
+
+  const nextAdapterConfig = {
+    ...adapterConfig
+  };
+
+  if (Object.keys(nextEnv).length > 0) {
+    nextAdapterConfig.env = nextEnv;
+  } else {
+    delete nextAdapterConfig.env;
+  }
+
+  return nextAdapterConfig;
+}
+
+export async function syncGitHubTokenPropagationForAgents(params: {
+  githubTokenSecretRef: string;
+  selectedAgentIds: string[];
+  previousAgentIds?: string[];
+}): Promise<void> {
+  const selectedAgentIds = normalizeAgentIds(params.selectedAgentIds);
+  const previousAgentIds = normalizeAgentIds(params.previousAgentIds);
+  const previousSelectedAgentIds = new Set(previousAgentIds);
+  const failures: string[] = [];
+
+  for (const agentId of selectedAgentIds) {
+    try {
+      const agent = await fetchJson<{ adapterConfig?: unknown }>(`/api/agents/${agentId}`);
+      const nextAdapterConfig = getAgentPropagationPatch({
+        adapterConfig: agent?.adapterConfig,
+        githubTokenSecretRef: params.githubTokenSecretRef,
+        mode: 'ensure'
+      });
+
+      if (!nextAdapterConfig) {
+        continue;
+      }
+
+      await fetchJson(`/api/agents/${agentId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({
+          adapterConfig: nextAdapterConfig
+        })
+      });
+    } catch {
+      failures.push(agentId);
+    }
+  }
+
+  for (const agentId of previousAgentIds) {
+    if (!previousSelectedAgentIds.has(agentId) || selectedAgentIds.includes(agentId)) {
+      continue;
+    }
+
+    try {
+      const agent = await fetchJson<{ adapterConfig?: unknown }>(`/api/agents/${agentId}`);
+      const nextAdapterConfig = getAgentPropagationPatch({
+        adapterConfig: agent?.adapterConfig,
+        githubTokenSecretRef: params.githubTokenSecretRef,
+        mode: 'remove'
+      });
+
+      if (!nextAdapterConfig) {
+        continue;
+      }
+
+      await fetchJson(`/api/agents/${agentId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({
+          adapterConfig: nextAdapterConfig
+        })
+      });
+    } catch {
+      failures.push(agentId);
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      `GitHub token propagation could not update these agents: ${[...new Set(failures)].join(', ')}.`
+    );
+  }
 }
 
 function normalizeCliAuthPollIntervalMs(value: unknown): number {
@@ -9657,6 +10014,14 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
       return;
     }
 
+    const savedValidatedLogin =
+      typeof settings.data.githubTokenLogin === 'string' && settings.data.githubTokenLogin.trim()
+        ? settings.data.githubTokenLogin.trim()
+        : null;
+    const savedBoardAccessIdentity =
+      typeof settings.data.paperclipBoardAccessIdentity === 'string' && settings.data.paperclipBoardAccessIdentity.trim()
+        ? settings.data.paperclipBoardAccessIdentity.trim()
+        : null;
     const nextScheduleFrequencyMinutes = normalizeScheduleFrequencyMinutes(settings.data.scheduleFrequencyMinutes);
     setForm({
       mappings: settings.data.mappings ?? [],
@@ -9673,19 +10038,19 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
     setScheduleFrequencyDraft(String(nextScheduleFrequencyMinutes));
     setIgnoredAuthorsDraft(normalizeAdvancedSettings(settings.data.advancedSettings).ignoredIssueAuthorUsernames.join(', '));
     setTokenDraft('');
-    if (!settings.data.paperclipBoardAccessConfigured) {
-      setBoardAccessIdentity(null);
-    }
+    setValidatedLogin(savedValidatedLogin);
+    setBoardAccessIdentity(settings.data.paperclipBoardAccessConfigured ? savedBoardAccessIdentity : null);
 
     if (settings.data.githubTokenConfigured) {
       setShowSavedTokenHint(true);
       setShowTokenEditor(false);
       setTokenStatusOverride('valid');
-    } else if (!showSavedTokenHint) {
+    } else {
+      setShowSavedTokenHint(false);
       setShowTokenEditor(true);
       setValidatedLogin(null);
     }
-  }, [settings.data, showSavedTokenHint]);
+  }, [settings.data]);
 
   useEffect(() => {
     const companyId = hostContext.companyId;
@@ -9986,6 +10351,12 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
     ?? browserAvailableAssignees,
     form.advancedSettings.defaultAssigneeAgentId
   );
+  const propagationAgents = getAvailablePropagationAgentOptions(
+    (currentSettings?.availableAssignees?.length ? currentSettings.availableAssignees : null)
+    ?? (form.availableAssignees?.length ? form.availableAssignees : null)
+    ?? browserAvailableAssignees,
+    form.advancedSettings.githubTokenPropagationAgentIds
+  );
   const savedMappingsSource = currentSettings ? currentSettings.mappings ?? [] : form.mappings;
   const savedMappings = getComparableMappings(savedMappingsSource);
   const draftMappings = getComparableMappings(form.mappings);
@@ -10061,7 +10432,9 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
       : connectingBoardAccess
         ? 'Approval in progress.'
         : boardAccessConfigured
-          ? 'Connected.'
+          ? boardAccessIdentity
+            ? `Connected as ${boardAccessIdentity}.`
+            : 'Connected.'
           : boardAccessRequired
             ? 'Required for sync.'
             : boardAccessRequirement.status === 'loading'
@@ -10108,7 +10481,9 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
     : 'ghsync__scope-pill ghsync__scope-pill--mixed';
   const manualSyncScopePillLabel = hasCompanyContext ? 'This company' : 'All companies';
   const manualSyncButtonLabel = hasCompanyContext ? 'Run sync for this company' : 'Run sync across all companies';
-  const advancedSettingsSummary = formatAdvancedSettingsSummary(form.advancedSettings, availableAssignees);
+  const advancedSettingsSummary = formatAdvancedSettingsSummary(form.advancedSettings, availableAssignees, {
+    includePropagation: boardAccessRequired
+  });
   const assigneeSelectOptions: SettingsSelectOption[] = [
     { value: '', label: 'Unassigned' },
     ...availableAssignees.map((option) => ({
@@ -10117,6 +10492,11 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
       icon: 'agent' as const
     }))
   ];
+  const propagationAgentOptions: SettingsSelectOption[] = propagationAgents.map((option) => ({
+    value: option.id,
+    label: formatAssigneeOptionLabel(option),
+    icon: 'agent' as const
+  }));
   const statusSelectOptions: SettingsSelectOption[] = PAPERCLIP_STATUS_OPTIONS.map((option) => ({
     value: option.value,
     label: option.label,
@@ -10282,6 +10662,47 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
     });
   }
 
+  async function propagateGitHubTokenToSelectedAgents(options: {
+    selectedAgentIds: string[];
+    previousAgentIds?: string[];
+    githubTokenSecretRef?: string;
+  }): Promise<void> {
+    if (!boardAccessRequired) {
+      return;
+    }
+
+    const selectedAgentIds = normalizeAgentIds(options.selectedAgentIds);
+    const previousAgentIds = normalizeAgentIds(options.previousAgentIds);
+    if (selectedAgentIds.length === 0 && previousAgentIds.length === 0) {
+      return;
+    }
+
+    let githubTokenSecretRef =
+      typeof options.githubTokenSecretRef === 'string' && options.githubTokenSecretRef.trim()
+        ? options.githubTokenSecretRef.trim()
+        : undefined;
+
+    if (!githubTokenSecretRef) {
+      const pluginId = await resolveCurrentPluginId(pluginIdFromLocation);
+      if (!pluginId) {
+        throw new Error('Plugin id is required to propagate the GitHub token to selected agents.');
+      }
+
+      const currentConfigResponse = await fetchJson<PluginConfigResponse | null>(`/api/plugins/${pluginId}/config`);
+      githubTokenSecretRef = normalizePluginConfig(currentConfigResponse?.configJson).githubTokenRef;
+    }
+
+    if (!githubTokenSecretRef) {
+      throw new Error('GitHub token propagation requires a GitHub token saved through this settings page.');
+    }
+
+    await syncGitHubTokenPropagationForAgents({
+      githubTokenSecretRef,
+      selectedAgentIds,
+      previousAgentIds
+    });
+  }
+
   async function handleSaveToken(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setSubmittingToken(true);
@@ -10334,8 +10755,21 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
       });
       await saveRegistration({
         companyId,
-        githubTokenRef: secret.id
+        githubTokenRef: secret.id,
+        githubTokenLogin: validation.login
       });
+
+      const selectedAgentIds = normalizeAgentIds(currentSettings?.advancedSettings?.githubTokenPropagationAgentIds);
+      let propagationError: unknown = null;
+      try {
+        await propagateGitHubTokenToSelectedAgents({
+          selectedAgentIds,
+          previousAgentIds: selectedAgentIds,
+          githubTokenSecretRef: secret.id
+        });
+      } catch (error) {
+        propagationError = error;
+      }
 
       setForm((current) => ({
         ...current,
@@ -10351,6 +10785,16 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
         body: 'Token saved.',
         tone: 'success'
       });
+      if (propagationError) {
+        toast({
+          title: 'GitHub token saved, but agent propagation needs attention',
+          body: getActionErrorMessage(
+            propagationError,
+            'GitHub Sync could not update the selected agents with the saved token.'
+          ),
+          tone: 'error'
+        });
+      }
       notifyGitHubSyncSettingsChanged();
 
       try {
@@ -10416,7 +10860,8 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
       });
       await updateBoardAccess({
         companyId,
-        paperclipBoardApiTokenRef: secret.id
+        paperclipBoardApiTokenRef: secret.id,
+        paperclipBoardAccessIdentity: identity ?? ''
       });
 
       setBoardAccessIdentity(identity);
@@ -10513,6 +10958,16 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
         ...(trustedPaperclipApiBaseUrl ? { paperclipApiBaseUrl: trustedPaperclipApiBaseUrl } : {})
       }) as GitHubSyncSettings;
 
+      let propagationError: unknown = null;
+      try {
+        await propagateGitHubTokenToSelectedAgents({
+          selectedAgentIds: normalizeAgentIds(normalizeAdvancedSettings(result.advancedSettings).githubTokenPropagationAgentIds),
+          previousAgentIds: normalizeAgentIds(currentSettings?.advancedSettings?.githubTokenPropagationAgentIds)
+        });
+      } catch (error) {
+        propagationError = error;
+      }
+
       setForm((current) => ({
         ...current,
         mappings: result.mappings.length > 0 ? result.mappings : [createEmptyMapping(0)],
@@ -10530,6 +10985,16 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
         body: `Advanced defaults, mappings, and automatic sync are saved for ${currentCompanyName}.`,
         tone: 'success'
       });
+      if (propagationError) {
+        toast({
+          title: 'Settings saved, but agent propagation needs attention',
+          body: getActionErrorMessage(
+            propagationError,
+            'GitHub Sync could not apply the selected agent token propagation updates.'
+          ),
+          tone: 'error'
+        });
+      }
       notifyGitHubSyncSettingsChanged();
 
       try {
@@ -10841,71 +11306,73 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
             ) : null}
           </section>
 
-          <section className="ghsync__section">
-            <div className="ghsync__section-head">
-              <div className="ghsync__section-copy">
-                <div className="ghsync__section-title-row">
-                  <h4>Paperclip board access</h4>
-                  <div className="ghsync__section-tags">
-                    <span className="ghsync__scope-pill ghsync__scope-pill--company">Company</span>
+          {boardAccessRequired ? (
+            <section className="ghsync__section">
+              <div className="ghsync__section-head">
+                <div className="ghsync__section-copy">
+                  <div className="ghsync__section-title-row">
+                    <h4>Paperclip board access</h4>
+                    <div className="ghsync__section-tags">
+                      <span className="ghsync__scope-pill ghsync__scope-pill--company">Company</span>
+                    </div>
                   </div>
+                  {boardAccessSectionDescription ? <p>{boardAccessSectionDescription}</p> : null}
                 </div>
-                {boardAccessSectionDescription ? <p>{boardAccessSectionDescription}</p> : null}
+                <span className={`ghsync__badge ${getToneClass(boardAccessTone)}`}>
+                  {boardAccessBannerLabel}
+                </span>
               </div>
-              <span className={`ghsync__badge ${getToneClass(boardAccessTone)}`}>
-                {boardAccessBannerLabel}
-              </span>
-            </div>
 
-            {hostContext.companyId ? (
-              <div className="ghsync__connected">
-                <div>
-                  <strong>
-                    {boardAccessConfigured
-                      ? boardAccessIdentity
-                        ? `Connected as ${boardAccessIdentity}`
-                        : 'Connected'
-                      : boardAccessRequired
-                        ? 'Required'
-                        : boardAccessRequirement.status === 'loading'
-                          ? 'Checking requirement'
-                          : 'Optional'}
-                  </strong>
-                  <span>
-                    {boardAccessConfigured
-                      ? 'Used for Paperclip API calls.'
-                      : boardAccessRequired
-                        ? 'Required in authenticated deployments.'
-                        : boardAccessRequirement.status === 'loading'
-                          ? 'Checking whether it is required.'
-                          : 'Only needed when Paperclip API calls require sign-in.'}
-                  </span>
+              {hostContext.companyId ? (
+                <div className="ghsync__connected">
+                  <div>
+                    <strong>
+                      {boardAccessConfigured
+                        ? boardAccessIdentity
+                          ? `Connected as ${boardAccessIdentity}`
+                          : 'Connected'
+                        : boardAccessRequired
+                          ? 'Required'
+                          : boardAccessRequirement.status === 'loading'
+                            ? 'Checking requirement'
+                            : 'Optional'}
+                    </strong>
+                    <span>
+                      {boardAccessConfigured
+                        ? 'Used for Paperclip API calls.'
+                        : boardAccessRequired
+                          ? 'Required in authenticated deployments.'
+                          : boardAccessRequirement.status === 'loading'
+                            ? 'Checking whether it is required.'
+                            : 'Only needed when Paperclip API calls require sign-in.'}
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    className={getPluginActionClassName({ variant: boardAccessConfigured ? 'secondary' : 'primary' })}
+                    disabled={!canConnectBoardAccess}
+                    onClick={() => {
+                      void handleConnectBoardAccess();
+                    }}
+                  >
+                    <LoadingButtonContent
+                      busy={connectingBoardAccess}
+                      label={boardAccessConfigured ? 'Reconnect' : 'Connect board access'}
+                      busyLabel="Waiting for approval…"
+                    />
+                  </button>
                 </div>
-                <button
-                  type="button"
-                  className={getPluginActionClassName({ variant: boardAccessConfigured ? 'secondary' : 'primary' })}
-                  disabled={!canConnectBoardAccess}
-                  onClick={() => {
-                    void handleConnectBoardAccess();
-                  }}
-                >
-                  <LoadingButtonContent
-                    busy={connectingBoardAccess}
-                    label={boardAccessConfigured ? 'Reconnect' : 'Connect board access'}
-                    busyLabel="Waiting for approval…"
-                  />
-                </button>
-              </div>
-            ) : (
-              <div className="ghsync__locked">
-                <div>
-                  <strong>Company required</strong>
-                  <span>Open a company to connect it.</span>
+              ) : (
+                <div className="ghsync__locked">
+                  <div>
+                    <strong>Company required</strong>
+                    <span>Open a company to connect it.</span>
+                  </div>
+                  <span className="ghsync__badge ghsync__badge--neutral">Unavailable</span>
                 </div>
-                <span className="ghsync__badge ghsync__badge--neutral">Unavailable</span>
-              </div>
-            )}
-          </section>
+              )}
+            </section>
+          ) : null}
 
           <section className="ghsync__section">
             <div className="ghsync__section-head">
@@ -11160,6 +11627,34 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
                   />
                   <p className="ghsync__hint">Comma or newline separated.</p>
                 </div>
+
+                {boardAccessRequired ? (
+                  <div className="ghsync__field">
+                    <label htmlFor="advanced-token-propagation">Propagate GitHub token to agents</label>
+                    <SettingsAgentMultiPicker
+                      id="advanced-token-propagation"
+                      values={form.advancedSettings.githubTokenPropagationAgentIds ?? []}
+                      options={propagationAgentOptions}
+                      disabled={settingsMutationsLocked || tokenStatus !== 'valid'}
+                      onChange={(nextValues) => {
+                        setForm((current) => ({
+                          ...current,
+                          advancedSettings: {
+                            ...current.advancedSettings,
+                            ...(nextValues.length > 0
+                              ? { githubTokenPropagationAgentIds: nextValues }
+                              : { githubTokenPropagationAgentIds: undefined })
+                          }
+                        }));
+                      }}
+                    />
+                    <p className="ghsync__hint">
+                      {tokenStatus === 'valid'
+                        ? 'Selected agents receive `GITHUB_TOKEN` from the saved GitHub secret when you save settings.'
+                        : 'Save a valid GitHub token before choosing agents to propagate it to.'}
+                    </p>
+                  </div>
+                ) : null}
               </div>
             ) : null}
           </section>
@@ -11365,15 +11860,17 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
               </span>
             </div>
 
-            <div className="ghsync__check">
-              <div className="ghsync__check-top">
-                <strong>Paperclip board access</strong>
-                <span className={`ghsync__badge ${getToneClass(boardAccessStatusTone)}`}>
-                  {boardAccessStatusLabel}
-                </span>
+            {boardAccessRequired ? (
+              <div className="ghsync__check">
+                <div className="ghsync__check-top">
+                  <strong>Paperclip board access</strong>
+                  <span className={`ghsync__badge ${getToneClass(boardAccessStatusTone)}`}>
+                    {boardAccessStatusLabel}
+                  </span>
+                </div>
+                <span>{boardAccessSummaryText}</span>
               </div>
-              <span>{boardAccessSummaryText}</span>
-            </div>
+            ) : null}
 
             <div className="ghsync__check">
               <div className="ghsync__check-top">

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -4390,6 +4390,10 @@ function normalizeGitHubUsername(value: string): string | null {
   return trimmed ? trimmed : null;
 }
 
+function normalizeOptionalText(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
 function normalizeIgnoredIssueAuthorUsernames(value: unknown): string[] {
   const rawEntries = Array.isArray(value)
     ? value
@@ -4535,6 +4539,32 @@ function formatAdvancedSettingsSummary(
   }
 
   return `Assignee: ${assigneeLabel} · Status: ${statusLabel} · Ignore: ${ignoredAuthorsLabel}`;
+}
+
+export function resolveSavedTokenUiState(params: {
+  githubTokenConfigured?: boolean;
+  githubTokenLogin?: string | null;
+}): {
+  showSavedTokenHint: boolean;
+  showTokenEditor: boolean;
+  tokenStatusOverride: TokenStatus | null;
+  validatedLogin: string | null;
+} {
+  if (params.githubTokenConfigured) {
+    return {
+      showSavedTokenHint: true,
+      showTokenEditor: false,
+      tokenStatusOverride: 'valid',
+      validatedLogin: normalizeOptionalText(params.githubTokenLogin)
+    };
+  }
+
+  return {
+    showSavedTokenHint: false,
+    showTokenEditor: true,
+    tokenStatusOverride: null,
+    validatedLogin: null
+  };
 }
 
 function formatAgentMultiSelectionLabel(values: string[], options: SettingsSelectOption[]): string {
@@ -6121,6 +6151,8 @@ async function patchPluginConfig(pluginId: string, patch: Record<string, unknown
   });
 }
 
+const GITHUB_TOKEN_PROPAGATION_CONCURRENCY_LIMIT = 4;
+
 function normalizeAgentAdapterConfig(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? { ...(value as Record<string, unknown>) }
@@ -6189,71 +6221,88 @@ function getAgentPropagationPatch(params: {
   return nextAdapterConfig;
 }
 
+async function runWithConcurrencyLimit<T>(
+  items: T[],
+  concurrencyLimit: number,
+  worker: (item: T) => Promise<void>
+): Promise<void> {
+  if (items.length === 0) {
+    return;
+  }
+
+  let nextIndex = 0;
+  const runnerCount = Math.min(concurrencyLimit, items.length);
+
+  await Promise.all(
+    Array.from({ length: runnerCount }, async () => {
+      while (nextIndex < items.length) {
+        const currentIndex = nextIndex;
+        nextIndex += 1;
+        await worker(items[currentIndex]);
+      }
+    })
+  );
+}
+
+async function applyGitHubTokenPropagationUpdate(params: {
+  agentId: string;
+  githubTokenSecretRef: string;
+  mode: 'ensure' | 'remove';
+}): Promise<void> {
+  const agent = await fetchJson<{ adapterConfig?: unknown }>(`/api/agents/${params.agentId}`);
+  const nextAdapterConfig = getAgentPropagationPatch({
+    adapterConfig: agent?.adapterConfig,
+    githubTokenSecretRef: params.githubTokenSecretRef,
+    mode: params.mode
+  });
+
+  if (!nextAdapterConfig) {
+    return;
+  }
+
+  await fetchJson(`/api/agents/${params.agentId}`, {
+    method: 'PATCH',
+    body: JSON.stringify({
+      adapterConfig: nextAdapterConfig
+    })
+  });
+}
+
 export async function syncGitHubTokenPropagationForAgents(params: {
   githubTokenSecretRef: string;
   selectedAgentIds: string[];
   previousAgentIds?: string[];
 }): Promise<void> {
   const selectedAgentIds = normalizeAgentIds(params.selectedAgentIds);
+  const selectedAgentIdSet = new Set(selectedAgentIds);
   const previousAgentIds = normalizeAgentIds(params.previousAgentIds);
-  const previousSelectedAgentIds = new Set(previousAgentIds);
-  const failures: string[] = [];
+  const failures = new Set<string>();
+  const operations = [
+    ...selectedAgentIds.map((agentId) => ({ agentId, mode: 'ensure' as const })),
+    ...previousAgentIds
+      .filter((agentId) => !selectedAgentIdSet.has(agentId))
+      .map((agentId) => ({ agentId, mode: 'remove' as const }))
+  ];
 
-  for (const agentId of selectedAgentIds) {
-    try {
-      const agent = await fetchJson<{ adapterConfig?: unknown }>(`/api/agents/${agentId}`);
-      const nextAdapterConfig = getAgentPropagationPatch({
-        adapterConfig: agent?.adapterConfig,
-        githubTokenSecretRef: params.githubTokenSecretRef,
-        mode: 'ensure'
-      });
-
-      if (!nextAdapterConfig) {
-        continue;
+  await runWithConcurrencyLimit(
+    operations,
+    GITHUB_TOKEN_PROPAGATION_CONCURRENCY_LIMIT,
+    async (operation) => {
+      try {
+        await applyGitHubTokenPropagationUpdate({
+          agentId: operation.agentId,
+          githubTokenSecretRef: params.githubTokenSecretRef,
+          mode: operation.mode
+        });
+      } catch {
+        failures.add(operation.agentId);
       }
-
-      await fetchJson(`/api/agents/${agentId}`, {
-        method: 'PATCH',
-        body: JSON.stringify({
-          adapterConfig: nextAdapterConfig
-        })
-      });
-    } catch {
-      failures.push(agentId);
     }
-  }
+  );
 
-  for (const agentId of previousAgentIds) {
-    if (!previousSelectedAgentIds.has(agentId) || selectedAgentIds.includes(agentId)) {
-      continue;
-    }
-
-    try {
-      const agent = await fetchJson<{ adapterConfig?: unknown }>(`/api/agents/${agentId}`);
-      const nextAdapterConfig = getAgentPropagationPatch({
-        adapterConfig: agent?.adapterConfig,
-        githubTokenSecretRef: params.githubTokenSecretRef,
-        mode: 'remove'
-      });
-
-      if (!nextAdapterConfig) {
-        continue;
-      }
-
-      await fetchJson(`/api/agents/${agentId}`, {
-        method: 'PATCH',
-        body: JSON.stringify({
-          adapterConfig: nextAdapterConfig
-        })
-      });
-    } catch {
-      failures.push(agentId);
-    }
-  }
-
-  if (failures.length > 0) {
+  if (failures.size > 0) {
     throw new Error(
-      `GitHub token propagation could not update these agents: ${[...new Set(failures)].join(', ')}.`
+      `GitHub token propagation could not update these agents: ${[...failures].join(', ')}.`
     );
   }
 }
@@ -10014,10 +10063,10 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
       return;
     }
 
-    const savedValidatedLogin =
-      typeof settings.data.githubTokenLogin === 'string' && settings.data.githubTokenLogin.trim()
-        ? settings.data.githubTokenLogin.trim()
-        : null;
+    const tokenUiState = resolveSavedTokenUiState({
+      githubTokenConfigured: settings.data.githubTokenConfigured,
+      githubTokenLogin: settings.data.githubTokenLogin
+    });
     const savedBoardAccessIdentity =
       typeof settings.data.paperclipBoardAccessIdentity === 'string' && settings.data.paperclipBoardAccessIdentity.trim()
         ? settings.data.paperclipBoardAccessIdentity.trim()
@@ -10038,18 +10087,11 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
     setScheduleFrequencyDraft(String(nextScheduleFrequencyMinutes));
     setIgnoredAuthorsDraft(normalizeAdvancedSettings(settings.data.advancedSettings).ignoredIssueAuthorUsernames.join(', '));
     setTokenDraft('');
-    setValidatedLogin(savedValidatedLogin);
+    setValidatedLogin(tokenUiState.validatedLogin);
     setBoardAccessIdentity(settings.data.paperclipBoardAccessConfigured ? savedBoardAccessIdentity : null);
-
-    if (settings.data.githubTokenConfigured) {
-      setShowSavedTokenHint(true);
-      setShowTokenEditor(false);
-      setTokenStatusOverride('valid');
-    } else {
-      setShowSavedTokenHint(false);
-      setShowTokenEditor(true);
-      setValidatedLogin(null);
-    }
+    setShowSavedTokenHint(tokenUiState.showSavedTokenHint);
+    setShowTokenEditor(tokenUiState.showTokenEditor);
+    setTokenStatusOverride(tokenUiState.tokenStatusOverride);
   }, [settings.data]);
 
   useEffect(() => {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -88,6 +88,7 @@ type PaperclipIssueUpdatePatchWithLabels = Parameters<PluginSetupContext['issues
 };
 type PaperclipLabelDirectory = Map<string, PaperclipIssueLabel[]>;
 type PaperclipBoardApiTokenRefs = Record<string, string>;
+type PaperclipBoardAccessIdentityByCompanyId = Record<string, string>;
 type CompanyAdvancedSettingsByCompanyId = Record<string, GitHubSyncAdvancedSettings>;
 type ProjectPullRequestFilter = 'all' | 'mergeable' | 'reviewable' | 'failing';
 type ProjectPullRequestUpToDateStatus = 'up_to_date' | 'can_update' | 'conflicts' | 'unknown';
@@ -148,6 +149,7 @@ interface GitHubSyncAdvancedSettings {
   defaultAssigneeAgentId?: string;
   defaultStatus: PaperclipIssueStatus;
   ignoredIssueAuthorUsernames: string[];
+  githubTokenPropagationAgentIds?: string[];
 }
 
 interface GitHubSyncAssigneeOption {
@@ -334,7 +336,9 @@ interface GitHubSyncSettings {
   scheduleFrequencyMinutes: number;
   paperclipApiBaseUrl?: string;
   githubTokenRef?: string;
+  githubTokenLogin?: string;
   paperclipBoardApiTokenRefs?: PaperclipBoardApiTokenRefs;
+  paperclipBoardAccessIdentityByCompanyId?: PaperclipBoardAccessIdentityByCompanyId;
   companyAdvancedSettingsByCompanyId?: CompanyAdvancedSettingsByCompanyId;
   totalSyncedIssuesCount?: number;
   updatedAt?: string;
@@ -3720,28 +3724,50 @@ function sanitizeSettingsForCurrentSetup(
 
 function getPublicSettings(
   settings: GitHubSyncSettings
-): Omit<GitHubSyncSettings, 'githubTokenRef' | 'paperclipBoardApiTokenRefs' | 'companyAdvancedSettingsByCompanyId'> {
+): Omit<
+  GitHubSyncSettings,
+  'githubTokenRef' | 'paperclipBoardApiTokenRefs' | 'paperclipBoardAccessIdentityByCompanyId' | 'companyAdvancedSettingsByCompanyId'
+> {
   const {
     githubTokenRef: _githubTokenRef,
     paperclipBoardApiTokenRefs: _paperclipBoardApiTokenRefs,
+    paperclipBoardAccessIdentityByCompanyId: _paperclipBoardAccessIdentityByCompanyId,
     companyAdvancedSettingsByCompanyId: _companyAdvancedSettingsByCompanyId,
     ...publicSettings
   } = settings;
   return publicSettings;
 }
 
+function getPaperclipBoardAccessIdentity(
+  settings: Pick<GitHubSyncSettings, 'paperclipBoardAccessIdentityByCompanyId'>,
+  companyId?: string
+): string | undefined {
+  const normalizedCompanyId = normalizeCompanyId(companyId);
+  if (!normalizedCompanyId) {
+    return undefined;
+  }
+
+  return normalizeOptionalString(settings.paperclipBoardAccessIdentityByCompanyId?.[normalizedCompanyId]);
+}
+
 function getPublicSettingsForScope(
   settings: GitHubSyncSettings,
   companyId?: string
-): Omit<GitHubSyncSettings, 'githubTokenRef' | 'paperclipBoardApiTokenRefs' | 'companyAdvancedSettingsByCompanyId'> & {
+): Omit<
+  GitHubSyncSettings,
+  'githubTokenRef' | 'paperclipBoardApiTokenRefs' | 'paperclipBoardAccessIdentityByCompanyId' | 'companyAdvancedSettingsByCompanyId'
+> & {
   advancedSettings: GitHubSyncAdvancedSettings;
+  paperclipBoardAccessIdentity?: string;
 } {
   const publicSettings = getPublicSettings(settings);
+  const paperclipBoardAccessIdentity = getPaperclipBoardAccessIdentity(settings, companyId);
 
   return {
     ...publicSettings,
     mappings: filterMappingsByCompany(publicSettings.mappings, companyId),
-    advancedSettings: getCompanyAdvancedSettings(settings, companyId)
+    advancedSettings: getCompanyAdvancedSettings(settings, companyId),
+    ...(paperclipBoardAccessIdentity ? { paperclipBoardAccessIdentity } : {})
   };
 }
 
@@ -4267,6 +4293,30 @@ function normalizePaperclipBoardApiTokenRefs(value: unknown): PaperclipBoardApiT
   return Object.fromEntries(entries);
 }
 
+function normalizePaperclipBoardAccessIdentityByCompanyId(
+  value: unknown
+): PaperclipBoardAccessIdentityByCompanyId | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .map(([companyId, identityLabel]) => {
+      const normalizedCompanyId = normalizeCompanyId(companyId);
+      const normalizedIdentityLabel = normalizeOptionalString(identityLabel);
+      return normalizedCompanyId && normalizedIdentityLabel
+        ? [normalizedCompanyId, normalizedIdentityLabel] as const
+        : null;
+    })
+    .filter((entry): entry is readonly [string, string] => entry !== null);
+
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(entries);
+}
+
 function normalizeSyncCancellationRequest(value: unknown): SyncCancellationRequest | null {
   if (!value || typeof value !== 'object') {
     return null;
@@ -4383,6 +4433,16 @@ function normalizeIgnoredIssueAuthorUsernames(value: unknown): string[] {
   return [...new Set(entries)];
 }
 
+function normalizeAgentIds(value: unknown): string[] {
+  const entries = Array.isArray(value)
+    ? value
+      .map((entry) => normalizeOptionalString(entry))
+      .filter((entry): entry is string => Boolean(entry))
+    : [];
+
+  return [...new Set(entries)].sort((left, right) => left.localeCompare(right));
+}
+
 function normalizeAdvancedSettings(value: unknown): GitHubSyncAdvancedSettings {
   if (!value || typeof value !== 'object') {
     return DEFAULT_ADVANCED_SETTINGS;
@@ -4398,11 +4458,16 @@ function normalizeAdvancedSettings(value: unknown): GitHubSyncAdvancedSettings {
     'ignoredIssueAuthorUsernames' in record
       ? normalizeIgnoredIssueAuthorUsernames(record.ignoredIssueAuthorUsernames)
       : DEFAULT_ADVANCED_SETTINGS.ignoredIssueAuthorUsernames;
+  const githubTokenPropagationAgentIds =
+    'githubTokenPropagationAgentIds' in record
+      ? normalizeAgentIds(record.githubTokenPropagationAgentIds)
+      : [];
 
   return {
     ...(defaultAssigneeAgentId ? { defaultAssigneeAgentId } : {}),
     defaultStatus,
-    ignoredIssueAuthorUsernames
+    ignoredIssueAuthorUsernames,
+    ...(githubTokenPropagationAgentIds.length > 0 ? { githubTokenPropagationAgentIds } : {})
   };
 }
 
@@ -4551,7 +4616,11 @@ function normalizeSettings(value: unknown): GitHubSyncSettings {
   const record = value as Record<string, unknown>;
   const paperclipApiBaseUrl = resolvePaperclipApiBaseUrl(record.paperclipApiBaseUrl);
   const githubTokenRef = normalizeGitHubTokenRef(record.githubTokenRef);
+  const githubTokenLogin = normalizeOptionalString(record.githubTokenLogin);
   const paperclipBoardApiTokenRefs = normalizePaperclipBoardApiTokenRefs(record.paperclipBoardApiTokenRefs);
+  const paperclipBoardAccessIdentityByCompanyId = normalizePaperclipBoardAccessIdentityByCompanyId(
+    record.paperclipBoardAccessIdentityByCompanyId
+  );
   const companyAdvancedSettingsByCompanyId = normalizeCompanyAdvancedSettingsByCompanyId(record.companyAdvancedSettingsByCompanyId);
 
   return {
@@ -4560,7 +4629,9 @@ function normalizeSettings(value: unknown): GitHubSyncSettings {
     scheduleFrequencyMinutes: normalizeScheduleFrequencyMinutes(record.scheduleFrequencyMinutes),
     ...(paperclipApiBaseUrl ? { paperclipApiBaseUrl } : {}),
     ...(githubTokenRef ? { githubTokenRef } : {}),
+    ...(githubTokenLogin ? { githubTokenLogin } : {}),
     ...(paperclipBoardApiTokenRefs ? { paperclipBoardApiTokenRefs } : {}),
+    ...(paperclipBoardAccessIdentityByCompanyId ? { paperclipBoardAccessIdentityByCompanyId } : {}),
     ...(companyAdvancedSettingsByCompanyId ? { companyAdvancedSettingsByCompanyId } : {}),
     updatedAt: typeof record.updatedAt === 'string' ? record.updatedAt : undefined
   };
@@ -14657,6 +14728,10 @@ const plugin = definePlugin({
         'githubTokenRef' in record
           ? normalizeGitHubTokenRef(record.githubTokenRef)
           : normalizeGitHubTokenRef(previous.githubTokenRef) ?? normalizeGitHubTokenRef(config.githubTokenRef);
+      const githubTokenLogin =
+        'githubTokenLogin' in record
+          ? normalizeOptionalString(record.githubTokenLogin)
+          : previous.githubTokenLogin;
       const inputMappings = hasMappingsPatch ? normalizeMappings(record.mappings) : previous.mappings;
       const nextCompanyAdvancedSettingsByCompanyId = {
         ...(previous.companyAdvancedSettingsByCompanyId ?? {})
@@ -14684,7 +14759,9 @@ const plugin = definePlugin({
           'paperclipApiBaseUrl' in record
             ? resolveTrustedPaperclipApiBaseUrlInput(record.paperclipApiBaseUrl, previous, config)
             : getConfiguredPaperclipApiBaseUrl(previous, config),
+        ...(githubTokenLogin ? { githubTokenLogin } : {}),
         paperclipBoardApiTokenRefs: previous.paperclipBoardApiTokenRefs,
+        paperclipBoardAccessIdentityByCompanyId: previous.paperclipBoardAccessIdentityByCompanyId,
         ...(Object.keys(nextCompanyAdvancedSettingsByCompanyId).length > 0
           ? { companyAdvancedSettingsByCompanyId: nextCompanyAdvancedSettingsByCompanyId }
           : {}),
@@ -14702,7 +14779,11 @@ const plugin = definePlugin({
         syncState: previous.syncState,
         scheduleFrequencyMinutes: current.scheduleFrequencyMinutes,
         ...(current.paperclipApiBaseUrl ? { paperclipApiBaseUrl: current.paperclipApiBaseUrl } : {}),
+        ...(current.githubTokenLogin ? { githubTokenLogin: current.githubTokenLogin } : {}),
         ...(current.paperclipBoardApiTokenRefs ? { paperclipBoardApiTokenRefs: current.paperclipBoardApiTokenRefs } : {}),
+        ...(current.paperclipBoardAccessIdentityByCompanyId
+          ? { paperclipBoardAccessIdentityByCompanyId: current.paperclipBoardAccessIdentityByCompanyId }
+          : {}),
         ...(current.companyAdvancedSettingsByCompanyId
           ? { companyAdvancedSettingsByCompanyId: current.companyAdvancedSettingsByCompanyId }
           : {}),
@@ -14737,21 +14818,38 @@ const plugin = definePlugin({
       const nextPaperclipBoardApiTokenRefs = {
         ...(previous.paperclipBoardApiTokenRefs ?? {})
       };
+      const nextPaperclipBoardAccessIdentityByCompanyId = {
+        ...(previous.paperclipBoardAccessIdentityByCompanyId ?? {})
+      };
 
       if (nextSecretRef) {
         nextPaperclipBoardApiTokenRefs[companyId] = nextSecretRef;
       } else {
         delete nextPaperclipBoardApiTokenRefs[companyId];
+        delete nextPaperclipBoardAccessIdentityByCompanyId[companyId];
+      }
+
+      if ('paperclipBoardAccessIdentity' in record) {
+        const nextIdentityLabel = normalizeOptionalString(record.paperclipBoardAccessIdentity);
+        if (nextIdentityLabel) {
+          nextPaperclipBoardAccessIdentityByCompanyId[companyId] = nextIdentityLabel;
+        } else {
+          delete nextPaperclipBoardAccessIdentityByCompanyId[companyId];
+        }
       }
 
       const {
         paperclipBoardApiTokenRefs: _previousPaperclipBoardApiTokenRefs,
+        paperclipBoardAccessIdentityByCompanyId: _previousPaperclipBoardAccessIdentityByCompanyId,
         ...previousWithoutBoardAccess
       } = previous;
       const next = sanitizeSettingsForCurrentSetup({
         ...previousWithoutBoardAccess,
         ...(Object.keys(nextPaperclipBoardApiTokenRefs).length > 0
           ? { paperclipBoardApiTokenRefs: nextPaperclipBoardApiTokenRefs }
+          : {}),
+        ...(Object.keys(nextPaperclipBoardAccessIdentityByCompanyId).length > 0
+          ? { paperclipBoardAccessIdentityByCompanyId: nextPaperclipBoardAccessIdentityByCompanyId }
           : {}),
         updatedAt: new Date().toISOString()
       }, {

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -553,6 +553,50 @@ test('settings UI no longer exports a local authenticated-controls preview overr
   assert.equal(uiModule.shouldShowAuthenticatedControlsPreview, undefined);
 });
 
+test('resolveSavedTokenUiState clears stale valid token state when no saved token remains', async () => {
+  const uiModule = await importFreshUiModule() as {
+    resolveSavedTokenUiState?: unknown;
+  };
+
+  assert.equal(typeof uiModule.resolveSavedTokenUiState, 'function');
+
+  const resolveSavedTokenUiState = uiModule.resolveSavedTokenUiState as (params: {
+    githubTokenConfigured?: boolean;
+    githubTokenLogin?: string | null;
+  }) => {
+    showSavedTokenHint: boolean;
+    showTokenEditor: boolean;
+    tokenStatusOverride: 'valid' | 'invalid' | 'required' | null;
+    validatedLogin: string | null;
+  };
+
+  assert.deepEqual(
+    resolveSavedTokenUiState({
+      githubTokenConfigured: true,
+      githubTokenLogin: '  octocat  '
+    }),
+    {
+      showSavedTokenHint: true,
+      showTokenEditor: false,
+      tokenStatusOverride: 'valid',
+      validatedLogin: 'octocat'
+    }
+  );
+
+  assert.deepEqual(
+    resolveSavedTokenUiState({
+      githubTokenConfigured: false,
+      githubTokenLogin: 'octocat'
+    }),
+    {
+      showSavedTokenHint: false,
+      showTokenEditor: true,
+      tokenStatusOverride: null,
+      validatedLogin: null
+    }
+  );
+});
+
 test('syncGitHubTokenPropagationForAgents adds and removes agent GITHUB_TOKEN secret refs without clobbering unrelated env config', async () => {
   const uiModule = await importFreshUiModule() as {
     syncGitHubTokenPropagationForAgents?: unknown;
@@ -642,7 +686,9 @@ test('syncGitHubTokenPropagationForAgents adds and removes agent GITHUB_TOKEN se
       previousAgentIds: ['agent-1', 'agent-2', 'agent-3']
     });
 
-    assert.deepEqual(patchBodies, [
+    assert.deepEqual(
+      [...patchBodies].sort((left, right) => left.agentId.localeCompare(right.agentId)),
+      [
       {
         agentId: 'agent-1',
         body: {
@@ -675,7 +721,101 @@ test('syncGitHubTokenPropagationForAgents adds and removes agent GITHUB_TOKEN se
           }
         }
       }
-    ]);
+      ]
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('syncGitHubTokenPropagationForAgents batches propagation updates with a small concurrency limit', async () => {
+  const uiModule = await importFreshUiModule() as {
+    syncGitHubTokenPropagationForAgents?: unknown;
+  };
+
+  assert.equal(typeof uiModule.syncGitHubTokenPropagationForAgents, 'function');
+
+  const syncGitHubTokenPropagationForAgents = uiModule.syncGitHubTokenPropagationForAgents as (params: {
+    githubTokenSecretRef: string;
+    selectedAgentIds: string[];
+    previousAgentIds?: string[];
+  }) => Promise<void>;
+  const originalFetch = globalThis.fetch;
+  const patchBodies: Array<{ agentId: string; body: Record<string, unknown> }> = [];
+  let inFlight = 0;
+  let maxInFlight = 0;
+
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = getRequestUrl(input);
+    const method = (init?.method ?? 'GET').toUpperCase();
+
+    if (!url.startsWith('/api/agents/')) {
+      throw new Error(`Unexpected fetch request: ${method} ${url}`);
+    }
+
+    const agentId = url.slice('/api/agents/'.length);
+    inFlight += 1;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+
+    await delay(20);
+
+    try {
+      if (method === 'GET') {
+        return jsonResponse({
+          id: agentId,
+          companyId: 'company-1',
+          adapterConfig: {
+            cwd: `/tmp/${agentId}`
+          }
+        });
+      }
+
+      if (method === 'PATCH') {
+        patchBodies.push({
+          agentId,
+          body: getJsonRequestBody(init) ?? {}
+        });
+        return jsonResponse({ ok: true });
+      }
+
+      throw new Error(`Unexpected fetch request: ${method} ${url}`);
+    } finally {
+      inFlight -= 1;
+    }
+  };
+
+  try {
+    await syncGitHubTokenPropagationForAgents({
+      githubTokenSecretRef: 'github-secret-ref',
+      selectedAgentIds: ['agent-1', 'agent-2', 'agent-3', 'agent-4', 'agent-5', 'agent-6']
+    });
+
+    assert.ok(maxInFlight > 1);
+    assert.ok(maxInFlight <= 4);
+    assert.deepEqual(
+      [...patchBodies].sort((left, right) => left.agentId.localeCompare(right.agentId)),
+      [
+        'agent-1',
+        'agent-2',
+        'agent-3',
+        'agent-4',
+        'agent-5',
+        'agent-6'
+      ].map((agentId) => ({
+        agentId,
+        body: {
+          adapterConfig: {
+            cwd: `/tmp/${agentId}`,
+            env: {
+              GITHUB_TOKEN: {
+                type: 'secret_ref',
+                secretId: 'github-secret-ref'
+              }
+            }
+          }
+        }
+      }))
+    );
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -545,6 +545,142 @@ test('resolveOrCreateProject enables isolated issue checkouts for new company pr
   }
 });
 
+test('settings UI no longer exports a local authenticated-controls preview override', async () => {
+  const uiModule = await importFreshUiModule() as {
+    shouldShowAuthenticatedControlsPreview?: unknown;
+  };
+
+  assert.equal(uiModule.shouldShowAuthenticatedControlsPreview, undefined);
+});
+
+test('syncGitHubTokenPropagationForAgents adds and removes agent GITHUB_TOKEN secret refs without clobbering unrelated env config', async () => {
+  const uiModule = await importFreshUiModule() as {
+    syncGitHubTokenPropagationForAgents?: unknown;
+  };
+
+  assert.equal(typeof uiModule.syncGitHubTokenPropagationForAgents, 'function');
+
+  const syncGitHubTokenPropagationForAgents = uiModule.syncGitHubTokenPropagationForAgents as (params: {
+    githubTokenSecretRef: string;
+    selectedAgentIds: string[];
+    previousAgentIds?: string[];
+  }) => Promise<void>;
+  const originalFetch = globalThis.fetch;
+  const patchBodies: Array<{ agentId: string; body: Record<string, unknown> }> = [];
+
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = getRequestUrl(input);
+    const method = (init?.method ?? 'GET').toUpperCase();
+
+    if (url === '/api/agents/agent-1' && method === 'GET') {
+      return jsonResponse({
+        id: 'agent-1',
+        companyId: 'company-1',
+        adapterConfig: {
+          cwd: '/tmp/agent-1',
+          env: {
+            EXISTING: {
+              type: 'plain',
+              value: '1'
+            }
+          }
+        }
+      });
+    }
+
+    if (url === '/api/agents/agent-2' && method === 'GET') {
+      return jsonResponse({
+        id: 'agent-2',
+        companyId: 'company-1',
+        adapterConfig: {
+          model: 'gpt-5.4',
+          env: {
+            GITHUB_TOKEN: {
+              type: 'secret_ref',
+              secretId: 'github-secret-ref'
+            },
+            KEEP_ME: {
+              type: 'plain',
+              value: '2'
+            }
+          }
+        }
+      });
+    }
+
+    if (url === '/api/agents/agent-3' && method === 'GET') {
+      return jsonResponse({
+        id: 'agent-3',
+        companyId: 'company-1',
+        adapterConfig: {
+          env: {
+            GITHUB_TOKEN: {
+              type: 'secret_ref',
+              secretId: 'different-secret-ref'
+            }
+          }
+        }
+      });
+    }
+
+    if (url.startsWith('/api/agents/') && method === 'PATCH') {
+      const agentId = url.slice('/api/agents/'.length);
+      patchBodies.push({
+        agentId,
+        body: getJsonRequestBody(init) ?? {}
+      });
+      return jsonResponse({ ok: true });
+    }
+
+    throw new Error(`Unexpected fetch request: ${method} ${url}`);
+  };
+
+  try {
+    await syncGitHubTokenPropagationForAgents({
+      githubTokenSecretRef: 'github-secret-ref',
+      selectedAgentIds: ['agent-1'],
+      previousAgentIds: ['agent-1', 'agent-2', 'agent-3']
+    });
+
+    assert.deepEqual(patchBodies, [
+      {
+        agentId: 'agent-1',
+        body: {
+          adapterConfig: {
+            cwd: '/tmp/agent-1',
+            env: {
+              EXISTING: {
+                type: 'plain',
+                value: '1'
+              },
+              GITHUB_TOKEN: {
+                type: 'secret_ref',
+                secretId: 'github-secret-ref'
+              }
+            }
+          }
+        }
+      },
+      {
+        agentId: 'agent-2',
+        body: {
+          adapterConfig: {
+            model: 'gpt-5.4',
+            env: {
+              KEEP_ME: {
+                type: 'plain',
+                value: '2'
+              }
+            }
+          }
+        }
+      }
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('resolveInstalledGitHubSyncPluginId finds the GitHub Sync installation id from plugin listings', () => {
   const records = [
     {
@@ -5883,6 +6019,89 @@ test('worker scopes mapping saves and settings reads to the requested company', 
   });
 });
 
+test('worker scopes github token propagation agent selections to the requested company', async () => {
+  const harness = createTestHarness({ manifest });
+  await plugin.definition.setup(harness.ctx);
+
+  await harness.performAction('settings.saveRegistration', {
+    companyId: 'company-1',
+    advancedSettings: {
+      defaultStatus: 'todo',
+      ignoredIssueAuthorUsernames: ['renovate'],
+      githubTokenPropagationAgentIds: ['agent-2', 'agent-1', 'agent-2']
+    },
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  await harness.performAction('settings.saveRegistration', {
+    companyId: 'company-2',
+    advancedSettings: {
+      defaultStatus: 'backlog',
+      ignoredIssueAuthorUsernames: ['dependabot'],
+      githubTokenPropagationAgentIds: ['agent-3']
+    },
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  const companyOneResult = await harness.getData<{
+    advancedSettings: {
+      defaultStatus: string;
+      ignoredIssueAuthorUsernames: string[];
+      githubTokenPropagationAgentIds?: string[];
+    };
+  }>('settings.registration', {
+    companyId: 'company-1'
+  });
+  const companyTwoResult = await harness.getData<{
+    advancedSettings: {
+      defaultStatus: string;
+      ignoredIssueAuthorUsernames: string[];
+      githubTokenPropagationAgentIds?: string[];
+    };
+  }>('settings.registration', {
+    companyId: 'company-2'
+  });
+
+  assert.deepEqual(companyOneResult.advancedSettings, {
+    defaultStatus: 'todo',
+    ignoredIssueAuthorUsernames: ['renovate'],
+    githubTokenPropagationAgentIds: ['agent-1', 'agent-2']
+  });
+  assert.deepEqual(companyTwoResult.advancedSettings, {
+    defaultStatus: 'backlog',
+    ignoredIssueAuthorUsernames: ['dependabot'],
+    githubTokenPropagationAgentIds: ['agent-3']
+  });
+
+  const savedSettings = harness.getState({
+    scopeKind: 'instance',
+    stateKey: 'paperclip-github-plugin-settings'
+  }) as {
+    companyAdvancedSettingsByCompanyId: Record<string, {
+      defaultStatus: string;
+      ignoredIssueAuthorUsernames: string[];
+      githubTokenPropagationAgentIds?: string[];
+    }>;
+  };
+
+  assert.deepEqual(savedSettings.companyAdvancedSettingsByCompanyId, {
+    'company-1': {
+      defaultStatus: 'todo',
+      ignoredIssueAuthorUsernames: ['renovate'],
+      githubTokenPropagationAgentIds: ['agent-1', 'agent-2']
+    },
+    'company-2': {
+      defaultStatus: 'backlog',
+      ignoredIssueAuthorUsernames: ['dependabot'],
+      githubTokenPropagationAgentIds: ['agent-3']
+    }
+  });
+});
+
 test('worker normalizes owner/repo slugs to canonical GitHub URLs when saving mappings', async () => {
   const harness = createTestHarness({ manifest });
   await plugin.definition.setup(harness.ctx);
@@ -6047,6 +6266,37 @@ test('settings.registration reports a configured token without resolving the sav
   assert.equal(resolveCount, 0);
 });
 
+test('settings.saveRegistration persists the saved GitHub login label for later settings reads', async () => {
+  const harness = createTestHarness({ manifest });
+  await plugin.definition.setup(harness.ctx);
+
+  const saveResult = await harness.performAction('settings.saveRegistration', {
+    githubTokenRef: 'github-secret-ref',
+    githubTokenLogin: 'octocat'
+  }) as {
+    githubTokenLogin?: string;
+  };
+
+  assert.equal(saveResult.githubTokenLogin, 'octocat');
+
+  const savedSettings = harness.getState({
+    scopeKind: 'instance',
+    stateKey: 'paperclip-github-plugin-settings'
+  }) as {
+    githubTokenLogin?: string;
+  };
+
+  assert.equal(savedSettings.githubTokenLogin, 'octocat');
+
+  const registrationResult = await harness.getData<{
+    githubTokenConfigured?: boolean;
+    githubTokenLogin?: string;
+  }>('settings.registration');
+
+  assert.equal(registrationResult.githubTokenConfigured, true);
+  assert.equal(registrationResult.githubTokenLogin, 'octocat');
+});
+
 test('settings.registration reports a configured token from the external config file without resolving secrets', { concurrency: false }, async () => {
   await withExternalPluginConfig(
     {
@@ -6137,6 +6387,52 @@ test('settings.registration reports company-specific board access without resolv
   assert.equal(companyTwoResult.paperclipBoardAccessConfigured, false);
   assert.equal(companyTwoResult.paperclipBoardAccessNeedsConfigSync, false);
   assert.equal(resolveCount, 0);
+});
+
+test('settings.updateBoardAccess persists a company-specific board access identity label', async () => {
+  const harness = createTestHarness({ manifest });
+  await plugin.definition.setup(harness.ctx);
+
+  const actionResult = await harness.performAction('settings.updateBoardAccess', {
+    companyId: 'company-1',
+    paperclipBoardApiTokenRef: 'board-secret-ref',
+    paperclipBoardAccessIdentity: 'Jane Operator'
+  }) as {
+    paperclipBoardAccessConfigured?: boolean;
+    paperclipBoardAccessIdentity?: string;
+  };
+
+  assert.equal(actionResult.paperclipBoardAccessConfigured, true);
+  assert.equal(actionResult.paperclipBoardAccessIdentity, 'Jane Operator');
+
+  const savedSettings = harness.getState({
+    scopeKind: 'instance',
+    stateKey: 'paperclip-github-plugin-settings'
+  }) as {
+    paperclipBoardAccessIdentityByCompanyId?: Record<string, string>;
+  };
+
+  assert.deepEqual(savedSettings.paperclipBoardAccessIdentityByCompanyId, {
+    'company-1': 'Jane Operator'
+  });
+
+  const companyOneResult = await harness.getData<{
+    paperclipBoardAccessConfigured?: boolean;
+    paperclipBoardAccessIdentity?: string;
+  }>('settings.registration', {
+    companyId: 'company-1'
+  });
+  const companyTwoResult = await harness.getData<{
+    paperclipBoardAccessConfigured?: boolean;
+    paperclipBoardAccessIdentity?: string;
+  }>('settings.registration', {
+    companyId: 'company-2'
+  });
+
+  assert.equal(companyOneResult.paperclipBoardAccessConfigured, true);
+  assert.equal(companyOneResult.paperclipBoardAccessIdentity, 'Jane Operator');
+  assert.equal(companyTwoResult.paperclipBoardAccessConfigured, false);
+  assert.equal(companyTwoResult.paperclipBoardAccessIdentity, undefined);
 });
 
 test('settings.registration reports company-specific board access from plugin config without resolving the saved secret', async () => {


### PR DESCRIPTION
## Summary

- add an authenticated-only agent multi-select so the saved GitHub token can be propagated to selected company agents as `GITHUB_TOKEN` secret refs
- persist non-secret GitHub and board identity labels so the settings page keeps `Authenticated as ...` and `Connected as ...` copy on later visits
- document the authenticated host behavior and remove the temporary local preview override so those controls only render when the deployment actually requires them

## Why

Authenticated Paperclip deployments need board access before GitHub Sync agent tools can be reached, and operators needed a supported way to share the plugin-managed GitHub token with selected agents without exposing raw credentials or surfacing those controls on unauthenticated hosts.

## Validation

- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Model Used

- Primary model: `gpt-5.4`
- Codex profile: `gpt-5-3-codex`
- Context window: not exposed by the local Codex Desktop runtime/config
- Reasoning effort: `xhigh`
- Tool use: local shell, `git`, `gh`, and repo verification commands
