### PR TITLE
Use public author_association for maintainer/admin detection

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -481,6 +481,7 @@ interface GitHubIssueRecord {
   body: string | null;
   htmlUrl: string;
   authorLogin?: string;
+  authorAssociation?: string;
   labels: GitHubIssueLabelRecord[];
   state: 'open' | 'closed';
   stateReason?: GitHubIssueStateReason;
@@ -527,6 +528,7 @@ interface GitHubApiIssueRecord {
   state: string;
   comments?: number;
   state_reason?: string | null;
+  author_association?: string | null;
   labels?: GitHubApiIssueLabelRecord[];
   pull_request?: unknown;
 }
@@ -806,6 +808,7 @@ interface GitHubIssueCommentRecord {
   body: string;
   url?: string;
   authorLogin?: string;
+  authorAssociation?: string;
   authorUrl?: string;
   authorAvatarUrl?: string;
   createdAt?: string;
@@ -1156,6 +1159,7 @@ const FAILED_STATUS_CONTEXT_STATES = new Set(['ERROR', 'FAILURE']);
 const PENDING_STATUS_CONTEXT_STATES = new Set(['EXPECTED', 'PENDING']);
 const GITHUB_REPOSITORY_MAINTAINER_WARMUP_CONCURRENCY = 4;
 const GITHUB_REPOSITORY_MAINTAINER_ROLE_NAMES = new Set(['admin', 'maintain']);
+const GITHUB_REPOSITORY_MAINTAINER_AUTHOR_ASSOCIATIONS = new Set(['collaborator', 'member', 'owner']);
 
 const GITHUB_ISSUE_STATUS_SNAPSHOT_QUERY = `
   query GitHubIssueStatusSnapshot($owner: String!, $repo: String!, $issueNumber: Int!, $after: String) {
@@ -4873,6 +4877,9 @@ function normalizeGitHubIssueRecord(issue: GitHubApiIssueRecord): GitHubIssueRec
     body: typeof issue.body === 'string' ? stripNullBytes(issue.body) : null,
     htmlUrl: issue.html_url,
     ...(normalizeGitHubUsername(issue.user?.login) ? { authorLogin: normalizeGitHubUsername(issue.user?.login) } : {}),
+    ...(normalizeGitHubLowercaseString(issue.author_association)
+      ? { authorAssociation: normalizeGitHubLowercaseString(issue.author_association) }
+      : {}),
     labels: normalizeGitHubIssueLabels(issue.labels),
     state: issue.state === 'closed' ? 'closed' : 'open',
     stateReason: normalizeGitHubIssueStateReason(issue.state_reason),
@@ -6078,6 +6085,33 @@ function buildGitHubRepositoryActorCacheKey(
   return `${repository.owner.toLowerCase()}/${repository.repo.toLowerCase()}:${login}`;
 }
 
+function getGitHubRepositoryMaintainerStatusFromAuthorAssociation(
+  authorAssociation: string | null | undefined
+): boolean | undefined {
+  const normalizedAssociation = normalizeGitHubLowercaseString(authorAssociation);
+  if (!normalizedAssociation) {
+    return undefined;
+  }
+
+  return GITHUB_REPOSITORY_MAINTAINER_AUTHOR_ASSOCIATIONS.has(normalizedAssociation);
+}
+
+function cacheGitHubRepositoryMaintainerStatusFromAuthorAssociation(
+  repository: ParsedRepositoryReference,
+  login: string | null | undefined,
+  authorAssociation: string | null | undefined,
+  cache: Map<string, boolean>
+): boolean | undefined {
+  const normalizedLogin = normalizeGitHubUserLogin(login);
+  const maintainerStatus = getGitHubRepositoryMaintainerStatusFromAuthorAssociation(authorAssociation);
+  if (!normalizedLogin || maintainerStatus === undefined) {
+    return maintainerStatus;
+  }
+
+  cache.set(buildGitHubRepositoryActorCacheKey(repository, normalizedLogin), maintainerStatus);
+  return maintainerStatus;
+}
+
 async function isGitHubUserRepositoryMaintainer(
   octokit: Octokit,
   repository: ParsedRepositoryReference,
@@ -6170,6 +6204,9 @@ async function listNewGitHubIssueCommentsSinceCount(
         body: typeof comment.body === 'string' ? stripNullBytes(comment.body) : '',
         url: comment.html_url ?? undefined,
         authorLogin: normalizeGitHubUserLogin(comment.user?.login),
+        ...(normalizeGitHubLowercaseString(comment.author_association)
+          ? { authorAssociation: normalizeGitHubLowercaseString(comment.author_association) }
+          : {}),
         createdAt: comment.created_at ?? undefined,
         updatedAt: comment.updated_at ?? undefined
       });
@@ -6230,6 +6267,19 @@ async function hasTrustedNewGitHubIssueComment(params: {
       return true;
     }
 
+    const maintainerStatus = cacheGitHubRepositoryMaintainerStatusFromAuthorAssociation(
+      params.repository,
+      authorLogin,
+      comment.authorAssociation,
+      params.maintainerCache
+    );
+    if (maintainerStatus === true) {
+      return true;
+    }
+    if (maintainerStatus === false) {
+      continue;
+    }
+
     unseenAuthors.add(authorLogin);
   }
 
@@ -6258,6 +6308,16 @@ async function isMaintainerAuthoredGitHubIssue(params: {
     return false;
   }
 
+  const maintainerStatus = cacheGitHubRepositoryMaintainerStatusFromAuthorAssociation(
+    params.repository,
+    authorLogin,
+    params.githubIssue.authorAssociation,
+    params.maintainerCache
+  );
+  if (maintainerStatus !== undefined) {
+    return maintainerStatus;
+  }
+
   return isGitHubUserRepositoryMaintainer(
     params.octokit,
     params.repository,
@@ -6273,9 +6333,20 @@ async function warmGitHubRepositoryMaintainerCache(params: {
   maintainerCache: Map<string, boolean>;
 }): Promise<void> {
   const uniqueAuthorLogins = [...new Set(
-    params.githubIssues
-      .map((issue) => normalizeGitHubUserLogin(issue.authorLogin))
-      .filter((authorLogin): authorLogin is string => Boolean(authorLogin))
+    params.githubIssues.flatMap((issue) => {
+      const authorLogin = normalizeGitHubUserLogin(issue.authorLogin);
+      if (!authorLogin) {
+        return [];
+      }
+
+      const maintainerStatus = cacheGitHubRepositoryMaintainerStatusFromAuthorAssociation(
+        params.repository,
+        authorLogin,
+        issue.authorAssociation,
+        params.maintainerCache
+      );
+      return maintainerStatus === undefined ? [authorLogin] : [];
+    })
   )].filter((authorLogin) => !params.maintainerCache.has(buildGitHubRepositoryActorCacheKey(params.repository, authorLogin)));
 
   if (uniqueAuthorLogins.length === 0) {
@@ -9849,6 +9920,9 @@ async function listAllGitHubIssueComments(
         body: typeof comment.body === 'string' ? stripNullBytes(comment.body) : '',
         url: comment.html_url ?? undefined,
         authorLogin: normalizeGitHubUserLogin(comment.user?.login),
+        ...(normalizeGitHubLowercaseString(comment.author_association)
+          ? { authorAssociation: normalizeGitHubLowercaseString(comment.author_association) }
+          : {}),
         authorUrl: comment.user?.html_url ?? undefined,
         authorAvatarUrl: comment.user?.avatar_url ?? undefined,
         createdAt: comment.created_at ?? undefined,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1159,7 +1159,7 @@ const FAILED_STATUS_CONTEXT_STATES = new Set(['ERROR', 'FAILURE']);
 const PENDING_STATUS_CONTEXT_STATES = new Set(['EXPECTED', 'PENDING']);
 const GITHUB_REPOSITORY_MAINTAINER_WARMUP_CONCURRENCY = 4;
 const GITHUB_REPOSITORY_MAINTAINER_ROLE_NAMES = new Set(['admin', 'maintain']);
-const GITHUB_REPOSITORY_MAINTAINER_AUTHOR_ASSOCIATIONS = new Set(['collaborator', 'member', 'owner']);
+const GITHUB_REPOSITORY_TRUSTED_AUTHOR_ASSOCIATIONS = new Set(['collaborator', 'member', 'owner']);
 
 const GITHUB_ISSUE_STATUS_SNAPSHOT_QUERY = `
   query GitHubIssueStatusSnapshot($owner: String!, $repo: String!, $issueNumber: Int!, $after: String) {
@@ -6085,7 +6085,7 @@ function buildGitHubRepositoryActorCacheKey(
   return `${repository.owner.toLowerCase()}/${repository.repo.toLowerCase()}:${login}`;
 }
 
-function getGitHubRepositoryMaintainerStatusFromAuthorAssociation(
+function getGitHubRepositoryTrustedAuthorStatusFromAssociation(
   authorAssociation: string | null | undefined
 ): boolean | undefined {
   const normalizedAssociation = normalizeGitHubLowercaseString(authorAssociation);
@@ -6093,23 +6093,23 @@ function getGitHubRepositoryMaintainerStatusFromAuthorAssociation(
     return undefined;
   }
 
-  return GITHUB_REPOSITORY_MAINTAINER_AUTHOR_ASSOCIATIONS.has(normalizedAssociation);
+  return GITHUB_REPOSITORY_TRUSTED_AUTHOR_ASSOCIATIONS.has(normalizedAssociation);
 }
 
-function cacheGitHubRepositoryMaintainerStatusFromAuthorAssociation(
+function cacheGitHubRepositoryTrustedAuthorStatusFromAssociation(
   repository: ParsedRepositoryReference,
   login: string | null | undefined,
   authorAssociation: string | null | undefined,
   cache: Map<string, boolean>
 ): boolean | undefined {
   const normalizedLogin = normalizeGitHubUserLogin(login);
-  const maintainerStatus = getGitHubRepositoryMaintainerStatusFromAuthorAssociation(authorAssociation);
-  if (!normalizedLogin || maintainerStatus === undefined) {
-    return maintainerStatus;
+  const trustedAuthorStatus = getGitHubRepositoryTrustedAuthorStatusFromAssociation(authorAssociation);
+  if (!normalizedLogin || trustedAuthorStatus === undefined) {
+    return trustedAuthorStatus;
   }
 
-  cache.set(buildGitHubRepositoryActorCacheKey(repository, normalizedLogin), maintainerStatus);
-  return maintainerStatus;
+  cache.set(buildGitHubRepositoryActorCacheKey(repository, normalizedLogin), trustedAuthorStatus);
+  return trustedAuthorStatus;
 }
 
 async function isGitHubUserRepositoryMaintainer(
@@ -6267,16 +6267,16 @@ async function hasTrustedNewGitHubIssueComment(params: {
       return true;
     }
 
-    const maintainerStatus = cacheGitHubRepositoryMaintainerStatusFromAuthorAssociation(
+    const trustedAuthorStatus = cacheGitHubRepositoryTrustedAuthorStatusFromAssociation(
       params.repository,
       authorLogin,
       comment.authorAssociation,
       params.maintainerCache
     );
-    if (maintainerStatus === true) {
+    if (trustedAuthorStatus === true) {
       return true;
     }
-    if (maintainerStatus === false) {
+    if (trustedAuthorStatus === false) {
       continue;
     }
 
@@ -6308,14 +6308,14 @@ async function isMaintainerAuthoredGitHubIssue(params: {
     return false;
   }
 
-  const maintainerStatus = cacheGitHubRepositoryMaintainerStatusFromAuthorAssociation(
+  const trustedAuthorStatus = cacheGitHubRepositoryTrustedAuthorStatusFromAssociation(
     params.repository,
     authorLogin,
     params.githubIssue.authorAssociation,
     params.maintainerCache
   );
-  if (maintainerStatus !== undefined) {
-    return maintainerStatus;
+  if (trustedAuthorStatus !== undefined) {
+    return trustedAuthorStatus;
   }
 
   return isGitHubUserRepositoryMaintainer(
@@ -6339,13 +6339,13 @@ async function warmGitHubRepositoryMaintainerCache(params: {
         return [];
       }
 
-      const maintainerStatus = cacheGitHubRepositoryMaintainerStatusFromAuthorAssociation(
+      const trustedAuthorStatus = cacheGitHubRepositoryTrustedAuthorStatusFromAssociation(
         params.repository,
         authorLogin,
         issue.authorAssociation,
         params.maintainerCache
       );
-      return maintainerStatus === undefined ? [authorLogin] : [];
+      return trustedAuthorStatus === undefined ? [authorLogin] : [];
     })
   )].filter((authorLogin) => !params.maintainerCache.has(buildGitHubRepositoryActorCacheKey(params.repository, authorLogin)));
 

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -7431,6 +7431,141 @@ test('worker imports admin-authored open issues as todo when collaborator permis
   }
 });
 
+test('worker imports member-authored open issues as todo when public author_association is present and collaborator permission requires auth', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubTokenRef: 'github-secret-ref'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+
+  await harness.performAction('settings.saveRegistration', {
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (input, init) => {
+    const rawUrl = getRequestUrl(input);
+    const url = new URL(rawUrl);
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues' && ['all', 'open'].includes(url.searchParams.get('state') ?? '')) {
+      return jsonResponse([
+        {
+          id: 2621,
+          number: 29,
+          title: 'Member-authored issue',
+          body: 'This came from a repo member',
+          html_url: 'https://github.com/paperclipai/example-repo/issues/29',
+          user: {
+            login: 'repo-member'
+          },
+          author_association: 'MEMBER',
+          state: 'open',
+          comments: 0
+        },
+        {
+          id: 2622,
+          number: 30,
+          title: 'External issue',
+          body: 'This came from an outsider',
+          html_url: 'https://github.com/paperclipai/example-repo/issues/30',
+          user: {
+            login: 'external-reporter'
+          },
+          author_association: 'NONE',
+          state: 'open',
+          comments: 0
+        }
+      ]);
+    }
+
+    if (
+      url.pathname === '/repos/paperclipai/example-repo/collaborators/repo-member/permission'
+      || url.pathname === '/repos/paperclipai/example-repo/collaborators/external-reporter/permission'
+    ) {
+      return jsonResponse(
+        {
+          message: 'Requires authentication'
+        },
+        401
+      );
+    }
+
+    if (url.pathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      const issueNumber = typeof variables.issueNumber === 'number' ? variables.issueNumber : undefined;
+
+      if (query.includes('query GitHubIssueParentRelationships')) {
+        return graphqlIssueParentRelationshipsResponse([
+          {
+            issueNumber: 29
+          },
+          {
+            issueNumber: 30
+          }
+        ]);
+      }
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && (issueNumber === 29 || issueNumber === 30)) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: issueNumber,
+              state: 'OPEN',
+              stateReason: null,
+              comments: {
+                totalCount: 0
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: []
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    const sync = await harness.performAction('sync.runNow', {}) as {
+      syncState: { status: string; createdIssuesCount?: number; skippedIssuesCount?: number; syncedIssuesCount?: number };
+    };
+
+    assert.equal(sync.syncState.status, 'success');
+    assert.equal(sync.syncState.createdIssuesCount, 2);
+    assert.equal(sync.syncState.skippedIssuesCount, 0);
+    assert.equal(sync.syncState.syncedIssuesCount, 2);
+
+    const importedIssues = await harness.ctx.issues.list({
+      companyId: 'company-1'
+    });
+
+    assert.equal(importedIssues.find((issue) => issue.title === 'Member-authored issue')?.status, 'todo');
+    assert.equal(importedIssues.find((issue) => issue.title === 'External issue')?.status, 'backlog');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('worker repairs missing import registry entries by reusing existing imported Paperclip issues', async () => {
   const harness = createTestHarness({
     manifest,
@@ -12567,6 +12702,223 @@ test('worker only resets imported issues to todo for new comments from the issue
       transitionComments[0]?.body ?? '',
       /a new GitHub comment from the issue author or a repository maintainer was added/
     );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('worker trusts public maintainer comment author_association when collaborator permission requires auth', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubTokenRef: 'github-secret-ref'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+
+  await harness.performAction('settings.saveRegistration', {
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  const originalUpdate = harness.ctx.issues.update;
+
+  const maintainerCommentIssue = await harness.ctx.issues.create({
+    companyId: 'company-1',
+    projectId: 'project-1',
+    title: 'Member comment can reset'
+  });
+  await originalUpdate(maintainerCommentIssue.id, { status: 'in_progress' }, 'company-1');
+
+  const outsiderCommentIssue = await harness.ctx.issues.create({
+    companyId: 'company-1',
+    projectId: 'project-1',
+    title: 'External comment cannot reset'
+  });
+  await originalUpdate(outsiderCommentIssue.id, { status: 'in_progress' }, 'company-1');
+
+  await harness.ctx.state.set(
+    {
+      scopeKind: 'instance',
+      stateKey: 'paperclip-github-plugin-import-registry'
+    },
+    [
+      {
+        mappingId: 'mapping-a',
+        githubIssueId: 4501,
+        githubIssueNumber: 45,
+        paperclipIssueId: maintainerCommentIssue.id,
+        importedAt: '2026-04-09T09:00:00.000Z',
+        lastSeenCommentCount: 1,
+        repositoryUrl: 'https://github.com/paperclipai/example-repo',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      },
+      {
+        mappingId: 'mapping-a',
+        githubIssueId: 4601,
+        githubIssueNumber: 46,
+        paperclipIssueId: outsiderCommentIssue.id,
+        importedAt: '2026-04-09T09:00:00.000Z',
+        lastSeenCommentCount: 1,
+        repositoryUrl: 'https://github.com/paperclipai/example-repo',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ]
+  );
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    const rawUrl = getRequestUrl(input);
+    const url = new URL(rawUrl);
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues' && ['all', 'open'].includes(url.searchParams.get('state') ?? '')) {
+      return jsonResponse([
+        {
+          id: 4501,
+          number: 45,
+          title: 'Member comment can reset',
+          body: null,
+          html_url: 'https://github.com/paperclipai/example-repo/issues/45',
+          user: {
+            login: 'external-reporter'
+          },
+          author_association: 'NONE',
+          state: 'open',
+          comments: 2
+        },
+        {
+          id: 4601,
+          number: 46,
+          title: 'External comment cannot reset',
+          body: null,
+          html_url: 'https://github.com/paperclipai/example-repo/issues/46',
+          user: {
+            login: 'another-reporter'
+          },
+          author_association: 'NONE',
+          state: 'open',
+          comments: 2
+        }
+      ]);
+    }
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues/45/comments') {
+      return jsonResponse([
+        {
+          id: 45011,
+          body: 'Initial issue comment',
+          user: {
+            login: 'someone-else'
+          },
+          author_association: 'NONE'
+        },
+        {
+          id: 45012,
+          body: 'Maintainer follow-up',
+          user: {
+            login: 'repo-member'
+          },
+          author_association: 'MEMBER'
+        }
+      ]);
+    }
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues/46/comments') {
+      return jsonResponse([
+        {
+          id: 46011,
+          body: 'Initial issue comment',
+          user: {
+            login: 'someone-else'
+          },
+          author_association: 'NONE'
+        },
+        {
+          id: 46012,
+          body: 'Drive-by comment',
+          user: {
+            login: 'random-driveby'
+          },
+          author_association: 'NONE'
+        }
+      ]);
+    }
+
+    if (
+      url.pathname === '/repos/paperclipai/example-repo/collaborators/repo-member/permission'
+      || url.pathname === '/repos/paperclipai/example-repo/collaborators/random-driveby/permission'
+    ) {
+      return jsonResponse(
+        {
+          message: 'Requires authentication'
+        },
+        401
+      );
+    }
+
+    if (url.pathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      const issueNumber = typeof variables.issueNumber === 'number' ? variables.issueNumber : undefined;
+
+      if (query.includes('query GitHubIssueParentRelationships')) {
+        return graphqlIssueParentRelationshipsResponse([
+          {
+            issueNumber: 45
+          },
+          {
+            issueNumber: 46
+          }
+        ]);
+      }
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && (issueNumber === 45 || issueNumber === 46)) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: issueNumber,
+              state: 'OPEN',
+              stateReason: null,
+              comments: {
+                totalCount: 2
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: []
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    const sync = await harness.performAction('sync.runNow', {
+      waitForCompletion: true
+    }) as {
+      syncState: { status: string };
+    };
+
+    assert.equal(sync.syncState.status, 'success');
+    assert.equal((await harness.ctx.issues.get(maintainerCommentIssue.id, 'company-1'))?.status, 'todo');
+    assert.equal((await harness.ctx.issues.get(outsiderCommentIssue.id, 'company-1'))?.status, 'in_progress');
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -7431,7 +7431,7 @@ test('worker imports admin-authored open issues as todo when collaborator permis
   }
 });
 
-test('worker imports member-authored open issues as todo when public author_association is present and collaborator permission requires auth', async () => {
+test('worker imports trusted-author-association open issues as todo when public author_association is present and collaborator permission requires auth', async () => {
   const harness = createTestHarness({
     manifest,
     config: {
@@ -12707,7 +12707,7 @@ test('worker only resets imported issues to todo for new comments from the issue
   }
 });
 
-test('worker trusts public maintainer comment author_association when collaborator permission requires auth', async () => {
+test('worker trusts public member author_association comments when collaborator permission requires auth', async () => {
   const harness = createTestHarness({
     manifest,
     config: {


### PR DESCRIPTION
## Summary
- Preserve public GitHub `author_association` on issues and comments
- Use that signal first for maintainer/admin detection, then fall back to collaborator-permission lookup
- Add regressions for maintainer-authored imports and maintainer comment resets

## Testing
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Model Used
- `gpt-5.3-codex`
- Tool use: shell commands and `apply_patch`
- Context window: not exposed in this environment