### PR TITLE
Set new projects to isolated checkout by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ GitHub tokens, repository mappings, advanced import defaults, and Paperclip boar
 
 ### Project binding that respects existing work
 
-If a company already has a Paperclip project bound to a GitHub repository workspace, the settings UI can reuse that project instead of creating a duplicate. New mappings can also create and bind a Paperclip project automatically, and those newly created projects opt into isolated issue checkouts.
+If a company already has a Paperclip project bound to a GitHub repository workspace, the settings UI can reuse that project instead of creating a duplicate. New mappings can also create and bind a Paperclip project automatically, and those newly created projects opt into isolated issue checkouts with new issues defaulting to isolated checkout.
 
 ### Status sync with delivery context
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -103,7 +103,7 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 
 - Saving a mapping MUST create or reuse the target Paperclip project.
 - Saving a company-scoped mapping from the settings page MUST create or reuse the target Paperclip project in that same company.
-- When the settings page creates a new target Paperclip project, it MUST set `executionWorkspacePolicy.enabled` to `true` so the project opts into isolated issue checkouts.
+- When the settings page creates a new target Paperclip project, it MUST set `executionWorkspacePolicy.enabled` to `true` and `executionWorkspacePolicy.defaultMode` to `"isolated_workspace"` so the project opts into isolated issue checkouts and new issues default to isolated checkout.
 - Saving a mapping for a Paperclip project that is already bound to the GitHub repository MUST reuse that existing project instead of creating a duplicate workspace binding.
 - Saving a mapping MUST bind the GitHub repository URL to the Paperclip project workspace.
 - Once a project has been created and linked, its project name field SHOULD be treated as read-only in the settings UI.

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -6015,7 +6015,8 @@ export async function resolveOrCreateProject(companyId: string, projectName: str
       name: projectName.trim(),
       status: 'planned',
       executionWorkspacePolicy: {
-        enabled: true
+        enabled: true,
+        defaultMode: 'isolated_workspace'
       }
     })
   });

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -536,7 +536,8 @@ test('resolveOrCreateProject enables isolated issue checkouts for new company pr
         name: 'Engineering',
         status: 'planned',
         executionWorkspacePolicy: {
-          enabled: true
+          enabled: true,
+          defaultMode: 'isolated_workspace'
         }
       }
     ]);


### PR DESCRIPTION
**Summary**
- Set new project creation to enable isolated issue checkouts and default new issues to isolated checkout.
- Update the repo spec and README to match the host contract.
- Tighten the project-creation test coverage around the isolated checkout default.

**Testing**
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` (one unrelated existing failure remains in `settings.registration reports a company-scoped configured token without resolving the saved secret`)

**Model Used**
- GPT-5.3-codex, medium reasoning, tool use enabled, context window size not exposed in this environment.
