### PR TITLE
Fix flickering sync buttons during sync polling

### DIFF
--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -869,6 +869,54 @@ function isSyncCancellationRequested(syncState: SyncRunState): boolean {
   return syncState.status === 'running' && Boolean(syncState.cancelRequestedAt?.trim());
 }
 
+export function resolveToolbarButtonState(params: {
+  loading: boolean;
+  runningSync: boolean;
+  cancellingSync: boolean;
+  syncState: SyncRunState;
+  allowToolbarCancellation: boolean;
+  effectiveCanRun: boolean;
+  effectiveLabel: string;
+}): {
+  busy: boolean;
+  disabled: boolean;
+  label: string;
+  busyLabel: string;
+  cancellationRequested: boolean;
+  syncPersistedRunning: boolean;
+  syncStartPending: boolean;
+} {
+  const syncPersistedRunning = params.syncState.status === 'running';
+  const syncStartPending = params.runningSync && !syncPersistedRunning;
+  const cancellationRequested =
+    syncPersistedRunning && (params.cancellingSync || isSyncCancellationRequested(params.syncState));
+  const loadingVisible = params.loading && !syncPersistedRunning;
+
+  return {
+    busy:
+      loadingVisible
+      || syncStartPending
+      || cancellationRequested
+      || (!params.allowToolbarCancellation && syncPersistedRunning),
+    disabled:
+      loadingVisible
+      || syncStartPending
+      || (syncPersistedRunning ? (params.allowToolbarCancellation ? cancellationRequested : true) : !params.effectiveCanRun),
+    label: syncPersistedRunning && params.allowToolbarCancellation ? 'Cancel sync' : params.effectiveLabel,
+    busyLabel:
+      syncPersistedRunning
+        ? cancellationRequested
+          ? 'Cancelling…'
+          : 'Syncing…'
+        : loadingVisible
+          ? 'Loading…'
+          : 'Syncing…',
+    cancellationRequested,
+    syncPersistedRunning,
+    syncStartPending
+  };
+}
+
 function getSyncToastTitle(syncState: SyncRunState): string {
   if (getActiveRateLimitPause(syncState)) {
     return 'GitHub sync is paused';
@@ -12679,23 +12727,25 @@ function GitHubSyncToolbarButtonSurface(props: {
       ? getSyncSetupMessage(boardAccessSetupIssue, hasCompanyContext)
       : state.message;
   const effectiveLabel = boardAccessSetupIssue ? 'Board access required' : state.label;
-  const syncPersistedRunning = effectiveSyncState.status === 'running';
-  const syncStartPending = runningSync && !syncPersistedRunning;
   const allowToolbarCancellation = Boolean(props.entityType);
-  const cancellationRequested = syncPersistedRunning && (cancellingSync || isSyncCancellationRequested(effectiveSyncState));
-  const toolbarButtonBusy =
-    toolbarState.loading
-    || syncStartPending
-    || cancellationRequested
-    || (!allowToolbarCancellation && syncPersistedRunning);
-  const toolbarButtonLabel = syncPersistedRunning && allowToolbarCancellation ? 'Cancel sync' : effectiveLabel;
-  const toolbarButtonBusyLabel = toolbarState.loading
-    ? 'Loading…'
-    : syncPersistedRunning
-      ? cancellationRequested
-        ? 'Cancelling…'
-        : 'Syncing…'
-      : 'Syncing…';
+  const toolbarButtonState = resolveToolbarButtonState({
+    loading: toolbarState.loading,
+    runningSync,
+    cancellingSync,
+    syncState: effectiveSyncState,
+    allowToolbarCancellation,
+    effectiveCanRun,
+    effectiveLabel
+  });
+  const {
+    busy: toolbarButtonBusy,
+    disabled: toolbarButtonDisabled,
+    label: toolbarButtonLabel,
+    busyLabel: toolbarButtonBusyLabel,
+    syncPersistedRunning,
+    syncStartPending,
+    cancellationRequested
+  } = toolbarButtonState;
   const armSyncCompletionToast = useSyncCompletionToast(effectiveSyncState, toast);
 
   useEffect(() => {
@@ -12911,11 +12961,7 @@ function GitHubSyncToolbarButtonSurface(props: {
         data-variant="outline"
         data-size="sm"
         className={props.entityType ? HOST_ENTITY_BUTTON_CLASSNAME : HOST_GLOBAL_BUTTON_CLASSNAME}
-        disabled={
-          toolbarState.loading
-          || syncStartPending
-          || (syncPersistedRunning ? (allowToolbarCancellation ? cancellationRequested : true) : !effectiveCanRun)
-        }
+        disabled={toolbarButtonDisabled}
         onClick={syncPersistedRunning && allowToolbarCancellation ? handleCancelSync : handleRunSync}
       >
         <LoadingButtonContent

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -598,6 +598,110 @@ test('resolveSavedTokenUiState clears stale valid token state when no saved toke
   );
 });
 
+test('resolveToolbarButtonState keeps entity sync buttons stable during background refreshes', async () => {
+  const uiModule = await importFreshUiModule() as {
+    resolveToolbarButtonState?: unknown;
+  };
+
+  assert.equal(typeof uiModule.resolveToolbarButtonState, 'function');
+
+  const resolveToolbarButtonState = uiModule.resolveToolbarButtonState as (params: {
+    loading: boolean;
+    runningSync: boolean;
+    cancellingSync: boolean;
+    syncState: {
+      status: 'idle' | 'running' | 'success' | 'error' | 'cancelled';
+      cancelRequestedAt?: string;
+    };
+    allowToolbarCancellation: boolean;
+    effectiveCanRun: boolean;
+    effectiveLabel: string;
+  }) => {
+    busy: boolean;
+    disabled: boolean;
+    label: string;
+    busyLabel: string;
+    cancellationRequested: boolean;
+    syncPersistedRunning: boolean;
+    syncStartPending: boolean;
+  };
+
+  assert.deepEqual(
+    resolveToolbarButtonState({
+      loading: true,
+      runningSync: false,
+      cancellingSync: false,
+      syncState: {
+        status: 'running'
+      },
+      allowToolbarCancellation: true,
+      effectiveCanRun: true,
+      effectiveLabel: 'Sync project'
+    }),
+    {
+      busy: false,
+      disabled: false,
+      label: 'Cancel sync',
+      busyLabel: 'Syncing…',
+      cancellationRequested: false,
+      syncPersistedRunning: true,
+      syncStartPending: false
+    }
+  );
+});
+
+test('resolveToolbarButtonState keeps the global toolbar on syncing instead of loading during polling', async () => {
+  const uiModule = await importFreshUiModule() as {
+    resolveToolbarButtonState?: unknown;
+  };
+
+  assert.equal(typeof uiModule.resolveToolbarButtonState, 'function');
+
+  const resolveToolbarButtonState = uiModule.resolveToolbarButtonState as (params: {
+    loading: boolean;
+    runningSync: boolean;
+    cancellingSync: boolean;
+    syncState: {
+      status: 'idle' | 'running' | 'success' | 'error' | 'cancelled';
+      cancelRequestedAt?: string;
+    };
+    allowToolbarCancellation: boolean;
+    effectiveCanRun: boolean;
+    effectiveLabel: string;
+  }) => {
+    busy: boolean;
+    disabled: boolean;
+    label: string;
+    busyLabel: string;
+    cancellationRequested: boolean;
+    syncPersistedRunning: boolean;
+    syncStartPending: boolean;
+  };
+
+  assert.deepEqual(
+    resolveToolbarButtonState({
+      loading: true,
+      runningSync: false,
+      cancellingSync: false,
+      syncState: {
+        status: 'running'
+      },
+      allowToolbarCancellation: false,
+      effectiveCanRun: true,
+      effectiveLabel: 'Sync GitHub'
+    }),
+    {
+      busy: true,
+      disabled: true,
+      label: 'Sync GitHub',
+      busyLabel: 'Syncing…',
+      cancellationRequested: false,
+      syncPersistedRunning: true,
+      syncStartPending: false
+    }
+  );
+});
+
 test('syncGitHubTokenPropagationForAgents adds and removes agent GITHUB_TOKEN secret refs without clobbering unrelated env config', async () => {
   const uiModule = await importFreshUiModule() as {
     syncGitHubTokenPropagationForAgents?: unknown;


### PR DESCRIPTION
## Summary
- Added `resolveToolbarButtonState` to keep toolbar copy and disabled state anchored to persisted sync state.
- Separated transient background refresh loading from visible running/canceling button state so polling no longer flashes `Loading…`.
- Added regression tests for both the entity toolbar cancel path and the global toolbar running path.

## Testing
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`

## Model Used
- GPT-5.3-codex, 128k context, medium reasoning, tool-using