### PR TITLE
[codex] Fix false worker-restart recovery after company-scoped sync completion

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -14186,28 +14186,25 @@ async function performSync(
       return materializeScopedSettings(next, config, targetCompanyId);
     }
 
-    const next = {
-      ...currentSettings,
-      syncState: {
-        status: 'success' as const,
-        message: `${options.target ? `GitHub sync for ${options.target.displayLabel} is complete. ` : 'Sync complete. '}Imported ${createdIssuesCount} issues, updated ${updatedStatusesCount} issue status${updatedStatusesCount === 1 ? '' : 'es'}, updated ${updatedLabelsCount} issue label set${updatedLabelsCount === 1 ? '' : 's'}, updated ${updatedDescriptionsCount} issue description${updatedDescriptionsCount === 1 ? '' : 's'}, and skipped ${skippedIssuesCount} already-synced issue${skippedIssuesCount === 1 ? '' : 's'}.`,
-        checkedAt: new Date().toISOString(),
-        syncedIssuesCount,
-        createdIssuesCount,
-        skippedIssuesCount,
-        erroredIssuesCount: 0,
-        lastRunTrigger: trigger
-      }
+    const nextSyncState = {
+      status: 'success' as const,
+      message: `${options.target ? `GitHub sync for ${options.target.displayLabel} is complete. ` : 'Sync complete. '}Imported ${createdIssuesCount} issues, updated ${updatedStatusesCount} issue status${updatedStatusesCount === 1 ? '' : 'es'}, updated ${updatedLabelsCount} issue label set${updatedLabelsCount === 1 ? '' : 's'}, updated ${updatedDescriptionsCount} issue description${updatedDescriptionsCount === 1 ? '' : 's'}, and skipped ${skippedIssuesCount} already-synced issue${skippedIssuesCount === 1 ? '' : 's'}.`,
+      checkedAt: new Date().toISOString(),
+      syncedIssuesCount,
+      createdIssuesCount,
+      skippedIssuesCount,
+      erroredIssuesCount: 0,
+      lastRunTrigger: trigger
     };
-    await ctx.state.set(SETTINGS_SCOPE, next);
-    await ctx.state.set(SYNC_STATE_SCOPE, next.syncState);
+    const next = await saveSettingsSyncState(ctx, currentSettings, nextSyncState, targetCompanyId);
     await ctx.state.set(IMPORT_REGISTRY_SCOPE, nextRegistry);
     return next;
   } catch (error) {
     if (error instanceof SyncCancellationError) {
-      const next = {
-        ...currentSettings,
-        syncState: createCancelledSyncState({
+      const next = await saveSettingsSyncState(
+        ctx,
+        currentSettings,
+        createCancelledSyncState({
           message: buildCancelledSyncMessage(options.target, currentProgress),
           trigger,
           syncedIssuesCount,
@@ -14215,10 +14212,9 @@ async function performSync(
           skippedIssuesCount,
           erroredIssuesCount: recoverableFailures.length,
           progress: currentProgress
-        })
-      };
-      await ctx.state.set(SETTINGS_SCOPE, next);
-      await ctx.state.set(SYNC_STATE_SCOPE, next.syncState);
+        }),
+        targetCompanyId
+      );
       await ctx.state.set(IMPORT_REGISTRY_SCOPE, nextRegistry);
       return next;
     }

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -15299,6 +15299,128 @@ test('repeat sync.runNow keeps a live company-scoped sync in running state', asy
   }
 });
 
+test('company-scoped sync.runNow persists the completed scoped sync state', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubToken: 'ghp_test_token'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+
+  await harness.performAction('settings.saveRegistration', {
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (input, init) => {
+    const rawUrl = getRequestUrl(input);
+    const url = new URL(rawUrl);
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues' && ['all', 'open'].includes(url.searchParams.get('state') ?? '')) {
+      return jsonResponse([
+        {
+          id: 1001,
+          number: 10,
+          title: 'Scoped sync success issue',
+          body: 'Body from GitHub',
+          html_url: 'https://github.com/paperclipai/example-repo/issues/10',
+          state: 'open'
+        }
+      ]);
+    }
+
+    if (url.pathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      const issueNumber = typeof variables.issueNumber === 'number' ? variables.issueNumber : undefined;
+
+      if (query.includes('query GitHubIssueParentRelationships')) {
+        return graphqlIssueParentRelationshipsResponse([
+          {
+            issueNumber: 10
+          }
+        ]);
+      }
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && issueNumber === 10) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: 10,
+              state: 'OPEN',
+              stateReason: null,
+              comments: {
+                totalCount: 0
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: []
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    const result = await harness.performAction('sync.runNow', {
+      companyId: 'company-1',
+      waitForCompletion: true
+    }) as {
+      syncState: {
+        status: string;
+      };
+    };
+
+    assert.equal(result.syncState.status, 'success');
+
+    const savedState = harness.getState({
+      scopeKind: 'instance',
+      stateKey: 'paperclip-github-plugin-settings'
+    }) as {
+      syncState: {
+        status: string;
+      };
+      syncStateByCompanyId?: Record<string, {
+        status?: string;
+      }>;
+    };
+
+    assert.equal(savedState.syncState.status, 'success');
+    assert.equal(savedState.syncStateByCompanyId?.['company-1']?.status, 'success');
+
+    const scopedSettings = await harness.getData<{
+      syncState: {
+        status: string;
+      };
+    }>('settings.registration', {
+      companyId: 'company-1'
+    });
+
+    assert.equal(scopedSettings.syncState.status, 'success');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('worker can cancel a long-running manual sync after it has started', async () => {
   const harness = createTestHarness({
     manifest,
@@ -15383,7 +15505,9 @@ test('worker can cancel a long-running manual sync after it has started', async 
   };
 
   try {
-    const runningResult = await harness.performAction('sync.runNow', {}) as {
+    const runningResult = await harness.performAction('sync.runNow', {
+      companyId: 'company-1'
+    }) as {
       syncState: { status: string; message?: string };
     };
     assert.equal(runningResult.syncState.status, 'running');
@@ -15429,6 +15553,13 @@ test('worker can cancel a long-running manual sync after it has started', async 
         syncedIssuesCount?: number;
         message?: string;
       };
+      syncStateByCompanyId?: Record<string, {
+        status?: string;
+        createdIssuesCount?: number;
+        skippedIssuesCount?: number;
+        syncedIssuesCount?: number;
+        message?: string;
+      }>;
     };
 
     assert.equal(cancelledState.syncState.status, 'cancelled');
@@ -15437,6 +15568,22 @@ test('worker can cancel a long-running manual sync after it has started', async 
     assert.equal(cancelledState.syncState.syncedIssuesCount, 1);
     assert.match(cancelledState.syncState.message ?? '', /was cancelled before it finished/i);
     assert.match(cancelledState.syncState.message ?? '', /completed 0 of 1 issues/i);
+    assert.equal(cancelledState.syncStateByCompanyId?.['company-1']?.status, 'cancelled');
+    assert.equal(cancelledState.syncStateByCompanyId?.['company-1']?.createdIssuesCount, 0);
+    assert.equal(cancelledState.syncStateByCompanyId?.['company-1']?.skippedIssuesCount, 0);
+    assert.equal(cancelledState.syncStateByCompanyId?.['company-1']?.syncedIssuesCount, 1);
+    assert.match(cancelledState.syncStateByCompanyId?.['company-1']?.message ?? '', /was cancelled before it finished/i);
+    assert.match(cancelledState.syncStateByCompanyId?.['company-1']?.message ?? '', /completed 0 of 1 issues/i);
+
+    const scopedSettings = await harness.getData<{
+      syncState: {
+        status: string;
+      };
+    }>('settings.registration', {
+      companyId: 'company-1'
+    });
+
+    assert.equal(scopedSettings.syncState.status, 'cancelled');
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
## Summary
- persist company-scoped sync completion and cancellation state through `saveSettingsSyncState(..., targetCompanyId)` so scoped runs do not leave stale per-company sync state behind
- add regression coverage for successful company-scoped completion and cancellation

## Root Cause
Company-scoped syncs updated the top-level `syncState`, but `syncStateByCompanyId[companyId]` could remain `running`. The settings page then interpreted that stale per-company state as an interrupted sync and showed a false worker-restart recovery message on the next poll.

## Validation
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- Manual browser verification in a fresh Paperclip instance from this worktree

## Model Used
- `gpt-5.4`
- Context window: `272000`
- Reasoning effort: `medium`
- Tools: terminal, git, GitHub CLI, browser automation
