### PR TITLE
Fix missing wakeups for imported todo issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ When the local Paperclip API is available, the plugin also syncs labels by name,
 Additional behavior:
 
 - Open issues with no linked pull request that are created by a verified repository maintainer/admin bypass the default imported status and start in `todo`.
+- Newly imported issues that finish sync in `todo` and are assigned to an agent enqueue an assignee wakeup so the agent can pick them up promptly.
 - Open imported issues that are already in `backlog` stay in `backlog` until someone changes them in Paperclip.
 - If an imported issue is `done` or `cancelled` and GitHub shows it open again with no linked pull request, sync moves it to `todo` so agents can pick it up again.
 - Trusted new GitHub comments from the original issue author or a verified maintainer/admin can move an open imported issue back to `todo`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -84,6 +84,7 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 - Repeated sync runs MUST continue reconciling imported Paperclip issue labels against the latest mapped GitHub labels, including removing labels that were removed on GitHub.
 - An open GitHub issue without a linked PR that was created by a repository maintainer/admin MUST map to Paperclip `todo` when it is first imported.
 - An open GitHub issue without a linked PR MUST otherwise map to the configured default Paperclip status when it is first imported, and that default MUST be `backlog` when the company has not chosen another status.
+- When a newly imported GitHub issue finishes sync in Paperclip `todo` and is assigned to an agent, the worker MUST best-effort enqueue an assignment wakeup for that assignee using the imported Paperclip issue as wake context.
 - If an imported Paperclip issue is currently `backlog` and its linked GitHub issue is still open, the sync flow MUST preserve `backlog`; only a manual Paperclip transition may move it out of `backlog`.
 - If a Paperclip issue that came from an open GitHub issue without a linked PR is later moved out of `backlog`, the sync flow SHOULD preserve that Paperclip status until another open-issue GitHub rule applies.
 - If that Paperclip issue is currently `done` or `cancelled` while the linked GitHub issue is open with no linked PR, the sync flow MUST move it to `todo` instead of `backlog` so it re-enters the active queue.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -61,6 +61,7 @@ const CANCELLING_SYNC_MESSAGE = 'Cancellation requested. GitHub sync will stop a
 const SYNC_PROGRESS_PERSIST_INTERVAL_MS = 250;
 const MAX_SYNC_FAILURE_LOG_ENTRIES = 25;
 const GITHUB_SECONDARY_RATE_LIMIT_FALLBACK_MS = 60_000;
+const IMPORTED_ISSUE_WAKEUP_CONCURRENCY = 4;
 const MISSING_GITHUB_TOKEN_SYNC_MESSAGE = 'Configure a GitHub token before running sync.';
 const MISSING_GITHUB_TOKEN_SYNC_ACTION =
   'Open settings and save a GitHub token secret, or create $PAPERCLIP_HOME/plugins/github-sync/config.json (or ~/.paperclip/plugins/github-sync/config.json when PAPERCLIP_HOME is unset) with a "githubToken" value, and then run sync again.';
@@ -9075,6 +9076,10 @@ async function synchronizePaperclipIssueStatuses(
   let updatedDescriptionsCount = 0;
   let completedIssueCount = 0;
   const totalIssueCount = importedIssues.length;
+  const queuedImportedIssueWakeups: Array<{
+    assigneeAgentId?: string | null;
+    paperclipIssueId: string;
+  }> = [];
 
   for (const importedIssue of importedIssues) {
       if (assertNotCancelled) {
@@ -9241,11 +9246,9 @@ async function synchronizePaperclipIssueStatuses(
 
       if (paperclipIssue.status === nextStatus) {
         if (shouldWakeImportedAssignee) {
-          await wakePaperclipAssigneeForImportedIssue(ctx, {
+          queuedImportedIssueWakeups.push({
             assigneeAgentId: paperclipIssue.assigneeAgentId,
-            paperclipIssueId: importedIssue.paperclipIssueId,
-            companyId: mapping.companyId,
-            paperclipApiBaseUrl
+            paperclipIssueId: importedIssue.paperclipIssueId
           });
         }
         continue;
@@ -9277,11 +9280,9 @@ async function synchronizePaperclipIssueStatuses(
       updatedStatusesCount += 1;
 
       if (shouldWakeImportedAssignee) {
-        await wakePaperclipAssigneeForImportedIssue(ctx, {
+        queuedImportedIssueWakeups.push({
           assigneeAgentId: paperclipIssue.assigneeAgentId,
-          paperclipIssueId: importedIssue.paperclipIssueId,
-          companyId: mapping.companyId,
-          paperclipApiBaseUrl
+          paperclipIssueId: importedIssue.paperclipIssueId
         });
       }
     } catch (error) {
@@ -9304,6 +9305,17 @@ async function synchronizePaperclipIssueStatuses(
       }
     }
   }
+
+  await mapWithConcurrency(
+    queuedImportedIssueWakeups,
+    IMPORTED_ISSUE_WAKEUP_CONCURRENCY,
+    async (queuedWakeup) => wakePaperclipAssigneeForImportedIssue(ctx, {
+      assigneeAgentId: queuedWakeup.assigneeAgentId,
+      paperclipIssueId: queuedWakeup.paperclipIssueId,
+      companyId: mapping.companyId,
+      paperclipApiBaseUrl
+    })
+  );
 
   return {
     updatedStatusesCount,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -71,6 +71,7 @@ const MISSING_BOARD_ACCESS_SYNC_MESSAGE =
   'Connect Paperclip board access before running sync on this authenticated deployment.';
 const MISSING_BOARD_ACCESS_SYNC_ACTION =
   'Open plugin settings for each mapped company that sync will touch, connect Paperclip board access, approve the flow, and then run sync again.';
+const IMPORTED_ISSUE_WAKE_REASON = 'GitHub Sync imported an assigned issue that is ready for work.';
 const ISSUE_LINK_ENTITY_TYPE = 'paperclip-github-plugin.issue-link';
 const PULL_REQUEST_LINK_ENTITY_TYPE = 'paperclip-github-plugin.pull-request-link';
 const COMMENT_ANNOTATION_ENTITY_TYPE = 'paperclip-github-plugin.comment-annotation';
@@ -7576,6 +7577,10 @@ function getPaperclipHealthEndpoint(baseUrl: string): string {
   return new URL('/api/health', baseUrl).toString();
 }
 
+function getPaperclipAgentWakeupEndpoint(baseUrl: string, agentId: string): string {
+  return new URL(`/api/agents/${agentId}/wakeup`, baseUrl).toString();
+}
+
 function getActivePaperclipApiAuthToken(companyId?: string): string | undefined {
   if (!companyId) {
     return undefined;
@@ -7637,6 +7642,57 @@ async function detectPaperclipBoardAccessRequirement(paperclipApiBaseUrl?: strin
     return Boolean(health && requiresPaperclipBoardAccess(health));
   } catch {
     return false;
+  }
+}
+
+async function wakePaperclipAssigneeForImportedIssue(
+  ctx: PluginSetupContext,
+  params: {
+    assigneeAgentId?: string | null;
+    paperclipIssueId: string;
+    companyId?: string;
+    paperclipApiBaseUrl?: string;
+  }
+): Promise<void> {
+  if (!params.assigneeAgentId || !params.paperclipApiBaseUrl) {
+    return;
+  }
+
+  try {
+    const response = await fetchPaperclipApi(
+      getPaperclipAgentWakeupEndpoint(params.paperclipApiBaseUrl, params.assigneeAgentId),
+      {
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          source: 'assignment',
+          triggerDetail: 'system',
+          reason: IMPORTED_ISSUE_WAKE_REASON,
+          payload: {
+            issueId: params.paperclipIssueId,
+            mutation: 'import'
+          }
+        })
+      },
+      {
+        companyId: params.companyId
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Wakeup request failed with status ${response.status}.`);
+    }
+  } catch (error) {
+    ctx.logger.warn('GitHub sync could not wake the assignee for an imported Paperclip issue.', {
+      issueId: params.paperclipIssueId,
+      agentId: params.assigneeAgentId,
+      companyId: params.companyId,
+      paperclipApiBaseUrl: params.paperclipApiBaseUrl,
+      error: error instanceof Error ? error.message : String(error)
+    });
   }
 }
 
@@ -9177,11 +9233,21 @@ async function synchronizePaperclipIssueStatuses(
         defaultImportedStatus: advancedSettings.defaultStatus,
         maintainerAuthoredImportedIssue
       });
+      const shouldWakeImportedAssignee =
+        wasImportedThisRun && nextStatus === 'todo' && Boolean(paperclipIssue.assigneeAgentId);
 
       importedIssue.githubIssueNumber = githubIssue.number;
       importedIssue.lastSeenCommentCount = snapshot.commentCount;
 
       if (paperclipIssue.status === nextStatus) {
+        if (shouldWakeImportedAssignee) {
+          await wakePaperclipAssigneeForImportedIssue(ctx, {
+            assigneeAgentId: paperclipIssue.assigneeAgentId,
+            paperclipIssueId: importedIssue.paperclipIssueId,
+            companyId: mapping.companyId,
+            paperclipApiBaseUrl
+          });
+        }
         continue;
       }
 
@@ -9209,6 +9275,15 @@ async function synchronizePaperclipIssueStatuses(
         paperclipApiBaseUrl
       });
       updatedStatusesCount += 1;
+
+      if (shouldWakeImportedAssignee) {
+        await wakePaperclipAssigneeForImportedIssue(ctx, {
+          assigneeAgentId: paperclipIssue.assigneeAgentId,
+          paperclipIssueId: importedIssue.paperclipIssueId,
+          companyId: mapping.companyId,
+          paperclipApiBaseUrl
+        });
+      }
     } catch (error) {
       if (isGitHubRateLimitError(error)) {
         throw error;

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -7527,6 +7527,155 @@ test('worker imports maintainer-authored open issues without linked pull request
   }
 });
 
+test('worker wakes the assignee when a newly imported maintainer-authored issue stays in todo', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+
+  await harness.performAction('settings.saveRegistration', {
+    companyId: 'company-1',
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    advancedSettings: {
+      defaultAssigneeAgentId: 'agent-1',
+      defaultStatus: 'backlog',
+      ignoredIssueAuthorUsernames: ['renovate']
+    },
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  const wakeupRequests: Array<{ path: string; body: Record<string, unknown> | null }> = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (input, init) => {
+    const rawUrl = getRequestUrl(input);
+    const url = new URL(rawUrl);
+    const method = (init?.method ?? 'GET').toUpperCase();
+
+    if (
+      url.origin === 'http://127.0.0.1:63675'
+      && url.pathname === '/api/agents/agent-1/wakeup'
+      && method === 'POST'
+    ) {
+      wakeupRequests.push({
+        path: url.pathname,
+        body: getJsonRequestBody(init)
+      });
+
+      return jsonResponse({
+        id: 'run-1',
+        agentId: 'agent-1',
+        status: 'queued'
+      });
+    }
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues' && ['all', 'open'].includes(url.searchParams.get('state') ?? '')) {
+      return jsonResponse([
+        {
+          id: 2621,
+          number: 29,
+          title: 'Maintainer-assigned issue',
+          body: 'Please pick this up',
+          html_url: 'https://github.com/paperclipai/example-repo/issues/29',
+          user: {
+            login: 'repo-maintainer'
+          },
+          state: 'open',
+          comments: 0
+        }
+      ]);
+    }
+
+    if (url.pathname === '/repos/paperclipai/example-repo/collaborators/repo-maintainer/permission') {
+      return jsonResponse({
+        permission: 'admin',
+        role_name: 'maintain',
+        user: {
+          login: 'repo-maintainer'
+        }
+      });
+    }
+
+    if (url.pathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      const issueNumber = typeof variables.issueNumber === 'number' ? variables.issueNumber : undefined;
+
+      if (query.includes('query GitHubIssueParentRelationships')) {
+        return graphqlIssueParentRelationshipsResponse([
+          {
+            issueNumber: 29
+          }
+        ]);
+      }
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && issueNumber === 29) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: 29,
+              state: 'OPEN',
+              stateReason: null,
+              comments: {
+                totalCount: 0
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: []
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected request: ${method} ${url.toString()}`);
+  };
+
+  try {
+    const sync = await harness.performAction('sync.runNow', {}) as {
+      syncState: { status: string; createdIssuesCount?: number };
+    };
+
+    assert.equal(sync.syncState.status, 'success');
+    assert.equal(sync.syncState.createdIssuesCount, 1);
+
+    const importedIssue = (await harness.ctx.issues.list({
+      companyId: 'company-1'
+    })).find((issue) => issue.title === 'Maintainer-assigned issue');
+
+    assert.ok(importedIssue);
+    assert.equal(importedIssue?.status, 'todo');
+    assert.equal(importedIssue?.assigneeAgentId, 'agent-1');
+    assert.equal(wakeupRequests.length, 1);
+    assert.deepEqual(wakeupRequests[0]?.body?.source, 'assignment');
+    assert.deepEqual(wakeupRequests[0]?.body?.triggerDetail, 'system');
+    assert.match(String(wakeupRequests[0]?.body?.reason ?? ''), /imported/i);
+    assert.deepEqual(wakeupRequests[0]?.body?.payload, {
+      issueId: importedIssue?.id,
+      mutation: 'import'
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('worker imports admin-authored open issues as todo when collaborator permission omits role_name', async () => {
   const harness = createTestHarness({
     manifest,

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -7676,6 +7676,167 @@ test('worker wakes the assignee when a newly imported maintainer-authored issue 
   }
 });
 
+test('worker batches imported-issue assignee wakeups with a small concurrency limit', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+
+  await harness.performAction('settings.saveRegistration', {
+    companyId: 'company-1',
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    advancedSettings: {
+      defaultAssigneeAgentId: 'agent-1',
+      defaultStatus: 'backlog',
+      ignoredIssueAuthorUsernames: ['renovate']
+    },
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  const originalFetch = globalThis.fetch;
+  let inFlightWakeups = 0;
+  let maxInFlightWakeups = 0;
+  let wakeupCount = 0;
+
+  globalThis.fetch = async (input, init) => {
+    const rawUrl = getRequestUrl(input);
+    const url = new URL(rawUrl);
+    const method = (init?.method ?? 'GET').toUpperCase();
+
+    if (
+      url.origin === 'http://127.0.0.1:63675'
+      && url.pathname === '/api/agents/agent-1/wakeup'
+      && method === 'POST'
+    ) {
+      wakeupCount += 1;
+      inFlightWakeups += 1;
+      maxInFlightWakeups = Math.max(maxInFlightWakeups, inFlightWakeups);
+
+      await delay(20);
+
+      inFlightWakeups -= 1;
+      return jsonResponse({
+        id: `run-${wakeupCount}`,
+        agentId: 'agent-1',
+        status: 'queued'
+      });
+    }
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues' && ['all', 'open'].includes(url.searchParams.get('state') ?? '')) {
+      return jsonResponse([
+        {
+          id: 2631,
+          number: 31,
+          title: 'Wake one',
+          body: 'Please pick this up',
+          html_url: 'https://github.com/paperclipai/example-repo/issues/31',
+          user: { login: 'repo-maintainer' },
+          state: 'open',
+          comments: 0
+        },
+        {
+          id: 2632,
+          number: 32,
+          title: 'Wake two',
+          body: 'Please pick this up too',
+          html_url: 'https://github.com/paperclipai/example-repo/issues/32',
+          user: { login: 'repo-maintainer' },
+          state: 'open',
+          comments: 0
+        },
+        {
+          id: 2633,
+          number: 33,
+          title: 'Wake three',
+          body: 'Please pick this up three',
+          html_url: 'https://github.com/paperclipai/example-repo/issues/33',
+          user: { login: 'repo-maintainer' },
+          state: 'open',
+          comments: 0
+        }
+      ]);
+    }
+
+    if (url.pathname === '/repos/paperclipai/example-repo/collaborators/repo-maintainer/permission') {
+      return jsonResponse({
+        permission: 'admin',
+        role_name: 'maintain',
+        user: {
+          login: 'repo-maintainer'
+        }
+      });
+    }
+
+    if (url.pathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      const issueNumber = typeof variables.issueNumber === 'number' ? variables.issueNumber : undefined;
+
+      if (query.includes('query GitHubIssueParentRelationships')) {
+        return graphqlIssueParentRelationshipsResponse([
+          { issueNumber: 31 },
+          { issueNumber: 32 },
+          { issueNumber: 33 }
+        ]);
+      }
+
+      if (
+        query.includes('query GitHubIssueStatusSnapshot')
+        && (issueNumber === 31 || issueNumber === 32 || issueNumber === 33)
+      ) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: issueNumber,
+              state: 'OPEN',
+              stateReason: null,
+              comments: {
+                totalCount: 0
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: []
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected request: ${method} ${url.toString()}`);
+  };
+
+  try {
+    const sync = await harness.performAction('sync.runNow', {}) as {
+      syncState: { status: string; createdIssuesCount?: number };
+    };
+
+    assert.equal(sync.syncState.status, 'success');
+    assert.equal(sync.syncState.createdIssuesCount, 3);
+    assert.equal(wakeupCount, 3);
+    assert.ok(maxInFlightWakeups > 1);
+    assert.ok(maxInFlightWakeups <= 4);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('worker imports admin-authored open issues as todo when collaborator permission omits role_name', async () => {
   const harness = createTestHarness({
     manifest,


### PR DESCRIPTION
**Summary**
- Wake the assigned agent when a newly imported GitHub issue stays in `todo`.
- Send the wakeup best-effort through `/api/agents/:id/wakeup` with the imported issue as context.
- Add regression coverage and document the behavior in `SPEC.md` and `README.md`.

**Testing**
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

**Model Used**
- GPT-5.3-codex
- Context window size: not exposed in this environment
- Reasoning mode: medium
- Tool use: enabled