### PR TITLE
Hide unlinked GitHub issue detail view

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The plugin adds a full in-host workflow instead of a one-off import script:
 - saved sync diagnostics that let operators inspect the latest per-issue failures, raw errors, and suggested next steps
 - a project sidebar item that opens a live project-scoped Pull Requests page for the mapped repository and can show the open PR count through a lightweight badge read
 - manual sync actions from global, project, and issue toolbar surfaces
-- a GitHub detail tab on synced Paperclip issues
+- a GitHub detail tab on synced Paperclip issues that stays hidden for Paperclip issues with no linked GitHub issue
 - GitHub link annotations on sync-generated status transition comments when the host supports comment annotations
 
 ## How it works

--- a/SPEC.md
+++ b/SPEC.md
@@ -114,6 +114,7 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 - The plugin MUST expose a dashboard widget contribution.
 - The plugin MUST expose a settings page contribution.
 - The plugin SHOULD expose an issue detail contribution for GitHub metadata.
+- The issue detail contribution SHOULD hide itself when the current Paperclip issue has no linked GitHub issue instead of rendering an unlinked empty-state placeholder.
 - The plugin SHOULD expose a project sidebar item that opens a project-scoped Pull Requests page for the mapped repository and can show the current open pull request count for mapped projects through a lightweight count read instead of the heavier summary-card metrics path.
 - The project pull request sidebar count, page, and metrics reads SHOULD tolerate saved mappings that are missing either the company id or the project id when the active Paperclip project context still identifies the intended mapping safely, and they SHOULD also fall back to the active project's bound GitHub repository when no saved sync mapping exists but the project workspace already defines that repository.
 - The project Pull Requests page SHOULD render live open pull request data for the mapped repository, including checks, an explicit up-to-date branch state, target branch badges, review summary, unresolved review-thread state, non-review comment counts, last-updated timestamps, Paperclip issue linkage, and quick actions.

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -13095,15 +13095,15 @@ export function resolveGitHubIssueDetailTabState(params: {
     return 'loading';
   }
 
+  if (params.issueDetails) {
+    return 'ready';
+  }
+
   if (params.detailsError) {
     return 'error';
   }
 
-  if (!params.issueDetails) {
-    return 'hidden';
-  }
-
-  return 'ready';
+  return 'hidden';
 }
 
 export function GitHubSyncIssueTaskDetailView(): React.JSX.Element | null {

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -271,6 +271,8 @@ interface GitHubIssueDetailsData {
   syncedAt?: string;
 }
 
+type GitHubIssueDetailTabState = 'loading' | 'error' | 'hidden' | 'ready';
+
 interface IssueIdentifierResolutionData {
   issueId: string;
   issueIdentifier: string;
@@ -12956,12 +12958,18 @@ function GitHubSyncIssueDetailTabContent(props: {
   issueId?: string | null;
   loadingIssueId?: boolean;
   themeVars: React.CSSProperties;
-}): React.JSX.Element {
+}): React.JSX.Element | null {
   const details = usePluginData<GitHubIssueDetailsData | null>('issue.githubDetails', {
     ...(props.companyId ? { companyId: props.companyId } : {}),
     ...(props.issueId ? { issueId: props.issueId } : {})
   });
   const issueDetails = details.data?.paperclipIssueId === props.issueId ? details.data : null;
+  const detailTabState = resolveGitHubIssueDetailTabState({
+    loadingIssueId: props.loadingIssueId,
+    detailsLoading: details.loading,
+    detailsError: Boolean(details.error),
+    issueDetails
+  });
 
   useEffect(() => {
     if (!props.companyId || !props.issueId) {
@@ -12975,17 +12983,18 @@ function GitHubSyncIssueDetailTabContent(props: {
     }
   }, [details.refresh, props.companyId, props.issueId]);
 
+  if (detailTabState === 'hidden') {
+    return null;
+  }
+
   return (
     <section className="ghsync-issue-detail" style={props.themeVars}>
       <style>{EXTENSION_SURFACE_STYLES}</style>
 
-      {props.loadingIssueId || (details.loading && !issueDetails) ? <p className="ghsync-extension-empty">Loading GitHub sync details…</p> : null}
-      {details.error ? <p className="ghsync-extension-empty">{details.error.message}</p> : null}
-      {!props.loadingIssueId && !details.loading && !details.error && !issueDetails ? (
-        <p className="ghsync-extension-empty">GitHub Sync has not linked this Paperclip issue to a GitHub issue yet.</p>
-      ) : null}
+      {detailTabState === 'loading' ? <p className="ghsync-extension-empty">Loading GitHub sync details…</p> : null}
+      {detailTabState === 'error' && details.error ? <p className="ghsync-extension-empty">{details.error.message}</p> : null}
 
-      {issueDetails ? (
+      {detailTabState === 'ready' && issueDetails ? (
         <>
           <div className="ghsync-extension-heading">
             <div>
@@ -13076,7 +13085,28 @@ function GitHubSyncIssueDetailTabContent(props: {
   );
 }
 
-export function GitHubSyncIssueTaskDetailView(): React.JSX.Element {
+export function resolveGitHubIssueDetailTabState(params: {
+  loadingIssueId?: boolean;
+  detailsLoading?: boolean;
+  detailsError?: boolean;
+  issueDetails?: GitHubIssueDetailsData | null;
+}): GitHubIssueDetailTabState {
+  if (params.loadingIssueId || (params.detailsLoading && !params.issueDetails)) {
+    return 'loading';
+  }
+
+  if (params.detailsError) {
+    return 'error';
+  }
+
+  if (!params.issueDetails) {
+    return 'hidden';
+  }
+
+  return 'ready';
+}
+
+export function GitHubSyncIssueTaskDetailView(): React.JSX.Element | null {
   const context = useHostContext();
   const themeMode = useResolvedThemeMode();
   const theme = themeMode === 'light' ? LIGHT_PALETTE : DARK_PALETTE;

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -2372,7 +2372,7 @@ test('fetchPaperclipHealth returns null when the Paperclip health endpoint is un
   }
 });
 
-test('resolveGitHubIssueDetailTabState hides unlinked issue detail views while preserving loading and error states', async () => {
+test('resolveGitHubIssueDetailTabState hides unlinked issue detail views while preserving loading, error, and cached-detail states', async () => {
   const uiModule = await importFreshUiModule() as {
     resolveGitHubIssueDetailTabState?: unknown;
   };
@@ -2418,6 +2418,17 @@ test('resolveGitHubIssueDetailTabState hides unlinked issue detail views while p
       loadingIssueId: false,
       detailsLoading: false,
       detailsError: false,
+      issueDetails: {
+        paperclipIssueId: 'issue-123'
+      }
+    }),
+    'ready'
+  );
+  assert.equal(
+    resolveGitHubIssueDetailTabState({
+      loadingIssueId: false,
+      detailsLoading: false,
+      detailsError: true,
       issueDetails: {
         paperclipIssueId: 'issue-123'
       }

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -2372,6 +2372,60 @@ test('fetchPaperclipHealth returns null when the Paperclip health endpoint is un
   }
 });
 
+test('resolveGitHubIssueDetailTabState hides unlinked issue detail views while preserving loading and error states', async () => {
+  const uiModule = await importFreshUiModule() as {
+    resolveGitHubIssueDetailTabState?: unknown;
+  };
+
+  assert.equal(typeof uiModule.resolveGitHubIssueDetailTabState, 'function');
+
+  const resolveGitHubIssueDetailTabState = uiModule.resolveGitHubIssueDetailTabState as (params: {
+    loadingIssueId?: boolean;
+    detailsLoading?: boolean;
+    detailsError?: boolean;
+    issueDetails?: { paperclipIssueId?: string } | null;
+  }) => 'loading' | 'error' | 'hidden' | 'ready';
+
+  assert.equal(
+    resolveGitHubIssueDetailTabState({
+      loadingIssueId: false,
+      detailsLoading: false,
+      detailsError: false,
+      issueDetails: null
+    }),
+    'hidden'
+  );
+  assert.equal(
+    resolveGitHubIssueDetailTabState({
+      loadingIssueId: true,
+      detailsLoading: false,
+      detailsError: false,
+      issueDetails: null
+    }),
+    'loading'
+  );
+  assert.equal(
+    resolveGitHubIssueDetailTabState({
+      loadingIssueId: false,
+      detailsLoading: false,
+      detailsError: true,
+      issueDetails: null
+    }),
+    'error'
+  );
+  assert.equal(
+    resolveGitHubIssueDetailTabState({
+      loadingIssueId: false,
+      detailsLoading: false,
+      detailsError: false,
+      issueDetails: {
+        paperclipIssueId: 'issue-123'
+      }
+    }),
+    'ready'
+  );
+});
+
 test('mergePluginConfig preserves existing config while merging token and board access refs by company', () => {
   const result = mergePluginConfig(
     {


### PR DESCRIPTION
## Summary
- The GitHub issue detail tab now returns `null` when the current Paperclip issue has no linked GitHub issue.
- Loading and error states still render for linked issue details.
- Added regression coverage and aligned the README and SPEC.

## Testing
- `pnpm test`

## Model Used
- `gpt-5.3-codex`, context window size not provided in session metadata, medium reasoning, tool-assisted