### PR TITLE
Add issue sync controls to task detail view

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ The plugin adds a full in-host workflow instead of a one-off import script:
 - a dashboard widget that shows readiness, sync status, and last-run results
 - saved sync diagnostics that let operators inspect the latest per-issue failures, raw errors, and suggested next steps
 - a project sidebar item that opens a live project-scoped Pull Requests page for the mapped repository and can show the open PR count through a lightweight badge read
-- manual sync actions from global, project, and issue toolbar surfaces
-- a GitHub detail tab on synced Paperclip issues
+- manual sync actions from the global toolbar, mapped project toolbar surfaces, and the GitHub issue task detail view
+- a GitHub task detail view on synced Paperclip issues
 - GitHub link annotations on sync-generated status transition comments when the host supports comment annotations
 
 ## How it works

--- a/SPEC.md
+++ b/SPEC.md
@@ -113,7 +113,7 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 - The plugin MUST register successfully in Paperclip.
 - The plugin MUST expose a dashboard widget contribution.
 - The plugin MUST expose a settings page contribution.
-- The plugin SHOULD expose an issue detail contribution for GitHub metadata.
+- The plugin SHOULD expose an issue task detail view contribution for GitHub metadata.
 - The plugin SHOULD expose a project sidebar item that opens a project-scoped Pull Requests page for the mapped repository and can show the current open pull request count for mapped projects through a lightweight count read instead of the heavier summary-card metrics path.
 - The project pull request sidebar count, page, and metrics reads SHOULD tolerate saved mappings that are missing either the company id or the project id when the active Paperclip project context still identifies the intended mapping safely, and they SHOULD also fall back to the active project's bound GitHub repository when no saved sync mapping exists but the project workspace already defines that repository.
 - The project Pull Requests page SHOULD render live open pull request data for the mapped repository, including checks, an explicit up-to-date branch state, target branch badges, review summary, unresolved review-thread state, non-review comment counts, last-updated timestamps, Paperclip issue linkage, and quick actions.
@@ -135,7 +135,7 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 - When a pull request is linked to a Paperclip issue, the project Pull Requests page SHOULD open that issue in a plugin-provided right drawer so operators can stay on the queue page, while still allowing explicit navigation away when desired.
 - When a pull request is not yet linked to a Paperclip issue, the project Pull Requests page SHOULD offer an inline create-issue action and wait for the returned Paperclip identifier before rendering the issue link or opening its drawer.
 - The settings page SHOULD audit the saved GitHub token against the mapped repositories in the active company and SHOULD warn when required pull-request-action permissions are missing or GitHub cannot verify them yet.
-- The plugin SHOULD expose manual sync buttons in the global toolbar and on mapped project/issue surfaces when the host renders those slot types.
+- The plugin SHOULD expose manual sync buttons in the global toolbar, on mapped project surfaces when the host renders those toolbar slot types, and inside the GitHub issue task detail view for issue-scoped sync.
 - The dashboard widget MUST summarize the current GitHub sync readiness and link to setup.
 - When the latest sync run records issue-level failures, the settings page SHOULD expose a saved failure log with per-failure repository, issue, phase, raw error, and suggested next-step details, and compact surfaces SHOULD still surface at least the latest saved failure snapshot.
 - The settings page MUST render inside the real Paperclip host.

--- a/scripts/e2e/run-paperclip-smoke.mjs
+++ b/scripts/e2e/run-paperclip-smoke.mjs
@@ -18,7 +18,6 @@ const seededRepositoryUrl = 'https://github.com/alvarosanchez/paperclip-github-p
 const seededIssueTitle = 'GitHub Sync Smoke Issue';
 const seededGitHubIssueUrl = 'https://github.com/paperclipai/example-repo/issues/999';
 const seededGitHubPullRequestUrl = 'https://github.com/paperclipai/example-repo/pull/1000';
-const issueDetailTabQuery = 'plugin:paperclip-github-plugin:paperclip-github-plugin-issue-detail-tab';
 const requestedPort = process.env.PAPERCLIP_E2E_PORT ? Number(process.env.PAPERCLIP_E2E_PORT) : 3100;
 const requestedDbPort = process.env.PAPERCLIP_E2E_DB_PORT ? Number(process.env.PAPERCLIP_E2E_DB_PORT) : 54329;
 const defaultTimeoutMs = 30000;
@@ -397,10 +396,7 @@ async function ensureSeedIssueWithGitHubMetadata(company, project) {
   }
 
   const companyIssuePrefix = resolveCompanyIssuePrefix(company, issueIdentifier);
-  const issueUrl = new URL(
-    `/${companyIssuePrefix}/issues/${encodeURIComponent(issueIdentifier)}?tab=${encodeURIComponent(issueDetailTabQuery)}`,
-    baseUrl
-  ).toString();
+  const issueUrl = new URL(`/${companyIssuePrefix}/issues/${encodeURIComponent(issueIdentifier)}`, baseUrl).toString();
 
   log(`Seeded issue ${issueIdentifier} with GitHub fallback metadata and comment links.`);
   return {
@@ -575,12 +571,10 @@ async function main() {
     log(`Opened smoke-test issue detail page: ${seededIssue.url}`);
 
     await page.getByRole('heading', { name: seededIssueTitle, exact: true }).waitFor({ timeout: 120000 });
-    const githubDetailTab = page.getByRole('tab', { name: 'GitHub', exact: true });
-    await githubDetailTab.click();
-
     const issueDetailSurface = page.locator('.ghsync-issue-detail');
     await issueDetailSurface.getByText('Issue #999', { exact: true }).waitFor({ timeout: 120000 });
     await issueDetailSurface.getByText('paperclipai/example-repo', { exact: true }).waitFor({ timeout: 120000 });
+    await issueDetailSurface.getByRole('button', { name: 'Sync #999', exact: true }).waitFor({ timeout: 120000 });
     const openOnGitHubLink = issueDetailSurface.getByRole('link', { name: 'Open on GitHub', exact: true });
     await openOnGitHubLink.waitFor({ timeout: 120000 });
     const openOnGitHubHref = await openOnGitHubLink.getAttribute('href');

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -103,10 +103,10 @@ export const manifest: PaperclipPluginManifestV1 = {
         exportName: 'GitHubSyncDashboardWidget'
       },
       {
-        type: 'detailTab',
+        type: 'taskDetailView',
         id: 'paperclip-github-plugin-issue-detail-tab',
         displayName: 'GitHub',
-        exportName: 'GitHubSyncIssueDetailTab',
+        exportName: 'GitHubSyncIssueTaskDetailView',
         entityTypes: ['issue']
       },
       {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -127,7 +127,7 @@ export const manifest: PaperclipPluginManifestV1 = {
         id: 'paperclip-github-plugin-toolbar-button',
         displayName: 'GitHub Sync',
         exportName: 'GitHubSyncEntityToolbarButton',
-        entityTypes: ['project', 'issue']
+        entityTypes: ['project']
       },
       {
         type: 'settingsPage',

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -4341,20 +4341,76 @@ const EXTENSION_SURFACE_STYLES = `
 
   .ghsync-issue-detail {
     display: grid;
-    gap: 16px;
+    gap: 12px;
     color: var(--ghsync-text);
     font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
+
+  .ghsync-issue-detail__header {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    align-items: flex-start;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--ghsync-border-soft);
+  }
+
+  .ghsync-issue-detail__header-copy {
+    display: grid;
+    gap: 4px;
+    min-width: 0;
+  }
+
+  .ghsync-issue-detail__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    justify-content: flex-end;
+    align-items: center;
+  }
+
+  .ghsync-issue-detail__action-content {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .ghsync-issue-detail__action-button {
+    text-decoration: none;
+    white-space: nowrap;
+  }
+
+  .ghsync-issue-detail__stats {
+    display: grid;
+    gap: 8px 12px;
+    grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  }
+
+  .ghsync-issue-detail__stat {
+    display: grid;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  .ghsync-issue-detail__stat-label {
+    color: var(--ghsync-muted);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .ghsync-issue-detail__stat-value {
+    color: var(--ghsync-title);
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1.35;
   }
 
   .ghsync-issue-detail__intro,
   .ghsync-issue-detail__section {
     display: grid;
-    gap: 8px;
-  }
-
-  .ghsync-issue-detail__intro {
-    padding-bottom: 12px;
-    border-bottom: 1px solid var(--ghsync-border-soft);
+    gap: 6px;
   }
 
   .ghsync-issue-detail__section-heading {
@@ -4373,6 +4429,16 @@ const EXTENSION_SURFACE_STYLES = `
 
   .ghsync-issue-detail__title h3 {
     margin: 0;
+  }
+
+  .ghsync-issue-detail .ghsync-extension-labels,
+  .ghsync-issue-detail .ghsync-extension-links {
+    gap: 6px;
+  }
+
+  .ghsync-issue-detail .ghsync-extension-pill {
+    padding: 5px 9px;
+    font-size: 11px;
   }
 
   ${SHARED_LOADING_STYLES}
@@ -12697,6 +12763,9 @@ function GitHubSyncToolbarButtonSurface(props: {
   entityId?: string | null;
   companyId?: string | null;
   projectId?: string | null;
+  embedded?: boolean;
+  ignoreVisibility?: boolean;
+  buttonClassName?: string;
 }): React.JSX.Element | null {
   const toast = usePluginToast();
   const runSyncNow = usePluginAction('sync.runNow');
@@ -12868,7 +12937,7 @@ function GitHubSyncToolbarButtonSurface(props: {
   }, [toolbarState.refresh, settingsRegistration.refresh, props.companyId, effectiveEntityId, props.entityType]);
 
   useEffect(() => {
-    if (!props.entityType) {
+    if (!props.entityType || props.embedded) {
       return;
     }
 
@@ -12888,9 +12957,15 @@ function GitHubSyncToolbarButtonSurface(props: {
     };
   });
 
-  if (!state.visible) {
+  if (!state.visible && !props.ignoreVisibility) {
     return null;
   }
+
+  const resolvedButtonClassName =
+    props.buttonClassName
+    ?? (props.entityType
+      ? HOST_ENTITY_BUTTON_CLASSNAME
+      : HOST_GLOBAL_BUTTON_CLASSNAME);
 
   async function handleRunSync(): Promise<void> {
     try {
@@ -12986,7 +13061,11 @@ function GitHubSyncToolbarButtonSurface(props: {
   return (
     <div
       ref={surfaceRef}
-      className={`ghsync-toolbar-button${props.entityType ? ' ghsync-toolbar-button--entity' : ''}`}
+      className={[
+        'ghsync-toolbar-button',
+        props.entityType && !props.embedded ? 'ghsync-toolbar-button--entity' : '',
+        props.embedded ? 'ghsync-toolbar-button--embedded' : ''
+      ].filter(Boolean).join(' ')}
       style={themeVars}
       title={toolbarState.error?.message ?? effectiveMessage}
     >
@@ -12996,7 +13075,7 @@ function GitHubSyncToolbarButtonSurface(props: {
         data-slot="button"
         data-variant="outline"
         data-size="sm"
-        className={props.entityType ? HOST_ENTITY_BUTTON_CLASSNAME : HOST_GLOBAL_BUTTON_CLASSNAME}
+        className={resolvedButtonClassName}
         disabled={
           toolbarState.loading
           || syncStartPending
@@ -13023,7 +13102,7 @@ export function GitHubSyncGlobalToolbarButton(): React.JSX.Element | null {
 export function GitHubSyncEntityToolbarButton(): React.JSX.Element | null {
   const context = useHostContext();
 
-  if ((context.entityType !== 'issue' && context.entityType !== 'project') || !context.entityId) {
+  if (context.entityType !== 'project' || !context.entityId) {
     return null;
   }
 
@@ -13037,7 +13116,30 @@ export function GitHubSyncEntityToolbarButton(): React.JSX.Element | null {
   );
 }
 
-function GitHubSyncIssueDetailTabContent(props: {
+function GitHubIssueDetailLinkButton(props: {
+  href: string;
+  label: string;
+}): React.JSX.Element {
+  return (
+    <a
+      href={props.href}
+      target="_blank"
+      rel="noreferrer"
+      className={getPluginActionClassName({
+        variant: 'secondary',
+        size: 'sm',
+        extraClassName: 'ghsync-issue-detail__action-button'
+      })}
+    >
+      <span className="ghsync-issue-detail__action-content">
+        <GitHubMarkIcon className="h-3.5 w-3.5" />
+        <span>{props.label}</span>
+      </span>
+    </a>
+  );
+}
+
+function GitHubSyncIssueTaskDetailViewContent(props: {
   companyId?: string | null;
   issueId?: string | null;
   loadingIssueId?: boolean;
@@ -13073,41 +13175,47 @@ function GitHubSyncIssueDetailTabContent(props: {
 
       {issueDetails ? (
         <>
-          <div className="ghsync-extension-heading">
-            <div>
+          <div className="ghsync-issue-detail__header">
+            <div className="ghsync-issue-detail__header-copy">
               <h4>Issue #{issueDetails.githubIssueNumber}</h4>
               <p>{formatGitHubRepositoryLabel(issueDetails.repositoryUrl)}</p>
             </div>
-            <a
-              href={issueDetails.githubIssueUrl}
-              target="_blank"
-              rel="noreferrer"
-              className={getPluginActionClassName({
-                variant: 'secondary',
-                size: 'sm',
-                extraClassName: 'ghsync-extension-link'
-              })}
-            >
-              Open on GitHub
-            </a>
+            <div className="ghsync-issue-detail__actions">
+              <GitHubIssueDetailLinkButton
+                href={issueDetails.githubIssueUrl}
+                label="Open on GitHub"
+              />
+              <GitHubSyncToolbarButtonSurface
+                companyId={props.companyId}
+                entityId={props.issueId}
+                entityType="issue"
+                embedded
+                ignoreVisibility
+                buttonClassName={getPluginActionClassName({
+                  variant: 'secondary',
+                  size: 'sm',
+                  extraClassName: 'ghsync-issue-detail__action-button'
+                })}
+              />
+            </div>
           </div>
 
-          <div className="ghsync-extension-grid">
-            <div className="ghsync-extension-metric">
-              <span>State</span>
-              <strong>{formatGitHubIssueState(issueDetails.githubIssueState, issueDetails.githubIssueStateReason)}</strong>
+          <div className="ghsync-issue-detail__stats">
+            <div className="ghsync-issue-detail__stat">
+              <span className="ghsync-issue-detail__stat-label">State</span>
+              <strong className="ghsync-issue-detail__stat-value">{formatGitHubIssueState(issueDetails.githubIssueState, issueDetails.githubIssueStateReason)}</strong>
             </div>
-            <div className="ghsync-extension-metric">
-              <span>Comments</span>
-              <strong>{issueDetails.commentsCount ?? 'Unknown'}</strong>
+            <div className="ghsync-issue-detail__stat">
+              <span className="ghsync-issue-detail__stat-label">Comments</span>
+              <strong className="ghsync-issue-detail__stat-value">{issueDetails.commentsCount ?? 'Unknown'}</strong>
             </div>
-            <div className="ghsync-extension-metric">
-              <span>Linked PRs</span>
-              <strong>{issueDetails.linkedPullRequestNumbers.length}</strong>
+            <div className="ghsync-issue-detail__stat">
+              <span className="ghsync-issue-detail__stat-label">Linked PRs</span>
+              <strong className="ghsync-issue-detail__stat-value">{issueDetails.linkedPullRequestNumbers.length}</strong>
             </div>
-            <div className="ghsync-extension-metric">
-              <span>Last synced</span>
-              <strong>{issueDetails.syncedAt ? formatDate(issueDetails.syncedAt, 'Unknown') : 'Pending refresh'}</strong>
+            <div className="ghsync-issue-detail__stat">
+              <span className="ghsync-issue-detail__stat-label">Last synced</span>
+              <strong className="ghsync-issue-detail__stat-value">{issueDetails.syncedAt ? formatDate(issueDetails.syncedAt, 'Unknown') : 'Pending refresh'}</strong>
             </div>
           </div>
 
@@ -13116,19 +13224,11 @@ function GitHubSyncIssueDetailTabContent(props: {
               <div className="ghsync-issue-detail__section-heading">Linked pull requests</div>
               <div className="ghsync-extension-links">
                 {issueDetails.linkedPullRequestNumbers.map((pullRequestNumber: number) => (
-                  <a
+                  <GitHubIssueDetailLinkButton
                     key={pullRequestNumber}
                     href={`${issueDetails.repositoryUrl}/pull/${pullRequestNumber}`}
-                    target="_blank"
-                    rel="noreferrer"
-                    className={getPluginActionClassName({
-                      variant: 'secondary',
-                      size: 'sm',
-                      extraClassName: 'ghsync-extension-link'
-                    })}
-                  >
-                    PR #{pullRequestNumber}
-                  </a>
+                    label={`PR #${pullRequestNumber}`}
+                  />
                 ))}
               </div>
             </div>
@@ -13162,7 +13262,7 @@ function GitHubSyncIssueDetailTabContent(props: {
   );
 }
 
-export function GitHubSyncIssueDetailTab(): React.JSX.Element {
+export function GitHubSyncIssueTaskDetailView(): React.JSX.Element {
   const context = useHostContext();
   const themeMode = useResolvedThemeMode();
   const theme = themeMode === 'light' ? LIGHT_PALETTE : DARK_PALETTE;
@@ -13176,7 +13276,7 @@ export function GitHubSyncIssueDetailTab(): React.JSX.Element {
   const detailKey = `${context.companyId ?? 'company-none'}:${resolvedIssue.issueIdentifier ?? context.entityId ?? 'issue-none'}`;
 
   return (
-    <GitHubSyncIssueDetailTabContent
+    <GitHubSyncIssueTaskDetailViewContent
       key={detailKey}
       companyId={context.companyId}
       issueId={resolvedIssue.issueId}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -9013,7 +9013,9 @@ function getConfiguredGithubTokenSource(
   const normalizedCompanyId = normalizeCompanyId(companyId);
   const secretRef =
     normalizedCompanyId
-      ? normalizeSecretRef(config.githubTokenRefs?.[normalizedCompanyId]) ?? getSavedGitHubTokenRef(settings, normalizedCompanyId)
+      ? normalizeSecretRef(config.githubTokenRefs?.[normalizedCompanyId])
+        ?? normalizeGitHubTokenRef(config.githubTokenRef)
+        ?? getSavedGitHubTokenRef(settings, normalizedCompanyId)
       : normalizeGitHubTokenRef(config.githubTokenRef) ?? getSavedGitHubTokenRef(settings);
   if (secretRef) {
     return { secretRef };

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3496,7 +3496,7 @@ async function buildToolbarSyncState(
 
     return {
       kind: 'issue',
-      visible: Boolean(link),
+      visible: false,
       canRun: githubTokenConfigured && mappings.length > 0,
       label: link?.githubIssueNumber ? `Sync #${link.githubIssueNumber}` : 'Sync issue',
       message: link
@@ -9012,11 +9012,9 @@ function getConfiguredGithubTokenSource(
 ): ResolvedGitHubTokenSource {
   const normalizedCompanyId = normalizeCompanyId(companyId);
   const secretRef =
-    (normalizedCompanyId
+    normalizedCompanyId
       ? normalizeSecretRef(config.githubTokenRefs?.[normalizedCompanyId]) ?? getSavedGitHubTokenRef(settings, normalizedCompanyId)
-      : undefined)
-    ?? normalizeGitHubTokenRef(config.githubTokenRef)
-    ?? getSavedGitHubTokenRef(settings);
+      : normalizeGitHubTokenRef(config.githubTokenRef) ?? getSavedGitHubTokenRef(settings);
   if (secretRef) {
     return { secretRef };
   }

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -2187,6 +2187,7 @@ test('manifest exposes GitHub Sync page, sidebar, dashboard, and settings UI met
   assert.equal(commentAnnotationSlot?.exportName, 'GitHubSyncCommentAnnotation');
   assert.equal(globalToolbarSlot?.exportName, 'GitHubSyncGlobalToolbarButton');
   assert.equal(entityToolbarSlot?.exportName, 'GitHubSyncEntityToolbarButton');
+  assert.deepEqual(entityToolbarSlot?.entityTypes, ['project']);
 });
 
 test('project.pullRequests.page returns live GitHub pull request summaries for the mapped repository', async () => {

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -2182,7 +2182,8 @@ test('manifest exposes GitHub Sync page, sidebar, dashboard, and settings UI met
   assert.equal(projectSidebarItemSlot?.order, 40);
   assert.equal(settingsSlot?.exportName, 'GitHubSyncSettingsPage');
   assert.equal(dashboardSlot?.exportName, 'GitHubSyncDashboardWidget');
-  assert.equal(issueDetailSlot?.exportName, 'GitHubSyncIssueDetailTab');
+  assert.equal(issueDetailSlot?.type, 'taskDetailView');
+  assert.equal(issueDetailSlot?.exportName, 'GitHubSyncIssueTaskDetailView');
   assert.equal(commentAnnotationSlot?.exportName, 'GitHubSyncCommentAnnotation');
   assert.equal(globalToolbarSlot?.exportName, 'GitHubSyncGlobalToolbarButton');
   assert.equal(entityToolbarSlot?.exportName, 'GitHubSyncEntityToolbarButton');
@@ -5454,7 +5455,7 @@ test('worker exposes toolbar sync state for global, project, and issue surfaces'
   assert.equal(projectState.canRun, true);
   assert.equal(projectState.label, 'Sync project');
   assert.equal(issueState.kind, 'issue');
-  assert.equal(issueState.visible, true);
+  assert.equal(issueState.visible, false);
   assert.equal(issueState.canRun, true);
   assert.equal(issueState.label, 'Sync #77');
 });
@@ -5770,6 +5771,7 @@ test('worker filters issue-scoped GitHub link records even when entities.list ig
     issueId: secondIssue.id
   });
   const toolbarState = await harness.getData<{
+    visible: boolean;
     label: string;
   }>('sync.toolbarState', {
     companyId: 'company-1',
@@ -5779,6 +5781,7 @@ test('worker filters issue-scoped GitHub link records even when entities.list ig
 
   assert.equal(details?.paperclipIssueId, secondIssue.id);
   assert.equal(details?.githubIssueNumber, 202);
+  assert.equal(toolbarState.visible, false);
   assert.equal(toolbarState.label, 'Sync #202');
 });
 
@@ -6475,6 +6478,8 @@ test('settings.registration reports a configured token without resolving the sav
 });
 
 test('settings.registration reports a company-scoped configured token without resolving the saved secret', async () => {
+  const previousPaperclipHome = process.env.PAPERCLIP_HOME;
+  const isolatedPaperclipHome = await mkdtemp(join(tmpdir(), 'paperclip-github-plugin-settings-registration-'));
   const harness = createTestHarness({
     manifest,
     config: {
@@ -6483,30 +6488,42 @@ test('settings.registration reports a company-scoped configured token without re
       }
     }
   });
-  await plugin.definition.setup(harness.ctx);
+  process.env.PAPERCLIP_HOME = isolatedPaperclipHome;
 
-  let resolveCount = 0;
-  harness.ctx.secrets.resolve = async () => {
-    resolveCount += 1;
-    throw new Error('Rate limit exceeded for secret resolution');
-  };
+  try {
+    await plugin.definition.setup(harness.ctx);
 
-  const companyOneResult = await harness.getData<{
-    githubTokenConfigured?: boolean;
-    syncState?: { status?: string };
-  }>('settings.registration', {
-    companyId: 'company-1'
-  });
-  const companyTwoResult = await harness.getData<{
-    githubTokenConfigured?: boolean;
-  }>('settings.registration', {
-    companyId: 'company-2'
-  });
+    let resolveCount = 0;
+    harness.ctx.secrets.resolve = async () => {
+      resolveCount += 1;
+      throw new Error('Rate limit exceeded for secret resolution');
+    };
 
-  assert.equal(companyOneResult.githubTokenConfigured, true);
-  assert.equal(companyOneResult.syncState?.status, 'idle');
-  assert.equal(companyTwoResult.githubTokenConfigured, false);
-  assert.equal(resolveCount, 0);
+    const companyOneResult = await harness.getData<{
+      githubTokenConfigured?: boolean;
+      syncState?: { status?: string };
+    }>('settings.registration', {
+      companyId: 'company-1'
+    });
+    const companyTwoResult = await harness.getData<{
+      githubTokenConfigured?: boolean;
+    }>('settings.registration', {
+      companyId: 'company-2'
+    });
+
+    assert.equal(companyOneResult.githubTokenConfigured, true);
+    assert.equal(companyOneResult.syncState?.status, 'idle');
+    assert.equal(companyTwoResult.githubTokenConfigured, false);
+    assert.equal(resolveCount, 0);
+  } finally {
+    if (previousPaperclipHome === undefined) {
+      delete process.env.PAPERCLIP_HOME;
+    } else {
+      process.env.PAPERCLIP_HOME = previousPaperclipHome;
+    }
+
+    await rm(isolatedPaperclipHome, { recursive: true, force: true });
+  }
 });
 
 test('settings.saveRegistration persists the saved GitHub login label for later company-scoped settings reads', async () => {


### PR DESCRIPTION
## Summary
- Move per-issue sync into the GitHub task detail view header
- Hide the standalone issue toolbar sync surface
- Tighten the task detail layout and switch issue actions to GitHub-icon buttons
- Update docs, manifest contract tests, and e2e smoke coverage for the new slot behavior

## Testing
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm test:e2e`