### PR TITLE
[codex] Store GitHub token as company secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ With this plugin, you can:
 The plugin adds a full in-host workflow instead of a one-off import script:
 
 - a hosted settings page for GitHub auth, repository mappings, company defaults, and sync controls
-- authenticated-only setup controls for Paperclip board access and company-scoped agent token propagation
+- setup controls for Paperclip board access and company-scoped agent token propagation on authenticated and `local_trusted` deployments
 - a dashboard widget that shows readiness, sync status, and last-run results
 - saved sync diagnostics that let operators inspect the latest per-issue failures, raw errors, and suggested next steps
 - a project sidebar item that opens a live project-scoped Pull Requests page for the mapped repository and can show the open PR count through a lightweight badge read
@@ -39,7 +39,7 @@ The plugin adds a full in-host workflow instead of a one-off import script:
 
 ## How it works
 
-1. Save a GitHub token in the plugin settings.
+1. Save a GitHub token in the plugin settings for the current company.
 2. Connect one or more GitHub repositories to Paperclip projects.
 3. Run a sync manually or let the scheduled job keep things up to date.
 
@@ -53,7 +53,7 @@ Long-running syncs continue in the background, so quick actions do not have to w
 
 ### Company-aware configuration
 
-GitHub tokens and sync cadence are shared at the plugin instance level, while repository mappings, advanced import defaults, and Paperclip board access are managed per company. When you open settings inside a specific company, you only edit that company's mappings and defaults.
+GitHub tokens, repository mappings, advanced import defaults, and Paperclip board access are all managed per company, while sync cadence remains shared at the plugin instance level. When you open settings inside a specific company, you only edit that company's setup and defaults.
 
 ### Project binding that respects existing work
 
@@ -107,14 +107,15 @@ npx paperclipai plugin install --local "$PWD"
 
 1. Open the plugin settings for **GitHub Sync** from inside the Paperclip company you want to configure.
 2. Paste a GitHub token, validate it, and save it.
-3. If the deployment is authenticated, connect Paperclip board access from the same settings page and complete the approval flow.
-4. If the deployment is authenticated, choose which agents in the current company should receive the saved GitHub token as `GITHUB_TOKEN`.
-5. Add one or more repository mappings for the current company.
-6. For each mapping, either choose an existing GitHub-linked Paperclip project or enter the project name that should receive synced issues.
-7. Optionally configure company-wide defaults for imported issues, including the default assignee, the default Paperclip status, and ignored GitHub usernames. Bot aliases such as `renovate[bot]` are matched when you save `renovate`.
-8. Choose the automatic sync interval in minutes.
-9. Save the settings and run the first manual sync.
-10. Repeat inside other companies if they need their own mappings, defaults, board access, or agent token propagation.
+3. If the deployment is authenticated or `local_trusted`, the settings page shows Paperclip board access and GitHub token propagation controls so you can configure and test them locally.
+4. If the deployment is authenticated, connect Paperclip board access from the same settings page and complete the approval flow before running sync.
+5. If the deployment is authenticated or `local_trusted`, choose which agents in the current company should receive the saved GitHub token as `GITHUB_TOKEN`.
+6. Add one or more repository mappings for the current company.
+7. For each mapping, either choose an existing GitHub-linked Paperclip project or enter the project name that should receive synced issues.
+8. Optionally configure company-wide defaults for imported issues, including the default assignee, the default Paperclip status, and ignored GitHub usernames. Bot aliases such as `renovate[bot]` are matched when you save `renovate`.
+9. Choose the automatic sync interval in minutes.
+10. Save the settings and run the first manual sync.
+11. Repeat inside other companies if they need their own mappings, defaults, board access, or agent token propagation.
 
 Repository input accepts either `owner/repo` or `https://github.com/owner/repo`.
 When a token is saved, the settings page audits the mapped repositories for the permissions needed by pull request actions and warns when permissions are missing or GitHub cannot verify them yet.
@@ -153,10 +154,11 @@ Additional behavior:
 
 The plugin is designed to avoid persisting raw credentials in plugin state.
 
-- GitHub tokens saved through the UI are stored as Paperclip secret references.
+- GitHub tokens saved through the UI are stored as per-company Paperclip secret references.
 - Paperclip board access tokens are also stored as per-company secret references.
-- The settings UI also keeps lightweight non-secret identity labels for those saved connections, so later visits can still show who the shared GitHub token and company board access are connected as.
-- On authenticated deployments, any selected propagation agents receive `GITHUB_TOKEN` as an agent env secret-ref binding that points at the same saved GitHub token secret instead of a copied raw token.
+- The settings UI also keeps lightweight non-secret identity labels for those saved connections, so later visits can still show who that company’s GitHub token and board access are connected as.
+- On authenticated and `local_trusted` deployments, any selected propagation agents receive `GITHUB_TOKEN` as an agent env secret-ref binding that points at the same saved GitHub token secret instead of a copied raw token.
+- If an older save left the company token secret only in plugin state, the settings UI repairs the config mirror and retries selected-agent propagation from that same company secret.
 - The worker resolves those secret references at runtime instead of storing raw tokens in plugin state.
 - On authenticated Paperclip deployments, sync is blocked until the relevant company has connected Paperclip board access.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -6,10 +6,10 @@ GitHub Sync is a Paperclip plugin for registering one or more GitHub repositorie
 
 The plugin MUST provide a settings page inside Paperclip where an operator can configure:
 
-- a GitHub token stored as a Paperclip secret reference
+- a company-scoped GitHub token stored as a Paperclip secret reference
 - an optional external config file at `${PAPERCLIP_HOME:-~/.paperclip}/plugins/github-sync/config.json` for worker-only global values such as a raw `githubToken`
 - Paperclip board access, which is optional on unauthenticated deployments and required when the Paperclip deployment reports `deploymentMode: "authenticated"`
-- on authenticated deployments, a company-scoped multi-select of agents that should receive `GITHUB_TOKEN` propagation from the saved GitHub token secret
+- on authenticated and `local_trusted` deployments, a company-scoped multi-select of agents that should receive `GITHUB_TOKEN` propagation from the saved GitHub token secret, while authenticated deployments remain the only mode where board access is required for sync
 - one or more GitHub repository mappings
 - company-scoped advanced defaults for imported issues: default assignee, default Paperclip status, and ignored GitHub issue authors, where a saved username such as `renovate` also matches GitHub bot logins such as `renovate[bot]`
 - the frequency for automatic scheduled sync runs
@@ -21,7 +21,7 @@ The settings page MUST allow saving mappings and triggering a manual sync.
 - The settings page SHOULD clearly label company-scoped setup versus plugin-instance-wide setup when both are shown together.
 - When a company context is present, the settings page SHOULD show the active company name prominently using a human-friendly label instead of a raw identifier.
 - When a company already has Paperclip projects bound to GitHub repository workspaces, the settings page SHOULD surface those projects so an operator can enable sync without recreating the project.
-- The settings page MUST only render the Paperclip board-access connect controls and the agent token-propagation selector when the current Paperclip deployment reports `deploymentMode: "authenticated"`.
+- The settings page MUST render the Paperclip board-access connect controls and the agent token-propagation selector when the current Paperclip deployment reports `deploymentMode: "authenticated"` or `deploymentMode: "local_trusted"`.
 - When the settings page successfully validates a saved GitHub token, it SHOULD persist the validated GitHub login as non-secret display metadata so later visits can continue showing `Authenticated as ...` instead of falling back to a generic ready state.
 - When the settings page successfully connects Paperclip board access for a company, it SHOULD persist a company-scoped non-secret identity label so later visits can continue showing `Connected as ...` instead of falling back to a generic connected state.
 - The plugin SHOULD also expose manual sync entry points from Paperclip toolbar surfaces when the SDK supports them.
@@ -33,11 +33,12 @@ The settings page MUST allow saving mappings and triggering a manual sync.
 
 - The raw GitHub token MUST NOT be persisted in plugin state.
 - Saving a token from the settings UI MUST create or reuse a company secret through the Paperclip host API.
-- The plugin MUST persist only the resulting secret UUID in plugin instance config.
-- The worker MUST resolve that secret UUID at runtime via `ctx.secrets.resolve(...)`.
-- The plugin MAY persist lightweight non-secret display metadata such as the validated GitHub login alongside the saved GitHub token secret ref so hosted UI can keep connected-state copy consistent across refreshes without resolving the secret.
-- When authenticated deployment settings select agents for GitHub token propagation, the hosted settings UI MUST patch those agents through the host API so `adapterConfig.env.GITHUB_TOKEN` points at that same secret UUID instead of copying the raw token value.
-- When an authenticated deployment settings save removes an agent from that propagation allowlist, the hosted settings UI SHOULD remove `adapterConfig.env.GITHUB_TOKEN` only when that binding still points at the plugin-managed secret UUID, so unrelated manual agent env settings are not clobbered.
+- The plugin MUST persist only the resulting secret UUID, keyed by company, in plugin instance config.
+- The worker MUST resolve the saved GitHub token secret for the active company at runtime via `ctx.secrets.resolve(...)`.
+- The plugin MAY persist lightweight company-scoped non-secret display metadata such as the validated GitHub login alongside the saved GitHub token secret ref so hosted UI can keep connected-state copy consistent across refreshes without resolving the secret.
+- When authenticated or `local_trusted` deployment settings select agents for GitHub token propagation, the hosted settings UI MUST patch those agents through the host API so `adapterConfig.env.GITHUB_TOKEN` points at that same secret UUID instead of copying the raw token value.
+- When an authenticated or `local_trusted` deployment settings save removes an agent from that propagation allowlist, the hosted settings UI SHOULD remove `adapterConfig.env.GITHUB_TOKEN` only when that binding still points at the plugin-managed secret UUID, so unrelated manual agent env settings are not clobbered.
+- When the worker or hosted UI detects that a saved company-scoped GitHub token secret has not been mirrored into plugin config yet, it SHOULD repair that config sync and retry selected-agent `GITHUB_TOKEN` propagation from the saved company secret ref.
 - If `${PAPERCLIP_HOME:-~/.paperclip}/plugins/github-sync/config.json` exists and contains a string `githubToken`, the worker MUST treat it as a worker-only fallback source for the GitHub token without persisting or returning that raw token.
 - The raw Paperclip board API token MUST NOT be persisted in plugin state.
 - Connecting Paperclip board access from the settings UI MUST create or reuse a company secret through the Paperclip host API and MUST persist only the resulting secret UUID, keyed by company in plugin state and mirrored into plugin instance config so the worker can resolve it.

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -46,9 +46,12 @@ export const manifest: PaperclipPluginManifestV1 = {
   instanceConfigSchema: {
     type: 'object',
     properties: {
-      githubTokenRef: {
-        type: 'string',
-        title: 'GitHub Token Secret'
+      githubTokenRefs: {
+        type: 'object',
+        title: 'GitHub Token Secrets',
+        additionalProperties: {
+          type: 'string'
+        }
       },
       paperclipBoardApiTokenRefs: {
         type: 'object',

--- a/src/paperclip-health.ts
+++ b/src/paperclip-health.ts
@@ -33,3 +33,9 @@ export function requiresPaperclipBoardAccess(value: unknown): boolean {
   const health = normalizePaperclipHealthResponse(value);
   return health?.deploymentMode?.toLowerCase() === 'authenticated';
 }
+
+export function shouldShowPaperclipBoardAccessSettings(value: unknown): boolean {
+  const health = normalizePaperclipHealthResponse(value);
+  const deploymentMode = health?.deploymentMode?.toLowerCase();
+  return deploymentMode === 'authenticated' || deploymentMode === 'local_trusted';
+}

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -12,7 +12,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
 import { parseRepositoryReference, type ParsedRepositoryReference } from '../github-repo.ts';
-import { requiresPaperclipBoardAccess } from '../paperclip-health.ts';
+import { requiresPaperclipBoardAccess, shouldShowPaperclipBoardAccessSettings } from '../paperclip-health.ts';
 import { normalizeCompanyAssigneeOptionsResponse, type GitHubSyncAssigneeOption } from './assignees.ts';
 import { buildPaperclipUrl, fetchJson, fetchPaperclipHealth, resolveCliAuthPollUrl } from './http.ts';
 import { resolveInstalledGitHubSyncPluginId, resolvePluginSettingsHref } from './plugin-installation.ts';
@@ -235,6 +235,8 @@ interface GitHubSyncSettings {
   paperclipApiBaseUrl?: string;
   githubTokenConfigured?: boolean;
   githubTokenLogin?: string;
+  githubTokenNeedsConfigSync?: boolean;
+  githubTokenConfigSyncRef?: string;
   paperclipBoardAccessConfigured?: boolean;
   paperclipBoardAccessIdentity?: string;
   paperclipBoardAccessNeedsConfigSync?: boolean;
@@ -801,8 +803,10 @@ function getSyncSetupMessage(
 function usePaperclipBoardAccessRequirement(): {
   status: BoardAccessRequirementStatus;
   required: boolean;
+  visible: boolean;
 } {
   const [status, setStatus] = useState<BoardAccessRequirementStatus>('loading');
+  const [visible, setVisible] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -815,9 +819,11 @@ function usePaperclipBoardAccessRequirement(): {
 
       if (!health) {
         setStatus('unknown');
+        setVisible(false);
         return;
       }
 
+      setVisible(shouldShowPaperclipBoardAccessSettings(health));
       setStatus(requiresPaperclipBoardAccess(health) ? 'required' : 'not_required');
     })();
 
@@ -828,7 +834,8 @@ function usePaperclipBoardAccessRequirement(): {
 
   return {
     status,
-    required: status === 'required'
+    required: status === 'required',
+    visible
   };
 }
 
@@ -10046,6 +10053,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
   const themeMode = useResolvedThemeMode();
   const boardAccessRequirement = usePaperclipBoardAccessRequirement();
   const armSyncCompletionToast = useSyncCompletionToast(form.syncState, toast);
+  const githubTokenConfigSyncAttemptRef = useRef<string | null>(null);
   const boardAccessConfigSyncAttemptRef = useRef<string | null>(null);
   const assigneeFallbackAttemptRef = useRef<string | null>(null);
 
@@ -10182,6 +10190,91 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
       cancelled = true;
     };
   }, [currentSettings?.availableAssignees?.length, currentSettings?.updatedAt, hostContext.companyId]);
+
+  useEffect(() => {
+    const companyId = hostContext.companyId;
+    const secretRef =
+      settings.data?.githubTokenNeedsConfigSync
+        ? settings.data.githubTokenConfigSyncRef
+        : undefined;
+
+    if (!companyId || !secretRef) {
+      return;
+    }
+
+    const attemptKey = `${companyId}:${secretRef}`;
+    if (githubTokenConfigSyncAttemptRef.current === attemptKey) {
+      return;
+    }
+    githubTokenConfigSyncAttemptRef.current = attemptKey;
+
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const pluginId = await resolveCurrentPluginId(pluginIdFromLocation);
+        if (!pluginId) {
+          throw new Error('Plugin id is required to finish syncing the GitHub token secret into plugin config.');
+        }
+
+        await patchPluginConfig(pluginId, {
+          githubTokenRefs: {
+            [companyId]: secretRef
+          }
+        });
+
+        if (cancelled) {
+          return;
+        }
+
+        const selectedAgentIds = normalizeAgentIds(settings.data?.advancedSettings?.githubTokenPropagationAgentIds);
+        if (selectedAgentIds.length > 0) {
+          try {
+            await propagateGitHubTokenToSelectedAgents({
+              selectedAgentIds,
+              previousAgentIds: selectedAgentIds,
+              githubTokenSecretRef: secretRef
+            });
+          } catch {
+            // Let the later refresh keep the saved token visible even if propagation needs manual attention.
+          }
+        }
+
+        notifyGitHubSyncSettingsChanged();
+
+        try {
+          await settings.refresh();
+        } catch {
+          return;
+        }
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+
+        toast({
+          title: 'GitHub token needs reconnection',
+          body: getActionErrorMessage(
+            error,
+            'GitHub Sync could not finish migrating the saved GitHub token secret into plugin config.'
+          ),
+          tone: 'error'
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    hostContext.companyId,
+    pluginIdFromLocation,
+    settings.data?.advancedSettings?.githubTokenPropagationAgentIds,
+    settings.data?.githubTokenConfigSyncRef,
+    settings.data?.githubTokenNeedsConfigSync,
+    settings.refresh,
+    toast
+  ]);
 
   useEffect(() => {
     const companyId = hostContext.companyId;
@@ -10336,6 +10429,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
   const hasSavedToken = Boolean(form.githubTokenConfigured || showSavedTokenHint);
   const boardAccessConfigured = Boolean(form.paperclipBoardAccessConfigured);
   const boardAccessRequired = boardAccessRequirement.required;
+  const boardAccessVisible = boardAccessRequirement.visible;
   const boardAccessReady = !boardAccessRequired || (hasCompanyContext && boardAccessConfigured);
   const tokenStatus = tokenStatusOverride ?? (hasSavedToken ? 'valid' : 'required');
   const tokenTone: Tone = tokenStatus === 'valid' ? 'success' : tokenStatus === 'invalid' ? 'danger' : 'warning';
@@ -10524,7 +10618,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
   const manualSyncScopePillLabel = hasCompanyContext ? 'This company' : 'All companies';
   const manualSyncButtonLabel = hasCompanyContext ? 'Run sync for this company' : 'Run sync across all companies';
   const advancedSettingsSummary = formatAdvancedSettingsSummary(form.advancedSettings, availableAssignees, {
-    includePropagation: boardAccessRequired
+    includePropagation: boardAccessVisible
   });
   const assigneeSelectOptions: SettingsSelectOption[] = [
     { value: '', label: 'Unassigned' },
@@ -10709,7 +10803,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
     previousAgentIds?: string[];
     githubTokenSecretRef?: string;
   }): Promise<void> {
-    if (!boardAccessRequired) {
+    if (!boardAccessVisible) {
       return;
     }
 
@@ -10725,13 +10819,18 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
         : undefined;
 
     if (!githubTokenSecretRef) {
+      const companyId = hostContext.companyId;
+      if (!companyId) {
+        throw new Error('Company context is required to propagate the GitHub token to selected agents.');
+      }
+
       const pluginId = await resolveCurrentPluginId(pluginIdFromLocation);
       if (!pluginId) {
         throw new Error('Plugin id is required to propagate the GitHub token to selected agents.');
       }
 
       const currentConfigResponse = await fetchJson<PluginConfigResponse | null>(`/api/plugins/${pluginId}/config`);
-      githubTokenSecretRef = normalizePluginConfig(currentConfigResponse?.configJson).githubTokenRef;
+      githubTokenSecretRef = normalizePluginConfig(currentConfigResponse?.configJson).githubTokenRefs?.[companyId];
     }
 
     if (!githubTokenSecretRef) {
@@ -10793,7 +10892,9 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
       const secret = await resolveOrCreateCompanySecret(companyId, secretName, trimmedToken);
 
       await patchPluginConfig(pluginId, {
-        githubTokenRef: secret.id
+        githubTokenRefs: {
+          [companyId]: secret.id
+        }
       });
       await saveRegistration({
         companyId,
@@ -11348,7 +11449,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
             ) : null}
           </section>
 
-          {boardAccessRequired ? (
+          {boardAccessVisible ? (
             <section className="ghsync__section">
               <div className="ghsync__section-head">
                 <div className="ghsync__section-copy">
@@ -11386,7 +11487,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
                           ? 'Required in authenticated deployments.'
                           : boardAccessRequirement.status === 'loading'
                             ? 'Checking whether it is required.'
-                            : 'Only needed when Paperclip API calls require sign-in.'}
+                            : 'Available here for local testing and only required when Paperclip API calls need sign-in.'}
                     </span>
                   </div>
                   <button
@@ -11670,7 +11771,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
                   <p className="ghsync__hint">Comma or newline separated.</p>
                 </div>
 
-                {boardAccessRequired ? (
+                {boardAccessVisible ? (
                   <div className="ghsync__field">
                     <label htmlFor="advanced-token-propagation">Propagate GitHub token to agents</label>
                     <SettingsAgentMultiPicker
@@ -11902,7 +12003,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
               </span>
             </div>
 
-            {boardAccessRequired ? (
+            {boardAccessVisible ? (
               <div className="ghsync__check">
                 <div className="ghsync__check-top">
                   <strong>Paperclip board access</strong>

--- a/src/ui/plugin-config.ts
+++ b/src/ui/plugin-config.ts
@@ -1,7 +1,8 @@
 export type PluginConfigBoardTokenRefs = Record<string, string>;
+export type PluginConfigGitHubTokenRefs = Record<string, string>;
 
 export interface GitHubSyncPluginConfig extends Record<string, unknown> {
-  githubTokenRef?: string;
+  githubTokenRefs?: PluginConfigGitHubTokenRefs;
   paperclipBoardApiTokenRefs?: PluginConfigBoardTokenRefs;
   paperclipApiBaseUrl?: string;
 }
@@ -45,20 +46,42 @@ export function normalizePluginConfigBoardTokenRefs(value: unknown): PluginConfi
   return Object.fromEntries(entries);
 }
 
+export function normalizePluginConfigGitHubTokenRefs(value: unknown): PluginConfigGitHubTokenRefs | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .map(([companyId, secretRef]) => {
+      const normalizedCompanyId = normalizeOptionalString(companyId);
+      const normalizedSecretRef = normalizeOptionalString(secretRef);
+      return normalizedCompanyId && normalizedSecretRef
+        ? [normalizedCompanyId, normalizedSecretRef] as const
+        : null;
+    })
+    .filter((entry): entry is readonly [string, string] => Boolean(entry));
+
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(entries);
+}
+
 export function normalizePluginConfig(value: unknown): GitHubSyncPluginConfig {
   if (!value || typeof value !== 'object') {
     return {};
   }
 
   const record = { ...(value as Record<string, unknown>) };
-  const githubTokenRef = normalizeOptionalString(record.githubTokenRef);
+  const githubTokenRefs = normalizePluginConfigGitHubTokenRefs(record.githubTokenRefs);
   const paperclipBoardApiTokenRefs = normalizePluginConfigBoardTokenRefs(record.paperclipBoardApiTokenRefs);
   const paperclipApiBaseUrl = normalizePaperclipApiBaseUrl(record.paperclipApiBaseUrl);
 
-  if (githubTokenRef) {
-    record.githubTokenRef = githubTokenRef;
+  if (githubTokenRefs) {
+    record.githubTokenRefs = githubTokenRefs;
   } else {
-    delete record.githubTokenRef;
+    delete record.githubTokenRefs;
   }
 
   if (paperclipBoardApiTokenRefs) {
@@ -81,12 +104,29 @@ export function mergePluginConfig(
   patch: Partial<GitHubSyncPluginConfig>
 ): GitHubSyncPluginConfig {
   const current = normalizePluginConfig(currentValue);
+  const currentGitHubTokenRefs = normalizePluginConfigGitHubTokenRefs(current.githubTokenRefs);
+  const patchGitHubTokenRefs = normalizePluginConfigGitHubTokenRefs(patch.githubTokenRefs);
   const currentBoardTokenRefs = normalizePluginConfigBoardTokenRefs(current.paperclipBoardApiTokenRefs);
   const patchBoardTokenRefs = normalizePluginConfigBoardTokenRefs(patch.paperclipBoardApiTokenRefs);
   const next = normalizePluginConfig({
     ...current,
     ...patch
   });
+
+  if ('githubTokenRefs' in patch) {
+    const mergedGitHubTokenRefs = {
+      ...(currentGitHubTokenRefs ?? {}),
+      ...(patchGitHubTokenRefs ?? {})
+    };
+
+    if (Object.keys(mergedGitHubTokenRefs).length > 0) {
+      next.githubTokenRefs = mergedGitHubTokenRefs;
+    } else {
+      delete next.githubTokenRefs;
+    }
+  } else if (currentGitHubTokenRefs) {
+    next.githubTokenRefs = currentGitHubTokenRefs;
+  }
 
   if ('paperclipBoardApiTokenRefs' in patch) {
     const mergedBoardTokenRefs = {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -88,7 +88,9 @@ type PaperclipIssueUpdatePatchWithLabels = Parameters<PluginSetupContext['issues
 };
 type PaperclipLabelDirectory = Map<string, PaperclipIssueLabel[]>;
 type PaperclipBoardApiTokenRefs = Record<string, string>;
+type GitHubTokenRefs = Record<string, string>;
 type PaperclipBoardAccessIdentityByCompanyId = Record<string, string>;
+type GitHubTokenLoginsByCompanyId = Record<string, string>;
 type CompanyAdvancedSettingsByCompanyId = Record<string, GitHubSyncAdvancedSettings>;
 type ProjectPullRequestFilter = 'all' | 'mergeable' | 'reviewable' | 'failing';
 type ProjectPullRequestUpToDateStatus = 'up_to_date' | 'can_update' | 'conflicts' | 'unknown';
@@ -335,6 +337,8 @@ interface GitHubSyncSettings {
   syncState: SyncRunState;
   scheduleFrequencyMinutes: number;
   paperclipApiBaseUrl?: string;
+  githubTokenRefs?: GitHubTokenRefs;
+  githubTokenLoginsByCompanyId?: GitHubTokenLoginsByCompanyId;
   githubTokenRef?: string;
   githubTokenLogin?: string;
   paperclipBoardApiTokenRefs?: PaperclipBoardApiTokenRefs;
@@ -345,6 +349,7 @@ interface GitHubSyncSettings {
 }
 
 interface GitHubSyncConfig {
+  githubTokenRefs?: GitHubTokenRefs;
   githubTokenRef?: string;
   githubToken?: string;
   paperclipBoardApiTokenRefs?: PaperclipBoardApiTokenRefs;
@@ -3211,7 +3216,7 @@ async function hydrateRecoveredPaperclipIssueGitHubLink(
 
   let octokit: Octokit;
   try {
-    octokit = await createGitHubToolOctokit(ctx);
+    octokit = await createGitHubToolOctokit(ctx, fallbackLink.companyId);
   } catch {
     return null;
   }
@@ -3437,8 +3442,8 @@ async function buildToolbarSyncState(
 ): Promise<Record<string, unknown>> {
   const settings = await getActiveOrCurrentSyncState(ctx);
   const config = await getResolvedConfig(ctx);
-  const githubTokenConfigured = hasConfiguredGithubToken(settings, config);
   const companyId = typeof input.companyId === 'string' && input.companyId.trim() ? input.companyId.trim() : undefined;
+  const githubTokenConfigured = hasConfiguredGithubToken(settings, config, companyId);
   const entityId = typeof input.entityId === 'string' && input.entityId.trim() ? input.entityId.trim() : undefined;
   const entityType = typeof input.entityType === 'string' && input.entityType.trim() ? input.entityType.trim() : undefined;
   const savedMappingCount = companyId
@@ -3730,9 +3735,16 @@ function getPublicSettings(
   settings: GitHubSyncSettings
 ): Omit<
   GitHubSyncSettings,
-  'githubTokenRef' | 'paperclipBoardApiTokenRefs' | 'paperclipBoardAccessIdentityByCompanyId' | 'companyAdvancedSettingsByCompanyId'
+  | 'githubTokenRefs'
+  | 'githubTokenLoginsByCompanyId'
+  | 'githubTokenRef'
+  | 'paperclipBoardApiTokenRefs'
+  | 'paperclipBoardAccessIdentityByCompanyId'
+  | 'companyAdvancedSettingsByCompanyId'
 > {
   const {
+    githubTokenRefs: _githubTokenRefs,
+    githubTokenLoginsByCompanyId: _githubTokenLoginsByCompanyId,
     githubTokenRef: _githubTokenRef,
     paperclipBoardApiTokenRefs: _paperclipBoardApiTokenRefs,
     paperclipBoardAccessIdentityByCompanyId: _paperclipBoardAccessIdentityByCompanyId,
@@ -3759,7 +3771,12 @@ function getPublicSettingsForScope(
   companyId?: string
 ): Omit<
   GitHubSyncSettings,
-  'githubTokenRef' | 'paperclipBoardApiTokenRefs' | 'paperclipBoardAccessIdentityByCompanyId' | 'companyAdvancedSettingsByCompanyId'
+  | 'githubTokenRefs'
+  | 'githubTokenLoginsByCompanyId'
+  | 'githubTokenRef'
+  | 'paperclipBoardApiTokenRefs'
+  | 'paperclipBoardAccessIdentityByCompanyId'
+  | 'companyAdvancedSettingsByCompanyId'
 > & {
   advancedSettings: GitHubSyncAdvancedSettings;
   paperclipBoardAccessIdentity?: string;
@@ -3773,6 +3790,36 @@ function getPublicSettingsForScope(
     advancedSettings: getCompanyAdvancedSettings(settings, companyId),
     ...(paperclipBoardAccessIdentity ? { paperclipBoardAccessIdentity } : {})
   };
+}
+
+function getSavedGitHubTokenRef(
+  settings: Pick<GitHubSyncSettings, 'githubTokenRefs' | 'githubTokenRef'> | null | undefined,
+  companyId?: string
+): string | undefined {
+  const normalizedCompanyId = normalizeCompanyId(companyId);
+  if (normalizedCompanyId) {
+    const scopedSecretRef = normalizeSecretRef(settings?.githubTokenRefs?.[normalizedCompanyId]);
+    if (scopedSecretRef) {
+      return scopedSecretRef;
+    }
+  }
+
+  return normalizeGitHubTokenRef(settings?.githubTokenRef);
+}
+
+function getSavedGitHubTokenLogin(
+  settings: Pick<GitHubSyncSettings, 'githubTokenLoginsByCompanyId' | 'githubTokenLogin'> | null | undefined,
+  companyId?: string
+): string | undefined {
+  const normalizedCompanyId = normalizeCompanyId(companyId);
+  if (normalizedCompanyId) {
+    const scopedLogin = normalizeOptionalString(settings?.githubTokenLoginsByCompanyId?.[normalizedCompanyId]);
+    if (scopedLogin) {
+      return scopedLogin;
+    }
+  }
+
+  return normalizeOptionalString(settings?.githubTokenLogin);
 }
 
 async function listAvailableAssignees(
@@ -4173,12 +4220,14 @@ function normalizeConfig(value: unknown): GitHubSyncConfig {
   }
 
   const record = value as Record<string, unknown>;
+  const githubTokenRefs = normalizeGitHubTokenRefs(record.githubTokenRefs);
   const githubTokenRef = normalizeGitHubTokenRef(record.githubTokenRef);
   const githubToken = normalizeGitHubToken(record.githubToken);
   const paperclipBoardApiTokenRefs = normalizePaperclipBoardApiTokenRefs(record.paperclipBoardApiTokenRefs);
   const paperclipApiBaseUrl = normalizePaperclipApiBaseUrl(record.paperclipApiBaseUrl);
 
   return {
+    ...(githubTokenRefs ? { githubTokenRefs } : {}),
     ...(githubTokenRef ? { githubTokenRef } : {}),
     ...(githubToken ? { githubToken } : {}),
     ...(paperclipBoardApiTokenRefs ? { paperclipBoardApiTokenRefs } : {}),
@@ -4276,6 +4325,14 @@ async function readExternalConfig(ctx: PluginSetupContext): Promise<GitHubSyncCo
 }
 
 function normalizePaperclipBoardApiTokenRefs(value: unknown): PaperclipBoardApiTokenRefs | undefined {
+  return normalizeCompanySecretRefs(value);
+}
+
+function normalizeGitHubTokenRefs(value: unknown): GitHubTokenRefs | undefined {
+  return normalizeCompanySecretRefs(value);
+}
+
+function normalizeCompanySecretRefs(value: unknown): Record<string, string> | undefined {
   if (!value || typeof value !== 'object') {
     return undefined;
   }
@@ -4286,6 +4343,28 @@ function normalizePaperclipBoardApiTokenRefs(value: unknown): PaperclipBoardApiT
       const normalizedSecretRef = normalizeSecretRef(secretRef);
       return normalizedCompanyId && normalizedSecretRef
         ? [normalizedCompanyId, normalizedSecretRef] as const
+        : null;
+    })
+    .filter((entry): entry is readonly [string, string] => entry !== null);
+
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(entries);
+}
+
+function normalizeGitHubTokenLoginsByCompanyId(value: unknown): GitHubTokenLoginsByCompanyId | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .map(([companyId, login]) => {
+      const normalizedCompanyId = normalizeCompanyId(companyId);
+      const normalizedLogin = normalizeOptionalString(login);
+      return normalizedCompanyId && normalizedLogin
+        ? [normalizedCompanyId, normalizedLogin] as const
         : null;
     })
     .filter((entry): entry is readonly [string, string] => entry !== null);
@@ -4619,6 +4698,8 @@ function normalizeSettings(value: unknown): GitHubSyncSettings {
 
   const record = value as Record<string, unknown>;
   const paperclipApiBaseUrl = resolvePaperclipApiBaseUrl(record.paperclipApiBaseUrl);
+  const githubTokenRefs = normalizeGitHubTokenRefs(record.githubTokenRefs);
+  const githubTokenLoginsByCompanyId = normalizeGitHubTokenLoginsByCompanyId(record.githubTokenLoginsByCompanyId);
   const githubTokenRef = normalizeGitHubTokenRef(record.githubTokenRef);
   const githubTokenLogin = normalizeOptionalString(record.githubTokenLogin);
   const paperclipBoardApiTokenRefs = normalizePaperclipBoardApiTokenRefs(record.paperclipBoardApiTokenRefs);
@@ -4632,6 +4713,8 @@ function normalizeSettings(value: unknown): GitHubSyncSettings {
     syncState: normalizeSyncState(record.syncState),
     scheduleFrequencyMinutes: normalizeScheduleFrequencyMinutes(record.scheduleFrequencyMinutes),
     ...(paperclipApiBaseUrl ? { paperclipApiBaseUrl } : {}),
+    ...(githubTokenRefs ? { githubTokenRefs } : {}),
+    ...(githubTokenLoginsByCompanyId ? { githubTokenLoginsByCompanyId } : {}),
     ...(githubTokenRef ? { githubTokenRef } : {}),
     ...(githubTokenLogin ? { githubTokenLogin } : {}),
     ...(paperclipBoardApiTokenRefs ? { paperclipBoardApiTokenRefs } : {}),
@@ -8852,10 +8935,17 @@ async function getResolvedConfig(ctx: PluginSetupContext): Promise<GitHubSyncCon
 }
 
 function getConfiguredGithubTokenSource(
-  settings: Pick<GitHubSyncSettings, 'githubTokenRef'> | null | undefined,
-  config: GitHubSyncConfig
+  settings: Pick<GitHubSyncSettings, 'githubTokenRefs' | 'githubTokenRef'> | null | undefined,
+  config: GitHubSyncConfig,
+  companyId?: string
 ): ResolvedGitHubTokenSource {
-  const secretRef = normalizeGitHubTokenRef(config.githubTokenRef) ?? normalizeGitHubTokenRef(settings?.githubTokenRef);
+  const normalizedCompanyId = normalizeCompanyId(companyId);
+  const secretRef =
+    (normalizedCompanyId
+      ? normalizeSecretRef(config.githubTokenRefs?.[normalizedCompanyId]) ?? getSavedGitHubTokenRef(settings, normalizedCompanyId)
+      : undefined)
+    ?? normalizeGitHubTokenRef(config.githubTokenRef)
+    ?? getSavedGitHubTokenRef(settings);
   if (secretRef) {
     return { secretRef };
   }
@@ -8865,17 +8955,19 @@ function getConfiguredGithubTokenSource(
 }
 
 function getConfiguredGithubTokenRef(
-  settings: Pick<GitHubSyncSettings, 'githubTokenRef'> | null | undefined,
-  config: GitHubSyncConfig
+  settings: Pick<GitHubSyncSettings, 'githubTokenRefs' | 'githubTokenRef'> | null | undefined,
+  config: GitHubSyncConfig,
+  companyId?: string
 ): string | undefined {
-  return getConfiguredGithubTokenSource(settings, config).secretRef;
+  return getConfiguredGithubTokenSource(settings, config, companyId).secretRef;
 }
 
 function hasConfiguredGithubToken(
-  settings: Pick<GitHubSyncSettings, 'githubTokenRef'> | null | undefined,
-  config: GitHubSyncConfig
+  settings: Pick<GitHubSyncSettings, 'githubTokenRefs' | 'githubTokenRef'> | null | undefined,
+  config: GitHubSyncConfig,
+  companyId?: string
 ): boolean {
-  const configuredTokenSource = getConfiguredGithubTokenSource(settings, config);
+  const configuredTokenSource = getConfiguredGithubTokenSource(settings, config, companyId);
   return Boolean(configuredTokenSource.secretRef ?? configuredTokenSource.token);
 }
 
@@ -9004,13 +9096,14 @@ async function resolvePaperclipApiAuthTokens(
 async function resolveGithubToken(
   ctx: PluginSetupContext,
   options: {
-    settings?: Pick<GitHubSyncSettings, 'githubTokenRef'> | null | undefined;
+    settings?: Pick<GitHubSyncSettings, 'githubTokenRefs' | 'githubTokenRef'> | null | undefined;
     config?: GitHubSyncConfig;
+    companyId?: string;
   } = {}
 ): Promise<string> {
   const settings = options.settings ?? normalizeSettings(await ctx.state.get(SETTINGS_SCOPE));
   const config = options.config ?? await getResolvedConfig(ctx);
-  const configuredTokenSource = getConfiguredGithubTokenSource(settings, config);
+  const configuredTokenSource = getConfiguredGithubTokenSource(settings, config, options.companyId);
   if (configuredTokenSource.secretRef) {
     return ctx.secrets.resolve(configuredTokenSource.secretRef);
   }
@@ -9117,8 +9210,8 @@ async function executeGitHubTool(
   }
 }
 
-async function createGitHubToolOctokit(ctx: PluginSetupContext): Promise<Octokit> {
-  const token = (await resolveGithubToken(ctx)).trim();
+async function createGitHubToolOctokit(ctx: PluginSetupContext, companyId?: string): Promise<Octokit> {
+  const token = (await resolveGithubToken(ctx, { companyId })).trim();
   if (!token) {
     throw new Error(MISSING_GITHUB_TOKEN_SYNC_MESSAGE);
   }
@@ -11108,7 +11201,7 @@ async function getOrLoadCachedProjectPullRequestMetricsEntry(
   }
 
   const loadMetricsPromise = (async () => {
-    const resolvedOctokit = octokit ?? await createGitHubToolOctokit(ctx);
+    const resolvedOctokit = octokit ?? await createGitHubToolOctokit(ctx, scope.companyId);
     const metrics = await listProjectPullRequestMetrics(resolvedOctokit, scope);
     return cacheProjectPullRequestMetricsEntry(scope, metrics);
   })();
@@ -11158,7 +11251,7 @@ async function getOrLoadCachedProjectPullRequestCount(
   }
 
   const loadCountPromise = (async () => {
-    const resolvedOctokit = octokit ?? await createGitHubToolOctokit(ctx);
+    const resolvedOctokit = octokit ?? await createGitHubToolOctokit(ctx, scope.companyId);
     const totalOpenPullRequests = await listProjectPullRequestCount(resolvedOctokit, scope);
 
     return setCacheValue(
@@ -11312,7 +11405,7 @@ async function getOrLoadProjectPullRequestSummaryRecordsForNumbers(
 
   const missingPullRequestNumbers = normalizedPullRequestNumbers.filter((pullRequestNumber) => !recordsByNumber.has(pullRequestNumber));
   if (missingPullRequestNumbers.length > 0) {
-    const resolvedOctokit = octokit ?? await createGitHubToolOctokit(ctx);
+    const resolvedOctokit = octokit ?? await createGitHubToolOctokit(ctx, scope.companyId);
     const loadedRecords = await listProjectPullRequestSummaryRecordsByNumbers(
       ctx,
       resolvedOctokit,
@@ -11362,7 +11455,7 @@ async function getOrLoadCachedProjectPullRequestSummary(
       });
     }
 
-    const resolvedOctokit = octokit ?? await createGitHubToolOctokit(ctx);
+    const resolvedOctokit = octokit ?? await createGitHubToolOctokit(ctx, scope.companyId);
     const remainingSummary = await listProjectPullRequestSummaryRecords(ctx, resolvedOctokit, scope, {
       collectAll: true,
       first: PROJECT_PULL_REQUEST_SUMMARY_BATCH_SIZE,
@@ -11527,7 +11620,7 @@ async function buildProjectPullRequestsPageData(
 
   const scope = await requireProjectPullRequestScope(ctx, input, projectMappings);
   const config = await getResolvedConfig(ctx);
-  if (!hasConfiguredGithubToken(settings, config)) {
+  if (!hasConfiguredGithubToken(settings, config, companyId)) {
     return {
       status: 'missing_token',
       projectId,
@@ -11547,7 +11640,7 @@ async function buildProjectPullRequestsPageData(
   }
 
   try {
-    const octokit = await createGitHubToolOctokit(ctx);
+    const octokit = await createGitHubToolOctokit(ctx, companyId);
     const pageCacheKey = buildProjectPullRequestPageCacheKey(scope, filter, pageIndex, cursor);
     const cachedPage = getFreshCacheValue(activeProjectPullRequestPageCache, pageCacheKey);
     if (cachedPage) {
@@ -11732,7 +11825,7 @@ async function buildProjectPullRequestMetricsData(
   }
 
   const config = await getResolvedConfig(ctx);
-  if (!hasConfiguredGithubToken(settings, config)) {
+  if (!hasConfiguredGithubToken(settings, config, companyId)) {
     return {
       status: 'missing_token',
       projectId,
@@ -11789,7 +11882,7 @@ async function buildProjectPullRequestCountData(
   }
 
   const config = await getResolvedConfig(ctx);
-  if (!hasConfiguredGithubToken(settings, config)) {
+  if (!hasConfiguredGithubToken(settings, config, companyId)) {
     return {
       status: 'missing_token',
       projectId,
@@ -11832,7 +11925,7 @@ async function buildSettingsTokenPermissionAuditData(
 
   const settings = normalizeSettings(await ctx.state.get(SETTINGS_SCOPE));
   const config = await getResolvedConfig(ctx);
-  if (!hasConfiguredGithubToken(settings, config)) {
+  if (!hasConfiguredGithubToken(settings, config, requestedCompanyId)) {
     return {
       status: 'missing_token',
       allRequiredPermissionsGranted: false,
@@ -11855,7 +11948,7 @@ async function buildSettingsTokenPermissionAuditData(
   }
 
   try {
-    const octokit = await createGitHubToolOctokit(ctx);
+    const octokit = await createGitHubToolOctokit(ctx, requestedCompanyId);
     const repositories = await Promise.all(
       [
         ...new Map(
@@ -11951,7 +12044,7 @@ async function buildProjectPullRequestDetailData(
   const cachedLinkedIssue = cachedSummaryRecord
     ? getLinkedPaperclipIssueFromProjectPullRequestRecord(cachedSummaryRecord)
     : undefined;
-  const octokit = await createGitHubToolOctokit(ctx);
+  const octokit = await createGitHubToolOctokit(ctx, scope.companyId);
   const response = await octokit.rest.pulls.get({
     owner: scope.repository.owner,
     repo: scope.repository.repo,
@@ -12111,7 +12204,7 @@ async function createProjectPullRequestPaperclipIssue(
   }
 
   const scope = await requireProjectPullRequestScope(ctx, input);
-  const octokit = await createGitHubToolOctokit(ctx);
+  const octokit = await createGitHubToolOctokit(ctx, scope.companyId);
   const pullRequestResponse = await octokit.rest.pulls.get({
     owner: scope.repository.owner,
     repo: scope.repository.repo,
@@ -12205,7 +12298,7 @@ async function updateProjectPullRequestBranch(
   }
 
   const scope = await requireProjectPullRequestScope(ctx, input);
-  const octokit = await createGitHubToolOctokit(ctx);
+  const octokit = await createGitHubToolOctokit(ctx, scope.companyId);
   const pullRequestResponse = await octokit.rest.pulls.get({
     owner: scope.repository.owner,
     repo: scope.repository.repo,
@@ -12282,7 +12375,7 @@ async function mergeProjectPullRequest(
   }
 
   const scope = await requireProjectPullRequestScope(ctx, input);
-  const octokit = await createGitHubToolOctokit(ctx);
+  const octokit = await createGitHubToolOctokit(ctx, scope.companyId);
   const response = await octokit.rest.pulls.merge({
     owner: scope.repository.owner,
     repo: scope.repository.repo,
@@ -12313,7 +12406,7 @@ async function closeProjectPullRequest(
   }
 
   const scope = await requireProjectPullRequestScope(ctx, input);
-  const octokit = await createGitHubToolOctokit(ctx);
+  const octokit = await createGitHubToolOctokit(ctx, scope.companyId);
   const response = await octokit.rest.pulls.update({
     owner: scope.repository.owner,
     repo: scope.repository.repo,
@@ -12349,7 +12442,7 @@ async function addProjectPullRequestComment(
   }
 
   const scope = await requireProjectPullRequestScope(ctx, input);
-  const octokit = await createGitHubToolOctokit(ctx);
+  const octokit = await createGitHubToolOctokit(ctx, scope.companyId);
   const response = await createProjectPullRequestGitHubComment(octokit, scope, pullRequestNumber, body);
 
   invalidateProjectPullRequestCaches(scope);
@@ -12431,7 +12524,7 @@ async function requestProjectPullRequestCopilotAction(
   }
 
   const scope = await requireProjectPullRequestScope(ctx, input);
-  const octokit = await createGitHubToolOctokit(ctx);
+  const octokit = await createGitHubToolOctokit(ctx, scope.companyId);
   const pullRequestResponse = await octokit.rest.pulls.get({
     owner: scope.repository.owner,
     repo: scope.repository.repo,
@@ -12574,7 +12667,7 @@ async function reviewProjectPullRequest(
 
   const body = typeof input.body === 'string' ? input.body.trim() : '';
   const scope = await requireProjectPullRequestScope(ctx, input);
-  const octokit = await createGitHubToolOctokit(ctx);
+  const octokit = await createGitHubToolOctokit(ctx, scope.companyId);
   let response;
   try {
     response = await octokit.rest.pulls.createReview({
@@ -12631,7 +12724,7 @@ async function rerunProjectPullRequestCi(
   }
 
   const scope = await requireProjectPullRequestScope(ctx, input);
-  const octokit = await createGitHubToolOctokit(ctx);
+  const octokit = await createGitHubToolOctokit(ctx, scope.companyId);
   const pullRequestResponse = await octokit.rest.pulls.get({
     owner: scope.repository.owner,
     repo: scope.repository.repo,
@@ -13568,9 +13661,11 @@ async function startSync(
     getResolvedConfig(ctx),
     ctx.state.get(SETTINGS_SCOPE).then((value) => normalizeSettings(value))
   ]);
+  const targetCompanyId = options.target?.companyId;
   const token = await resolveGithubToken(ctx, {
     config,
-    settings: persistedSettings
+    settings: persistedSettings,
+    companyId: targetCompanyId
   }).catch(() => '');
   let currentSettings = sanitizeSettingsForCurrentSetup(persistedSettings, {
     hasToken: Boolean(token.trim()),
@@ -13677,7 +13772,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
     getGitHubAgentToolDeclaration('search_repository_items'),
     async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
-      const octokit = await createGitHubToolOctokit(ctx);
+      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
       const repository = await resolveGitHubToolRepository(ctx, runCtx, input);
       const rawQuery = normalizeOptionalToolString(input.query);
       if (!rawQuery) {
@@ -13754,7 +13849,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
     async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const target = await resolveGitHubIssueToolTarget(ctx, runCtx, input);
-      const octokit = await createGitHubToolOctokit(ctx);
+      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
       const response = await octokit.rest.issues.get({
         owner: target.repository.owner,
         repo: target.repository.repo,
@@ -13807,7 +13902,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
     async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const target = await resolveGitHubIssueToolTarget(ctx, runCtx, input);
-      const octokit = await createGitHubToolOctokit(ctx);
+      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
       const comments = await listAllGitHubIssueComments(octokit, target.repository, target.issueNumber);
 
       return buildToolSuccessResult(
@@ -13827,7 +13922,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
     async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const target = await resolveGitHubIssueToolTarget(ctx, runCtx, input);
-      const octokit = await createGitHubToolOctokit(ctx);
+      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
       const currentResponse = await octokit.rest.issues.get({
         owner: target.repository.owner,
         repo: target.repository.repo,
@@ -13929,7 +14024,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
     async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const target = await resolveGitHubIssueToolTarget(ctx, runCtx, input);
-      const octokit = await createGitHubToolOctokit(ctx);
+      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
       const body = appendAiAuthorshipFooter(String(input.body ?? ''), normalizeOptionalToolString(input.llmModel) ?? '');
       const response = await octokit.rest.issues.createComment({
         owner: target.repository.owner,
@@ -13971,7 +14066,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
         throw new Error('head, base, and title are required.');
       }
 
-      const octokit = await createGitHubToolOctokit(ctx);
+      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
       const response = await octokit.rest.pulls.create({
         owner: repository.owner,
         repo: repository.repo,
@@ -14010,7 +14105,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
     async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const target = await resolveGitHubPullRequestToolTarget(ctx, runCtx, input);
-      const octokit = await createGitHubToolOctokit(ctx);
+      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
       const response = await octokit.rest.pulls.get({
         owner: target.repository.owner,
         repo: target.repository.repo,
@@ -14060,7 +14155,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
     async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const target = await resolveGitHubPullRequestToolTarget(ctx, runCtx, input);
-      const octokit = await createGitHubToolOctokit(ctx);
+      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
       let currentResponse = await octokit.rest.pulls.get({
         owner: target.repository.owner,
         repo: target.repository.repo,
@@ -14134,7 +14229,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
     async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const target = await resolveGitHubPullRequestToolTarget(ctx, runCtx, input);
-      const octokit = await createGitHubToolOctokit(ctx);
+      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
       const files = await listAllPullRequestFiles(octokit, target.repository, target.pullRequestNumber);
 
       return buildToolSuccessResult(
@@ -14154,7 +14249,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
     async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const target = await resolveGitHubPullRequestToolTarget(ctx, runCtx, input);
-      const octokit = await createGitHubToolOctokit(ctx);
+      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
       const pullRequestResponse = await octokit.rest.pulls.get({
         owner: target.repository.owner,
         repo: target.repository.repo,
@@ -14262,7 +14357,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
     async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const target = await resolveGitHubPullRequestToolTarget(ctx, runCtx, input);
-      const octokit = await createGitHubToolOctokit(ctx);
+      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
       const threads = await listDetailedPullRequestReviewThreads(octokit, target.repository, target.pullRequestNumber);
 
       return buildToolSuccessResult(
@@ -14279,7 +14374,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
   ctx.tools.register(
     'reply_to_review_thread',
     getGitHubAgentToolDeclaration('reply_to_review_thread'),
-    async (params) => executeGitHubTool(async () => {
+    async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const threadId = normalizeOptionalToolString(input.threadId);
       if (!threadId) {
@@ -14287,7 +14382,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
       }
 
       const body = appendAiAuthorshipFooter(String(input.body ?? ''), normalizeOptionalToolString(input.llmModel) ?? '');
-      const octokit = await createGitHubToolOctokit(ctx);
+      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
       const response = await octokit.graphql<GitHubAddPullRequestReviewThreadReplyMutationResult>(
         GITHUB_ADD_PULL_REQUEST_REVIEW_THREAD_REPLY_MUTATION,
         {
@@ -14318,14 +14413,14 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
   ctx.tools.register(
     'resolve_review_thread',
     getGitHubAgentToolDeclaration('resolve_review_thread'),
-    async (params) => executeGitHubTool(async () => {
+    async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const threadId = normalizeOptionalToolString(input.threadId);
       if (!threadId) {
         throw new Error('threadId is required.');
       }
 
-      const octokit = await createGitHubToolOctokit(ctx);
+      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
       const response = await octokit.graphql<GitHubResolveReviewThreadMutationResult>(
         GITHUB_RESOLVE_REVIEW_THREAD_MUTATION,
         {
@@ -14352,14 +14447,14 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
   ctx.tools.register(
     'unresolve_review_thread',
     getGitHubAgentToolDeclaration('unresolve_review_thread'),
-    async (params) => executeGitHubTool(async () => {
+    async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const threadId = normalizeOptionalToolString(input.threadId);
       if (!threadId) {
         throw new Error('threadId is required.');
       }
 
-      const octokit = await createGitHubToolOctokit(ctx);
+      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
       const response = await octokit.graphql<GitHubUnresolveReviewThreadMutationResult>(
         GITHUB_UNRESOLVE_REVIEW_THREAD_MUTATION,
         {
@@ -14395,7 +14490,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
         throw new Error('Provide at least one user reviewer or team reviewer.');
       }
 
-      const octokit = await createGitHubToolOctokit(ctx);
+      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
       const response = await octokit.rest.pulls.requestReviewers({
         owner: target.repository.owner,
         repo: target.repository.repo,
@@ -14422,14 +14517,14 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
   ctx.tools.register(
     'list_organization_projects',
     getGitHubAgentToolDeclaration('list_organization_projects'),
-    async (params) => executeGitHubTool(async () => {
+    async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const organization = normalizeOptionalToolString(input.organization);
       if (!organization) {
         throw new Error('organization is required.');
       }
 
-      const octokit = await createGitHubToolOctokit(ctx);
+      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
       const projects = await listGitHubOrganizationProjects(octokit, organization, {
         includeClosed: input.includeClosed === true,
         query: normalizeOptionalToolString(input.query),
@@ -14452,7 +14547,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
     async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const target = await resolveGitHubPullRequestToolTarget(ctx, runCtx, input);
-      const octokit = await createGitHubToolOctokit(ctx);
+      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
       const projectTarget = await resolveGitHubProjectToolTarget(octokit, input);
       const pullRequest = await getGitHubPullRequestProjectItems(
         octokit,
@@ -14538,17 +14633,40 @@ const plugin = definePlugin({
       const importRegistry = normalizeImportRegistry(await ctx.state.get(IMPORT_REGISTRY_SCOPE));
       const normalizedSettings = normalizeSettings(saved);
       const config = await getResolvedConfig(ctx);
-      const githubTokenRef = getConfiguredGithubTokenRef(normalizedSettings, config);
+      const configuredGitHubTokenRef = requestedCompanyId
+        ? normalizeSecretRef(config.githubTokenRefs?.[requestedCompanyId])
+        : normalizeGitHubTokenRef(config.githubTokenRef);
+      const savedGitHubTokenRef = getSavedGitHubTokenRef(normalizedSettings, requestedCompanyId);
+      const githubTokenRef = getConfiguredGithubTokenRef(normalizedSettings, config, requestedCompanyId);
+      const githubTokenLogin = getSavedGitHubTokenLogin(normalizedSettings, requestedCompanyId);
       const paperclipApiBaseUrl = getConfiguredPaperclipApiBaseUrl(normalizedSettings, config);
-      const githubTokenConfigured = hasConfiguredGithubToken(normalizedSettings, config);
+      const githubTokenConfigured = hasConfiguredGithubToken(normalizedSettings, config, requestedCompanyId);
       const configuredBoardTokenRef = getConfiguredPaperclipBoardApiTokenRef(config, requestedCompanyId);
       const savedBoardTokenRef = getSavedPaperclipBoardApiTokenRef(normalizedSettings, requestedCompanyId);
-      const settingsWithResolvedToken = githubTokenRef === normalizedSettings.githubTokenRef
+      const settingsWithResolvedToken = githubTokenRef === getSavedGitHubTokenRef(normalizedSettings, requestedCompanyId)
+        && githubTokenLogin === getSavedGitHubTokenLogin(normalizedSettings, requestedCompanyId)
         && paperclipApiBaseUrl === normalizedSettings.paperclipApiBaseUrl
         ? normalizedSettings
         : {
             ...normalizedSettings,
-            ...(githubTokenRef ? { githubTokenRef } : {}),
+            ...(requestedCompanyId && githubTokenRef
+              ? {
+                  githubTokenRefs: {
+                    ...(normalizedSettings.githubTokenRefs ?? {}),
+                    [requestedCompanyId]: githubTokenRef
+                  }
+                }
+              : {}),
+            ...(requestedCompanyId && githubTokenLogin
+              ? {
+                  githubTokenLoginsByCompanyId: {
+                    ...(normalizedSettings.githubTokenLoginsByCompanyId ?? {}),
+                    [requestedCompanyId]: githubTokenLogin
+                  }
+                }
+              : {}),
+            ...(!requestedCompanyId && githubTokenRef ? { githubTokenRef } : {}),
+            ...(!requestedCompanyId && githubTokenLogin ? { githubTokenLogin } : {}),
             ...(paperclipApiBaseUrl ? { paperclipApiBaseUrl } : {})
           };
       const settingsForResponse = sanitizeSettingsForCurrentSetup(settingsWithResolvedToken, {
@@ -14570,6 +14688,9 @@ const plugin = definePlugin({
         ...(includeAssignees ? { availableAssignees } : {}),
         totalSyncedIssuesCount: countImportedIssuesForMappings(importRegistry, scopedMappings),
         githubTokenConfigured,
+        ...(githubTokenLogin ? { githubTokenLogin } : {}),
+        ...(savedGitHubTokenRef ? { githubTokenConfigSyncRef: savedGitHubTokenRef } : {}),
+        githubTokenNeedsConfigSync: Boolean(requestedCompanyId && savedGitHubTokenRef && !configuredGitHubTokenRef),
         paperclipBoardAccessConfigured: requestedCompanyId
           ? hasConfiguredPaperclipBoardAccess(settingsForResponse, config, requestedCompanyId)
           : hasConfiguredPaperclipBoardAccessForMappings(settingsForResponse, config, scopedMappings),
@@ -14635,18 +14756,34 @@ const plugin = definePlugin({
       const requestedCompanyId = normalizeCompanyId(record.companyId);
       const hasMappingsPatch = 'mappings' in record;
       const hasAdvancedSettingsPatch = 'advancedSettings' in record;
-      const githubTokenRef =
-        'githubTokenRef' in record
-          ? normalizeGitHubTokenRef(record.githubTokenRef)
-          : normalizeGitHubTokenRef(previous.githubTokenRef) ?? normalizeGitHubTokenRef(config.githubTokenRef);
-      const githubTokenLogin =
-        'githubTokenLogin' in record
-          ? normalizeOptionalString(record.githubTokenLogin)
-          : previous.githubTokenLogin;
+      const githubTokenRef = 'githubTokenRef' in record ? normalizeGitHubTokenRef(record.githubTokenRef) : undefined;
+      const githubTokenLogin = 'githubTokenLogin' in record ? normalizeOptionalString(record.githubTokenLogin) : undefined;
       const inputMappings = hasMappingsPatch ? normalizeMappings(record.mappings) : previous.mappings;
+      const nextGitHubTokenRefs = {
+        ...(previous.githubTokenRefs ?? {})
+      };
+      const nextGitHubTokenLoginsByCompanyId = {
+        ...(previous.githubTokenLoginsByCompanyId ?? {})
+      };
       const nextCompanyAdvancedSettingsByCompanyId = {
         ...(previous.companyAdvancedSettingsByCompanyId ?? {})
       };
+
+      if (requestedCompanyId && 'githubTokenRef' in record) {
+        if (githubTokenRef) {
+          nextGitHubTokenRefs[requestedCompanyId] = githubTokenRef;
+        } else {
+          delete nextGitHubTokenRefs[requestedCompanyId];
+        }
+      }
+
+      if (requestedCompanyId && 'githubTokenLogin' in record) {
+        if (githubTokenLogin) {
+          nextGitHubTokenLoginsByCompanyId[requestedCompanyId] = githubTokenLogin;
+        } else {
+          delete nextGitHubTokenLoginsByCompanyId[requestedCompanyId];
+        }
+      }
 
       if (requestedCompanyId && hasAdvancedSettingsPatch) {
         nextCompanyAdvancedSettingsByCompanyId[requestedCompanyId] = normalizeAdvancedSettings(record.advancedSettings);
@@ -14670,13 +14807,21 @@ const plugin = definePlugin({
           'paperclipApiBaseUrl' in record
             ? resolveTrustedPaperclipApiBaseUrlInput(record.paperclipApiBaseUrl, previous, config)
             : getConfiguredPaperclipApiBaseUrl(previous, config),
-        ...(githubTokenLogin ? { githubTokenLogin } : {}),
+        ...(Object.keys(nextGitHubTokenRefs).length > 0 ? { githubTokenRefs: nextGitHubTokenRefs } : {}),
+        ...(Object.keys(nextGitHubTokenLoginsByCompanyId).length > 0
+          ? { githubTokenLoginsByCompanyId: nextGitHubTokenLoginsByCompanyId }
+          : {}),
+        ...(!requestedCompanyId
+          ? (githubTokenLogin ? { githubTokenLogin } : previous.githubTokenLogin ? { githubTokenLogin: previous.githubTokenLogin } : {})
+          : {}),
         paperclipBoardApiTokenRefs: previous.paperclipBoardApiTokenRefs,
         paperclipBoardAccessIdentityByCompanyId: previous.paperclipBoardAccessIdentityByCompanyId,
         ...(Object.keys(nextCompanyAdvancedSettingsByCompanyId).length > 0
           ? { companyAdvancedSettingsByCompanyId: nextCompanyAdvancedSettingsByCompanyId }
           : {}),
-        ...(githubTokenRef ? { githubTokenRef } : {})
+        ...(!requestedCompanyId
+          ? (githubTokenRef ? { githubTokenRef } : previous.githubTokenRef ? { githubTokenRef: previous.githubTokenRef } : {})
+          : {})
       });
       const nextMappings = current.mappings.map((mapping, index) => ({
         id: mapping.id.trim() || createMappingId(index),
@@ -14690,6 +14835,8 @@ const plugin = definePlugin({
         syncState: previous.syncState,
         scheduleFrequencyMinutes: current.scheduleFrequencyMinutes,
         ...(current.paperclipApiBaseUrl ? { paperclipApiBaseUrl: current.paperclipApiBaseUrl } : {}),
+        ...(current.githubTokenRefs ? { githubTokenRefs: current.githubTokenRefs } : {}),
+        ...(current.githubTokenLoginsByCompanyId ? { githubTokenLoginsByCompanyId: current.githubTokenLoginsByCompanyId } : {}),
         ...(current.githubTokenLogin ? { githubTokenLogin: current.githubTokenLogin } : {}),
         ...(current.paperclipBoardApiTokenRefs ? { paperclipBoardApiTokenRefs: current.paperclipBoardApiTokenRefs } : {}),
         ...(current.paperclipBoardAccessIdentityByCompanyId
@@ -14698,18 +14845,20 @@ const plugin = definePlugin({
         ...(current.companyAdvancedSettingsByCompanyId
           ? { companyAdvancedSettingsByCompanyId: current.companyAdvancedSettingsByCompanyId }
           : {}),
-        ...(githubTokenRef ? { githubTokenRef } : {}),
+        ...(current.githubTokenRef ? { githubTokenRef: current.githubTokenRef } : {}),
         updatedAt: new Date().toISOString()
       }, {
-        hasToken: hasConfiguredGithubToken({ githubTokenRef }, config),
+        hasToken: hasConfiguredGithubToken(current, config, requestedCompanyId),
         hasMappings: getSyncableMappings(nextMappings).length > 0
       });
 
       await ctx.state.set(SETTINGS_SCOPE, next);
       await ctx.state.set(SYNC_STATE_SCOPE, next.syncState);
       clearGitHubRepositoryTokenCapabilityAudits();
+      const scopedGitHubTokenLogin = getSavedGitHubTokenLogin(next, requestedCompanyId);
       return {
         ...getPublicSettingsForScope(next, requestedCompanyId),
+        ...(scopedGitHubTokenLogin ? { githubTokenLogin: scopedGitHubTokenLogin } : {}),
         availableAssignees: requestedCompanyId
           ? await listAvailableAssignees(ctx, requestedCompanyId)
           : []
@@ -14764,7 +14913,7 @@ const plugin = definePlugin({
           : {}),
         updatedAt: new Date().toISOString()
       }, {
-        hasToken: hasConfiguredGithubToken(previous, config),
+        hasToken: hasConfiguredGithubToken(previous, config, companyId),
         hasMappings: getSyncableMappings(previous.mappings).length > 0
       });
 

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -9,7 +9,7 @@ import type { Agent, Project } from '@paperclipai/plugin-sdk';
 import { createTestHarness } from '@paperclipai/plugin-sdk/testing';
 
 import manifest from '../src/manifest.ts';
-import { requiresPaperclipBoardAccess } from '../src/paperclip-health.ts';
+import { requiresPaperclipBoardAccess, shouldShowPaperclipBoardAccessSettings } from '../src/paperclip-health.ts';
 import { normalizeCompanyAssigneeOptionsResponse } from '../src/ui/assignees.ts';
 import { fetchJson, fetchPaperclipHealth, resolveCliAuthPollUrl } from '../src/ui/http.ts';
 import { resolveInstalledGitHubSyncPluginId, resolvePluginSettingsHref } from '../src/ui/plugin-installation.ts';
@@ -2053,6 +2053,28 @@ test('fetchPaperclipHealth normalizes authenticated deployment metadata', async 
   }
 });
 
+test('shouldShowPaperclipBoardAccessSettings returns true for authenticated and local trusted deployments', () => {
+  assert.equal(
+    shouldShowPaperclipBoardAccessSettings({
+      deploymentMode: 'authenticated'
+    }),
+    true
+  );
+  assert.equal(
+    shouldShowPaperclipBoardAccessSettings({
+      deploymentMode: 'local_trusted'
+    }),
+    true
+  );
+  assert.equal(
+    shouldShowPaperclipBoardAccessSettings({
+      deploymentMode: 'unauthenticated'
+    }),
+    false
+  );
+  assert.equal(shouldShowPaperclipBoardAccessSettings(null), false);
+});
+
 test('fetchPaperclipHealth returns null when the Paperclip health endpoint is unavailable', async () => {
   const originalFetch = globalThis.fetch;
 
@@ -2067,23 +2089,31 @@ test('fetchPaperclipHealth returns null when the Paperclip health endpoint is un
   }
 });
 
-test('mergePluginConfig preserves existing config while merging board access refs by company', () => {
+test('mergePluginConfig preserves existing config while merging company-scoped token refs by company', () => {
   const result = mergePluginConfig(
     {
-      githubTokenRef: 'github-secret-ref',
+      githubTokenRefs: {
+        'company-1': 'github-secret-ref-1'
+      },
       paperclipBoardApiTokenRefs: {
         'company-1': 'board-secret-ref-1'
       },
       customFlag: true
     },
     {
+      githubTokenRefs: {
+        'company-2': 'github-secret-ref-2'
+      },
       paperclipBoardApiTokenRefs: {
         'company-2': 'board-secret-ref-2'
       }
     }
   );
 
-  assert.equal(result.githubTokenRef, 'github-secret-ref');
+  assert.deepEqual(result.githubTokenRefs, {
+    'company-1': 'github-secret-ref-1',
+    'company-2': 'github-secret-ref-2'
+  });
   assert.deepEqual(result.paperclipBoardApiTokenRefs, {
     'company-1': 'board-secret-ref-1',
     'company-2': 'board-secret-ref-2'
@@ -2125,7 +2155,7 @@ test('manifest exposes GitHub Sync page, sidebar, dashboard, and settings UI met
   assert.ok(manifest.capabilities.includes('issue.comments.read'));
   assert.ok(manifest.capabilities.includes('issue.comments.create'));
   assert.ok(manifest.capabilities.includes('agents.read'));
-  assert.equal((manifest.instanceConfigSchema as { properties?: Record<string, unknown> }).properties?.githubTokenRef ? 'present' : 'missing', 'present');
+  assert.equal((manifest.instanceConfigSchema as { properties?: Record<string, unknown> }).properties?.githubTokenRefs ? 'present' : 'missing', 'present');
   assert.equal((manifest.instanceConfigSchema as { properties?: Record<string, unknown> }).properties?.paperclipBoardApiTokenRefs ? 'present' : 'missing', 'present');
   const pullRequestsPageSlot = manifest.ui?.slots?.find((slot) => slot.id === 'paperclip-github-plugin-project-pull-requests-page');
   const projectSidebarItemSlot = manifest.ui?.slots?.find((slot) => slot.id === 'paperclip-github-plugin-project-pull-requests-sidebar-item');
@@ -5521,6 +5551,44 @@ test('worker uses the saved githubTokenRef fallback for toolbar state when confi
   assert.equal(globalState.message, 'Run a GitHub sync across every saved repository mapping.');
 });
 
+test('worker uses the saved company-scoped githubTokenRef fallback for toolbar state when config is stale', async () => {
+  const harness = createTestHarness({ manifest });
+  await plugin.definition.setup(harness.ctx);
+
+  await harness.performAction('settings.saveRegistration', {
+    companyId: 'company-1',
+    githubTokenRef: 'github-secret-ref',
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  const settingsResult = await harness.getData<{
+    githubTokenConfigured?: boolean;
+  }>('settings.registration', {
+    companyId: 'company-1'
+  });
+  const companyState = await harness.getData<{
+    canRun: boolean;
+    message?: string;
+  }>('sync.toolbarState', {
+    companyId: 'company-1'
+  });
+
+  assert.equal(settingsResult.githubTokenConfigured, true);
+  assert.equal(companyState.canRun, true);
+  assert.equal(companyState.message, 'Run a GitHub sync across every saved repository mapping for this company.');
+});
+
 test('worker issue.githubDetails returns issue-scoped GitHub detail payloads', async () => {
   const harness = createTestHarness({ manifest });
   await plugin.definition.setup(harness.ctx);
@@ -6406,11 +6474,47 @@ test('settings.registration reports a configured token without resolving the sav
   assert.equal(resolveCount, 0);
 });
 
-test('settings.saveRegistration persists the saved GitHub login label for later settings reads', async () => {
+test('settings.registration reports a company-scoped configured token without resolving the saved secret', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubTokenRefs: {
+        'company-1': 'github-secret-ref'
+      }
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+
+  let resolveCount = 0;
+  harness.ctx.secrets.resolve = async () => {
+    resolveCount += 1;
+    throw new Error('Rate limit exceeded for secret resolution');
+  };
+
+  const companyOneResult = await harness.getData<{
+    githubTokenConfigured?: boolean;
+    syncState?: { status?: string };
+  }>('settings.registration', {
+    companyId: 'company-1'
+  });
+  const companyTwoResult = await harness.getData<{
+    githubTokenConfigured?: boolean;
+  }>('settings.registration', {
+    companyId: 'company-2'
+  });
+
+  assert.equal(companyOneResult.githubTokenConfigured, true);
+  assert.equal(companyOneResult.syncState?.status, 'idle');
+  assert.equal(companyTwoResult.githubTokenConfigured, false);
+  assert.equal(resolveCount, 0);
+});
+
+test('settings.saveRegistration persists the saved GitHub login label for later company-scoped settings reads', async () => {
   const harness = createTestHarness({ manifest });
   await plugin.definition.setup(harness.ctx);
 
   const saveResult = await harness.performAction('settings.saveRegistration', {
+    companyId: 'company-1',
     githubTokenRef: 'github-secret-ref',
     githubTokenLogin: 'octocat'
   }) as {
@@ -6423,15 +6527,19 @@ test('settings.saveRegistration persists the saved GitHub login label for later 
     scopeKind: 'instance',
     stateKey: 'paperclip-github-plugin-settings'
   }) as {
-    githubTokenLogin?: string;
+    githubTokenLoginsByCompanyId?: Record<string, string>;
   };
 
-  assert.equal(savedSettings.githubTokenLogin, 'octocat');
+  assert.deepEqual(savedSettings.githubTokenLoginsByCompanyId, {
+    'company-1': 'octocat'
+  });
 
   const registrationResult = await harness.getData<{
     githubTokenConfigured?: boolean;
     githubTokenLogin?: string;
-  }>('settings.registration');
+  }>('settings.registration', {
+    companyId: 'company-1'
+  });
 
   assert.equal(registrationResult.githubTokenConfigured, true);
   assert.equal(registrationResult.githubTokenLogin, 'octocat');
@@ -12748,6 +12856,33 @@ test('sync.runNow falls back to the saved githubTokenRef when config has not pro
   });
 
   const result = await harness.performAction('sync.runNow', {}) as {
+    syncState: { status: string; message?: string; lastRunTrigger?: string };
+  };
+
+  assert.equal(resolvedSecretRef, 'github-secret-ref');
+  assert.equal(result.syncState.status, 'error');
+  assert.equal(result.syncState.message, 'Save at least one mapping with a created Paperclip project before running sync.');
+  assert.equal(result.syncState.lastRunTrigger, 'manual');
+});
+
+test('sync.runNow falls back to the saved company-scoped githubTokenRef when config has not propagated yet', async () => {
+  const harness = createTestHarness({ manifest });
+  await plugin.definition.setup(harness.ctx);
+
+  let resolvedSecretRef: string | null = null;
+  harness.ctx.secrets.resolve = async (secretRef) => {
+    resolvedSecretRef = secretRef;
+    return 'github-token';
+  };
+
+  await harness.performAction('settings.saveRegistration', {
+    companyId: 'company-1',
+    githubTokenRef: 'github-secret-ref'
+  });
+
+  const result = await harness.performAction('sync.runNow', {
+    companyId: 'company-1'
+  }) as {
     syncState: { status: string; message?: string; lastRunTrigger?: string };
   };
 


### PR DESCRIPTION
## Summary
- store GitHub tokens from the settings UI as company-scoped Paperclip secrets and mirror those refs into plugin config by company
- repair missing config sync for saved company token refs and retry selected-agent `GITHUB_TOKEN` propagation from the saved company secret
- show board-access and token-propagation settings on `local_trusted` deployments for local testing while keeping authenticated sync enforcement unchanged

## Why
Saving the GitHub token as an instance-scoped setting failed in authenticated instances and did not match the existing company-scoped board token flow. Local testing also needed the board-access and propagation controls to be visible on `local_trusted` deployments.

## Impact
- GitHub token saves now follow the same company-secret model as board access
- agent propagation reuses the saved company secret ref instead of copying raw token values
- local trusted instances can exercise the settings flow end to end without pretending to be authenticated

## Validation
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Model Used
- Runtime: Codex desktop agent based on GPT-5
- Exact model ID/version: not exposed by this runtime
- Context window size: not exposed by this runtime
- Capabilities used: terminal commands, file editing, git, GitHub CLI, and local test/build execution
