### PR TITLE
Fix orphaned GitHub sync loops after restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ During sync, the plugin imports one top-level Paperclip issue per GitHub issue, 
 
 When the host exposes plugin issue creation, imported GitHub issues are created through the Paperclip plugin SDK path so they are not attributed to the connected board user. The worker still uses direct local Paperclip REST calls for label sync and for description or status repair paths when those routes are available.
 
-Long-running syncs continue in the background, so quick actions do not have to wait for the whole import to finish. Once a sync has started, the settings page, dashboard widget, and toolbar actions can request cancellation; the worker stops cooperatively after the current repository or issue step finishes.
+Long-running syncs continue in the background, so quick actions do not have to wait for the whole import to finish. Once a sync has started, the settings page, dashboard widget, and toolbar actions can request cancellation; the worker stops cooperatively after the current repository or issue step finishes. If the worker restarts mid-run, GitHub Sync now recovers that orphaned `running` state on the next read or control action instead of leaving the UI stuck in `running` or silently restarting the old run.
 
 ## Highlights
 
@@ -203,6 +203,7 @@ Current host caveat: on authenticated Paperclip deployments, the Paperclip host 
 - If a GitHub-linked project does not show the **Pull requests** sidebar entry, reopen the plugin settings and re-save the mapping. The project pull request surfaces also recover older mappings when saved ids are missing, and they can fall back to the active project's bound GitHub repository when the project already has a GitHub workspace configured.
 - If GitHub rate limiting is hit, the plugin pauses sync until the reported reset time instead of retrying pointlessly.
 - If a manual sync takes longer than the host action window, it continues in the background and updates the UI when it finishes or when a cancellation request stops it.
+- If a sync shows `running` after the worker has restarted, the next settings read, toolbar read, cancel action, or scheduler tick will reconcile that stale run into an interrupted error or a cancelled result so you can retry cleanly.
 
 ## Development
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -27,6 +27,7 @@ The settings page MUST allow saving mappings and triggering a manual sync.
 - The plugin SHOULD also expose manual sync entry points from Paperclip toolbar surfaces when the SDK supports them.
 - When a manual sync will outlive a quick action response, the worker MUST persist a `running` sync state immediately and complete the sync asynchronously.
 - Once a sync is running, the settings page, dashboard widget, and toolbar sync entry points MUST provide a way to request cancellation, and the worker MUST stop cooperatively after the current repository or issue step finishes.
+- If a worker restart or similar interruption leaves a persisted sync state in `running` without a live in-memory sync behind it, the next worker-visible read or control path MUST reconcile that orphaned run into an interrupted error or cancelled result instead of leaving the UI stuck in `running` or silently restarting the abandoned run.
 - The settings page, dashboard widget, and sync toolbar surfaces SHOULD detect authenticated deployments from `/api/health` and MUST require connected Paperclip board access before enabling sync for the affected company.
 
 ## Secret handling

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -58,6 +58,10 @@ const GITHUB_TOKEN_PERMISSION_AUDIT_CACHE_TTL_MS = 5 * 60_000;
 const MANUAL_SYNC_RESPONSE_GRACE_PERIOD_MS = 500;
 const RUNNING_SYNC_MESSAGE = 'GitHub sync is running in the background. This page will update when it finishes.';
 const CANCELLING_SYNC_MESSAGE = 'Cancellation requested. GitHub sync will stop after the current step finishes.';
+const INTERRUPTED_SYNC_MESSAGE =
+  'GitHub sync stopped unexpectedly before it finished. The worker restarted while the sync was running.';
+const INTERRUPTED_SYNC_ACTION =
+  'Run GitHub sync again. If it stops on the same repository or issue, retry that narrower scope to isolate the failing step.';
 const SYNC_PROGRESS_PERSIST_INTERVAL_MS = 250;
 const MAX_SYNC_FAILURE_LOG_ENTRIES = 25;
 const GITHUB_SECONDARY_RATE_LIMIT_FALLBACK_MS = 60_000;
@@ -4115,6 +4119,119 @@ async function getSyncCancellationRequest(
   return normalizeSyncCancellationRequest(await ctx.state.get(SYNC_CANCELLATION_SCOPE));
 }
 
+function buildInterruptedSyncMessage(progress: SyncProgressState | undefined): string {
+  const completedIssueCount =
+    typeof progress?.completedIssueCount === 'number' ? Math.max(0, progress.completedIssueCount) : undefined;
+  const totalIssueCount =
+    typeof progress?.totalIssueCount === 'number' ? Math.max(0, progress.totalIssueCount) : undefined;
+  const completionSummary =
+    completedIssueCount !== undefined && totalIssueCount !== undefined
+      ? ` Completed ${Math.min(completedIssueCount, totalIssueCount)} of ${totalIssueCount} issues before the worker restarted.`
+      : '';
+
+  return `${INTERRUPTED_SYNC_MESSAGE}${completionSummary}`;
+}
+
+function getInterruptedSyncFailurePhase(progress: SyncProgressState | undefined): SyncFailurePhase | undefined {
+  switch (progress?.phase) {
+    case 'preparing':
+      return 'building_import_plan';
+    case 'importing':
+      return 'importing_issue';
+    case 'syncing':
+      return 'evaluating_github_status';
+    default:
+      return undefined;
+  }
+}
+
+async function reconcileOrphanedRunningSyncState(
+  ctx: PluginSetupContext,
+  companyId?: string,
+  resolution: 'error' | 'cancelled' = 'error'
+): Promise<GitHubSyncSettings> {
+  const normalizedCompanyId = normalizeCompanyId(companyId);
+  if (
+    activeRunningSyncState?.syncState.status === 'running'
+    && activeRunningSyncCompanyId === normalizedCompanyId
+  ) {
+    return materializeScopedSettings(activeRunningSyncState, null, normalizedCompanyId);
+  }
+
+  const current = normalizeSettings(await ctx.state.get(SETTINGS_SCOPE));
+  const scopedSyncState = getScopedSyncState(current, normalizedCompanyId);
+  if (scopedSyncState.status !== 'running') {
+    return materializeScopedSettings(current, null, normalizedCompanyId);
+  }
+
+  const trigger = scopedSyncState.lastRunTrigger ?? 'manual';
+  const progress = normalizeSyncProgress(scopedSyncState.progress);
+  const syncCounts = {
+    syncedIssuesCount: scopedSyncState.syncedIssuesCount ?? 0,
+    createdIssuesCount: scopedSyncState.createdIssuesCount ?? 0,
+    skippedIssuesCount: scopedSyncState.skippedIssuesCount ?? 0,
+    erroredIssuesCount: scopedSyncState.erroredIssuesCount ?? 0
+  };
+
+  const nextSyncState =
+    resolution === 'cancelled' || Boolean(scopedSyncState.cancelRequestedAt?.trim())
+      ? createCancelledSyncState({
+          message: buildCancelledSyncMessage(undefined, progress),
+          trigger,
+          ...syncCounts,
+          ...(progress ? { progress } : {})
+        })
+      : (() => {
+          const errorDetails = normalizeSyncErrorDetails({
+            ...(getInterruptedSyncFailurePhase(progress) ? { phase: getInterruptedSyncFailurePhase(progress) } : {}),
+            ...(progress?.currentRepositoryUrl ? { repositoryUrl: progress.currentRepositoryUrl } : {}),
+            ...(typeof progress?.currentIssueNumber === 'number'
+              ? { githubIssueNumber: progress.currentIssueNumber }
+              : {}),
+            rawMessage: INTERRUPTED_SYNC_MESSAGE,
+            suggestedAction: INTERRUPTED_SYNC_ACTION
+          });
+          const message = buildInterruptedSyncMessage(progress);
+
+          return createErrorSyncState({
+            message,
+            trigger,
+            ...syncCounts,
+            ...(progress ? { progress } : {}),
+            ...(errorDetails ? { errorDetails } : {}),
+            recentFailures: appendRecentSyncFailureLogEntry(
+              scopedSyncState.recentFailures,
+              createSyncFailureLogEntry({
+                message,
+                ...(errorDetails ? { errorDetails } : {})
+              })
+            )
+          });
+        })();
+
+  const next = await saveSettingsSyncState(ctx, current, nextSyncState, normalizedCompanyId);
+  await setSyncCancellationRequest(ctx, null);
+  return next;
+}
+
+function resolvePersistedRunningSyncCompanyId(
+  settings: Pick<GitHubSyncSettings, 'syncState' | 'syncStateByCompanyId'>
+): string | undefined | null {
+  if (normalizeSyncState(settings.syncState).status === 'running') {
+    return undefined;
+  }
+
+  const runningCompanyIds = Object.entries(settings.syncStateByCompanyId ?? {})
+    .flatMap(([companyId, syncState]) => {
+      const normalizedCompanyId = normalizeCompanyId(companyId);
+      return normalizedCompanyId && normalizeSyncState(syncState).status === 'running'
+        ? [normalizedCompanyId]
+        : [];
+    });
+
+  return runningCompanyIds.length === 1 ? runningCompanyIds[0] : null;
+}
+
 function buildCancelledSyncMessage(
   target: ResolvedSyncTarget | undefined,
   progress: SyncProgressState | undefined
@@ -4203,8 +4320,7 @@ async function getActiveOrCurrentSyncState(
     return materializeScopedSettings(activeRunningSyncState, null, normalizedCompanyId);
   }
 
-  const current = normalizeSettings(await ctx.state.get(SETTINGS_SCOPE));
-  return materializeScopedSettings(current, null, normalizedCompanyId);
+  return reconcileOrphanedRunningSyncState(ctx, normalizedCompanyId);
 }
 
 function updateSyncFailureContext(
@@ -13477,6 +13593,10 @@ function shouldRunScheduledSync(settings: GitHubSyncSettings, scheduledAt?: stri
     return false;
   }
 
+  if (settings.syncState.status === 'running') {
+    return false;
+  }
+
   if (!settings.syncState.checkedAt) {
     return true;
   }
@@ -14135,6 +14255,8 @@ async function startSync(
 
     return quickResult ?? await getActiveOrCurrentSyncState(ctx);
   }
+
+  await reconcileOrphanedRunningSyncState(ctx, options.target?.companyId);
 
   const [config, persistedSettings] = await Promise.all([
     getResolvedConfig(ctx),
@@ -15123,6 +15245,7 @@ const plugin = definePlugin({
       const record = input && typeof input === 'object' ? input as Record<string, unknown> : {};
       const requestedCompanyId = normalizeCompanyId(record.companyId);
       const includeAssignees = Boolean(requestedCompanyId && record.includeAssignees === true);
+      await reconcileOrphanedRunningSyncState(ctx, requestedCompanyId);
       const saved = await ctx.state.get(SETTINGS_SCOPE);
       const importRegistry = normalizeImportRegistry(await ctx.state.get(IMPORT_REGISTRY_SCOPE));
       const normalizedSettings = normalizeSettings(saved);
@@ -15508,7 +15631,15 @@ const plugin = definePlugin({
     });
 
     ctx.actions.register('sync.cancel', async () => {
-      const currentSettings = await getActiveOrCurrentSyncState(ctx, activeRunningSyncCompanyId);
+      const persistedRunningSyncCompanyId =
+        activeRunningSyncState?.syncState.status === 'running'
+          ? activeRunningSyncCompanyId
+          : resolvePersistedRunningSyncCompanyId(normalizeSettings(await ctx.state.get(SETTINGS_SCOPE)));
+      const currentSettings = await reconcileOrphanedRunningSyncState(
+        ctx,
+        persistedRunningSyncCompanyId === null ? undefined : persistedRunningSyncCompanyId,
+        'cancelled'
+      );
       if (currentSettings.syncState.status !== 'running') {
         return currentSettings;
       }
@@ -15534,7 +15665,7 @@ const plugin = definePlugin({
           message: CANCELLING_SYNC_MESSAGE,
           cancelRequestedAt: cancellationRequest.requestedAt
         }),
-        activeRunningSyncCompanyId
+        persistedRunningSyncCompanyId === null ? undefined : persistedRunningSyncCompanyId
       );
       activeRunningSyncState = next;
       return next;
@@ -15548,7 +15679,8 @@ const plugin = definePlugin({
       const scheduledTargets = listScheduledSyncTargets(settings);
 
       if (scheduledTargets.length === 0) {
-        if (job.trigger === 'schedule' && !shouldRunScheduledSync(settings, job.scheduledAt)) {
+        const reconciledSettings = await reconcileOrphanedRunningSyncState(ctx);
+        if (job.trigger === 'schedule' && !shouldRunScheduledSync(reconciledSettings, job.scheduledAt)) {
           return;
         }
 
@@ -15557,7 +15689,7 @@ const plugin = definePlugin({
       }
 
       for (const target of scheduledTargets) {
-        const scopedSettings = materializeScopedSettings(settings, null, target?.companyId);
+        const scopedSettings = await reconcileOrphanedRunningSyncState(ctx, target?.companyId);
         if (job.trigger === 'schedule' && !shouldRunScheduledSync(scopedSettings, job.scheduledAt)) {
           continue;
         }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4145,17 +4145,32 @@ function getInterruptedSyncFailurePhase(progress: SyncProgressState | undefined)
   }
 }
 
+function getActiveRunningSyncForScope(companyId?: string): GitHubSyncSettings | null {
+  const normalizedCompanyId = normalizeCompanyId(companyId);
+  if (activeRunningSyncState?.syncState.status !== 'running') {
+    return null;
+  }
+
+  const activeSyncMatchesScope =
+    normalizedCompanyId === undefined
+    || activeRunningSyncCompanyId === undefined
+    || activeRunningSyncCompanyId === normalizedCompanyId;
+  if (!activeSyncMatchesScope) {
+    return null;
+  }
+
+  return materializeScopedSettings(activeRunningSyncState, null, normalizedCompanyId);
+}
+
 async function reconcileOrphanedRunningSyncState(
   ctx: PluginSetupContext,
   companyId?: string,
   resolution: 'error' | 'cancelled' = 'error'
 ): Promise<GitHubSyncSettings> {
   const normalizedCompanyId = normalizeCompanyId(companyId);
-  if (
-    activeRunningSyncState?.syncState.status === 'running'
-    && activeRunningSyncCompanyId === normalizedCompanyId
-  ) {
-    return materializeScopedSettings(activeRunningSyncState, null, normalizedCompanyId);
+  const activeRunningSync = getActiveRunningSyncForScope(normalizedCompanyId);
+  if (activeRunningSync) {
+    return activeRunningSync;
   }
 
   const current = normalizeSettings(await ctx.state.get(SETTINGS_SCOPE));
@@ -4313,11 +4328,9 @@ async function getActiveOrCurrentSyncState(
   companyId?: string
 ): Promise<GitHubSyncSettings> {
   const normalizedCompanyId = normalizeCompanyId(companyId);
-  if (
-    activeRunningSyncState?.syncState.status === 'running'
-    && activeRunningSyncCompanyId === normalizedCompanyId
-  ) {
-    return materializeScopedSettings(activeRunningSyncState, null, normalizedCompanyId);
+  const activeRunningSync = getActiveRunningSyncForScope(normalizedCompanyId);
+  if (activeRunningSync) {
+    return activeRunningSync;
   }
 
   return reconcileOrphanedRunningSyncState(ctx, normalizedCompanyId);

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -5866,8 +5866,8 @@ test('worker scopes toolbar sync status to the requested company', async () => {
     companyId: 'company-2'
   });
 
-  assert.equal(companyOneState.syncState.status, 'running');
-  assert.equal(companyOneState.syncState.message, 'Syncing company one');
+  assert.equal(companyOneState.syncState.status, 'error');
+  assert.match(companyOneState.syncState.message ?? '', /worker restarted/i);
   assert.equal(companyTwoState.syncState.status, 'success');
   assert.equal(companyTwoState.syncState.message, 'Company two synced');
 });
@@ -14110,9 +14110,9 @@ test('settings.registration returns the saved sync state for the requested compa
     companyId: 'company-2'
   });
 
-  assert.equal(companyOneResult.syncState.status, 'running');
-  assert.equal(companyOneResult.syncState.message, 'Syncing company one');
-  assert.equal(companyOneResult.syncState.checkedAt, '2026-04-09T10:00:00.000Z');
+  assert.equal(companyOneResult.syncState.status, 'error');
+  assert.match(companyOneResult.syncState.message ?? '', /worker restarted/i);
+  assert.equal(typeof companyOneResult.syncState.checkedAt, 'string');
   assert.equal(companyTwoResult.syncState.status, 'success');
   assert.equal(companyTwoResult.syncState.message, 'Company two synced');
   assert.equal(companyTwoResult.syncState.checkedAt, '2026-04-09T11:00:00.000Z');
@@ -15083,6 +15083,344 @@ test('sync.runNow clears the cancellation marker with state.delete instead of wr
     assert.equal(result.syncState.syncedIssuesCount, 0);
     assert.equal(result.syncState.createdIssuesCount, 0);
     assert.ok(deletedStateKeys.includes('paperclip-github-plugin-sync-cancel-request'));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('settings.registration recovers an orphaned running sync after a worker restart', async () => {
+  const harness = createTestHarness({ manifest });
+  await plugin.definition.setup(harness.ctx);
+
+  await harness.ctx.state.set(
+    {
+      scopeKind: 'instance',
+      stateKey: 'paperclip-github-plugin-settings'
+    },
+    {
+      mappings: [
+        {
+          id: 'mapping-a',
+          repositoryUrl: 'paperclipai/example-repo',
+          paperclipProjectName: 'Engineering',
+          paperclipProjectId: 'project-1',
+          companyId: 'company-1'
+        }
+      ],
+      syncState: {
+        status: 'running',
+        message: 'GitHub sync is running in the background. This page will update when it finishes.',
+        syncedIssuesCount: 3,
+        createdIssuesCount: 1,
+        skippedIssuesCount: 0,
+        erroredIssuesCount: 0,
+        lastRunTrigger: 'manual',
+        progress: {
+          phase: 'syncing',
+          totalRepositoryCount: 1,
+          currentRepositoryIndex: 1,
+          currentRepositoryUrl: 'https://github.com/paperclipai/example-repo',
+          completedIssueCount: 1,
+          totalIssueCount: 3,
+          currentIssueNumber: 10
+        }
+      },
+      scheduleFrequencyMinutes: 15,
+      updatedAt: '2026-04-09T09:00:00.000Z'
+    }
+  );
+
+  const result = await harness.getData<{
+    syncState: {
+      status: string;
+      message?: string;
+      checkedAt?: string;
+      createdIssuesCount?: number;
+      syncedIssuesCount?: number;
+      progress?: {
+        currentIssueNumber?: number;
+      };
+    };
+  }>('settings.registration', {
+    companyId: 'company-1'
+  });
+
+  assert.equal(result.syncState.status, 'error');
+  assert.match(result.syncState.message ?? '', /stopped unexpectedly/i);
+  assert.match(result.syncState.message ?? '', /worker restarted/i);
+  assert.equal(typeof result.syncState.checkedAt, 'string');
+  assert.equal(result.syncState.createdIssuesCount, 1);
+  assert.equal(result.syncState.syncedIssuesCount, 3);
+  assert.equal(result.syncState.progress?.currentIssueNumber, 10);
+
+  const savedState = harness.getState({
+    scopeKind: 'instance',
+    stateKey: 'paperclip-github-plugin-settings'
+  }) as {
+    syncState: {
+      status: string;
+      message?: string;
+      checkedAt?: string;
+    };
+  };
+
+  assert.equal(savedState.syncState.status, 'error');
+  assert.match(savedState.syncState.message ?? '', /worker restarted/i);
+  assert.equal(typeof savedState.syncState.checkedAt, 'string');
+});
+
+test('sync.cancel finalizes an orphaned running sync instead of leaving it stuck in running', async () => {
+  const harness = createTestHarness({ manifest });
+  await plugin.definition.setup(harness.ctx);
+
+  await harness.ctx.state.set(
+    {
+      scopeKind: 'instance',
+      stateKey: 'paperclip-github-plugin-settings'
+    },
+    {
+      mappings: [
+        {
+          id: 'mapping-a',
+          repositoryUrl: 'paperclipai/example-repo',
+          paperclipProjectName: 'Engineering',
+          paperclipProjectId: 'project-1',
+          companyId: 'company-1'
+        }
+      ],
+      syncState: {
+        status: 'running',
+        message: 'Cancellation requested. GitHub sync will stop after the current step finishes.',
+        syncedIssuesCount: 3,
+        createdIssuesCount: 1,
+        skippedIssuesCount: 0,
+        erroredIssuesCount: 0,
+        lastRunTrigger: 'manual',
+        cancelRequestedAt: '2026-04-09T09:01:00.000Z',
+        progress: {
+          phase: 'syncing',
+          totalRepositoryCount: 1,
+          currentRepositoryIndex: 1,
+          currentRepositoryUrl: 'https://github.com/paperclipai/example-repo',
+          completedIssueCount: 1,
+          totalIssueCount: 3,
+          currentIssueNumber: 10
+        }
+      },
+      scheduleFrequencyMinutes: 15,
+      updatedAt: '2026-04-09T09:00:00.000Z'
+    }
+  );
+  await harness.ctx.state.set(
+    {
+      scopeKind: 'instance',
+      stateKey: 'paperclip-github-plugin-sync-cancel-request'
+    },
+    {
+      requestedAt: '2026-04-09T09:01:00.000Z'
+    }
+  );
+
+  const result = await harness.performAction('sync.cancel', {}) as {
+    syncState: {
+      status: string;
+      message?: string;
+      checkedAt?: string;
+      cancelRequestedAt?: string;
+      syncedIssuesCount?: number;
+      progress?: {
+        totalIssueCount?: number;
+        completedIssueCount?: number;
+      };
+    };
+  };
+
+  assert.equal(result.syncState.status, 'cancelled');
+  assert.match(result.syncState.message ?? '', /was cancelled before it finished/i);
+  assert.equal(typeof result.syncState.checkedAt, 'string');
+  assert.equal(result.syncState.cancelRequestedAt, undefined);
+  assert.equal(result.syncState.syncedIssuesCount, 3);
+  assert.equal(result.syncState.progress?.completedIssueCount, 1);
+  assert.equal(result.syncState.progress?.totalIssueCount, 3);
+
+  const savedCancellationRequest = harness.getState({
+    scopeKind: 'instance',
+    stateKey: 'paperclip-github-plugin-sync-cancel-request'
+  });
+  assert.equal(savedCancellationRequest, undefined);
+});
+
+test('sync.cancel finalizes the only company-scoped orphaned running sync after a worker restart', async () => {
+  const harness = createTestHarness({ manifest });
+  await plugin.definition.setup(harness.ctx);
+
+  await harness.ctx.state.set(
+    {
+      scopeKind: 'instance',
+      stateKey: 'paperclip-github-plugin-settings'
+    },
+    {
+      mappings: [
+        {
+          id: 'mapping-a',
+          repositoryUrl: 'paperclipai/example-repo',
+          paperclipProjectName: 'Engineering',
+          paperclipProjectId: 'project-1',
+          companyId: 'company-1'
+        }
+      ],
+      syncState: {
+        status: 'idle'
+      },
+      syncStateByCompanyId: {
+        'company-1': {
+          status: 'running',
+          message: 'GitHub sync is running in the background. This page will update when it finishes.',
+          syncedIssuesCount: 3,
+          createdIssuesCount: 1,
+          skippedIssuesCount: 0,
+          erroredIssuesCount: 0,
+          lastRunTrigger: 'manual',
+          progress: {
+            phase: 'syncing',
+            totalRepositoryCount: 1,
+            currentRepositoryIndex: 1,
+            currentRepositoryUrl: 'https://github.com/paperclipai/example-repo',
+            completedIssueCount: 1,
+            totalIssueCount: 3,
+            currentIssueNumber: 10
+          }
+        }
+      },
+      scheduleFrequencyMinutes: 15,
+      updatedAt: '2026-04-09T09:00:00.000Z'
+    }
+  );
+
+  const result = await harness.performAction('sync.cancel', {}) as {
+    syncState: {
+      status: string;
+      message?: string;
+      checkedAt?: string;
+      cancelRequestedAt?: string;
+      syncedIssuesCount?: number;
+      progress?: {
+        totalIssueCount?: number;
+        completedIssueCount?: number;
+      };
+    };
+  };
+
+  assert.equal(result.syncState.status, 'cancelled');
+  assert.match(result.syncState.message ?? '', /was cancelled before it finished/i);
+  assert.equal(typeof result.syncState.checkedAt, 'string');
+  assert.equal(result.syncState.cancelRequestedAt, undefined);
+  assert.equal(result.syncState.syncedIssuesCount, 3);
+  assert.equal(result.syncState.progress?.completedIssueCount, 1);
+  assert.equal(result.syncState.progress?.totalIssueCount, 3);
+
+  const savedState = harness.getState({
+    scopeKind: 'instance',
+    stateKey: 'paperclip-github-plugin-settings'
+  }) as {
+    syncStateByCompanyId?: Record<string, {
+      status?: string;
+      message?: string;
+      checkedAt?: string;
+    }>;
+  };
+
+  assert.equal(savedState.syncStateByCompanyId?.['company-1']?.status, 'cancelled');
+  assert.match(savedState.syncStateByCompanyId?.['company-1']?.message ?? '', /was cancelled before it finished/i);
+  assert.equal(typeof savedState.syncStateByCompanyId?.['company-1']?.checkedAt, 'string');
+});
+
+test('scheduled job does not restart an orphaned running sync', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubToken: 'ghp_test_token'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+
+  await harness.ctx.state.set(
+    {
+      scopeKind: 'instance',
+      stateKey: 'paperclip-github-plugin-settings'
+    },
+    {
+      mappings: [
+        {
+          id: 'mapping-a',
+          repositoryUrl: 'paperclipai/example-repo',
+          paperclipProjectName: 'Engineering',
+          paperclipProjectId: 'project-1',
+          companyId: 'company-1'
+        }
+      ],
+      syncState: {
+        status: 'running',
+        message: 'GitHub sync is running in the background. This page will update when it finishes.',
+        syncedIssuesCount: 2,
+        createdIssuesCount: 1,
+        skippedIssuesCount: 0,
+        erroredIssuesCount: 0,
+        lastRunTrigger: 'schedule',
+        progress: {
+          phase: 'syncing',
+          totalRepositoryCount: 1,
+          currentRepositoryIndex: 1,
+          currentRepositoryUrl: 'https://github.com/paperclipai/example-repo',
+          completedIssueCount: 1,
+          totalIssueCount: 2,
+          currentIssueNumber: 10
+        }
+      },
+      scheduleFrequencyMinutes: 15,
+      updatedAt: '2026-04-09T09:00:00.000Z'
+    }
+  );
+
+  const originalFetch = globalThis.fetch;
+  let githubRequestCount = 0;
+
+  globalThis.fetch = async (input) => {
+    const rawUrl = getRequestUrl(input);
+    const url = new URL(rawUrl);
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues' && ['all', 'open'].includes(url.searchParams.get('state') ?? '')) {
+      githubRequestCount += 1;
+      return jsonResponse([]);
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    await harness.runJob('sync.github-issues', {
+      trigger: 'schedule',
+      scheduledAt: '2026-04-09T09:45:00.000Z'
+    });
+
+    assert.equal(githubRequestCount, 0);
+
+    const savedState = harness.getState({
+      scopeKind: 'instance',
+      stateKey: 'paperclip-github-plugin-settings'
+    }) as {
+      syncState: {
+        status: string;
+        message?: string;
+        checkedAt?: string;
+        lastRunTrigger?: string;
+      };
+    };
+
+    assert.equal(savedState.syncState.status, 'error');
+    assert.match(savedState.syncState.message ?? '', /worker restarted/i);
+    assert.equal(typeof savedState.syncState.checkedAt, 'string');
+    assert.equal(savedState.syncState.lastRunTrigger, 'schedule');
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -14877,6 +14877,259 @@ test('worker returns a running state for long manual syncs and persists the fina
   }
 });
 
+test('global toolbar reads keep a live company-scoped sync in running state', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubTokenRef: 'github-secret-ref'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+
+  await harness.performAction('settings.saveRegistration', {
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (input, init) => {
+    const rawUrl = getRequestUrl(input);
+    const url = new URL(rawUrl);
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues' && ['all', 'open'].includes(url.searchParams.get('state') ?? '')) {
+      await delay(700);
+
+      return jsonResponse([
+        {
+          id: 1001,
+          number: 10,
+          title: 'Scoped sync issue',
+          body: 'Body from GitHub',
+          html_url: 'https://github.com/paperclipai/example-repo/issues/10',
+          state: 'open'
+        }
+      ]);
+    }
+
+    if (url.pathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      const issueNumber = typeof variables.issueNumber === 'number' ? variables.issueNumber : undefined;
+
+      if (query.includes('query GitHubIssueParentRelationships')) {
+        return graphqlIssueParentRelationshipsResponse([
+          {
+            issueNumber: 10
+          }
+        ]);
+      }
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && issueNumber === 10) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: 10,
+              state: 'OPEN',
+              stateReason: null,
+              comments: {
+                totalCount: 0
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: []
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    const scopedResult = await harness.performAction('sync.runNow', {
+      companyId: 'company-1'
+    }) as {
+      syncState: { status: string; message?: string };
+    };
+    assert.equal(scopedResult.syncState.status, 'running');
+
+    const globalToolbarState = await harness.getData<{
+      kind: string;
+      syncState: { status: string; message?: string };
+    }>('sync.toolbarState', {});
+    assert.equal(globalToolbarState.kind, 'global');
+    assert.equal(globalToolbarState.syncState.status, 'running');
+
+    const persistedState = harness.getState({
+      scopeKind: 'instance',
+      stateKey: 'paperclip-github-plugin-settings'
+    }) as {
+      syncState: { status: string; message?: string };
+    };
+    assert.equal(persistedState.syncState.status, 'running');
+
+    await waitFor(() => {
+      const current = harness.getState({
+        scopeKind: 'instance',
+        stateKey: 'paperclip-github-plugin-settings'
+      }) as {
+        syncState?: { status?: string };
+      } | undefined;
+
+      return current?.syncState?.status === 'success';
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('repeat sync.runNow keeps a live company-scoped sync in running state', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubTokenRef: 'github-secret-ref'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+
+  await harness.performAction('settings.saveRegistration', {
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (input, init) => {
+    const rawUrl = getRequestUrl(input);
+    const url = new URL(rawUrl);
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues' && ['all', 'open'].includes(url.searchParams.get('state') ?? '')) {
+      await delay(700);
+
+      return jsonResponse([
+        {
+          id: 1001,
+          number: 10,
+          title: 'Scoped sync issue',
+          body: 'Body from GitHub',
+          html_url: 'https://github.com/paperclipai/example-repo/issues/10',
+          state: 'open'
+        }
+      ]);
+    }
+
+    if (url.pathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      const issueNumber = typeof variables.issueNumber === 'number' ? variables.issueNumber : undefined;
+
+      if (query.includes('query GitHubIssueParentRelationships')) {
+        return graphqlIssueParentRelationshipsResponse([
+          {
+            issueNumber: 10
+          }
+        ]);
+      }
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && issueNumber === 10) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: 10,
+              state: 'OPEN',
+              stateReason: null,
+              comments: {
+                totalCount: 0
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: []
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    const scopedRunPromise = harness.performAction('sync.runNow', {
+      companyId: 'company-1'
+    }) as Promise<{
+      syncState: { status: string; message?: string };
+    }>;
+
+    await waitFor(() => {
+      const current = harness.getState({
+        scopeKind: 'instance',
+        stateKey: 'paperclip-github-plugin-settings'
+      }) as {
+        syncState?: { status?: string };
+      } | undefined;
+
+      return current?.syncState?.status === 'running';
+    });
+
+    const repeatedResult = await harness.performAction('sync.runNow', {}) as {
+      syncState: { status: string; message?: string };
+    };
+    assert.equal(repeatedResult.syncState.status, 'running');
+
+    const persistedState = harness.getState({
+      scopeKind: 'instance',
+      stateKey: 'paperclip-github-plugin-settings'
+    }) as {
+      syncState: { status: string; message?: string };
+    };
+    assert.equal(persistedState.syncState.status, 'running');
+
+    const scopedResult = await scopedRunPromise;
+    assert.equal(scopedResult.syncState.status, 'running');
+
+    await waitFor(() => {
+      const current = harness.getState({
+        scopeKind: 'instance',
+        stateKey: 'paperclip-github-plugin-settings'
+      }) as {
+        syncState?: { status?: string };
+      } | undefined;
+
+      return current?.syncState?.status === 'success';
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('worker can cancel a long-running manual sync after it has started', async () => {
   const harness = createTestHarness({
     manifest,


### PR DESCRIPTION
## Summary
- Reconcile persisted `running` sync state after worker restarts so reads, cancel actions, and scheduled jobs stop treating orphaned runs as live work.
- Harden `sync.cancel` for company-scoped orphaned runs and add regressions for read, cancel, and scheduler paths.
- Update docs to describe the restart-recovery behavior.

## Testing
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Model Used
- GPT-5.3-codex, reasoning: medium, tool use enabled; context window size not exposed in this environment