### PR TITLE
Add GitHub icons and issue creator details to issue detail tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ The plugin adds a full in-host workflow instead of a one-off import script:
 - a dashboard widget that shows readiness, sync status, and last-run results
 - saved sync diagnostics that let operators inspect the latest per-issue failures, raw errors, and suggested next steps
 - a project sidebar item that opens a live project-scoped Pull Requests page for the mapped repository and can show the open PR count through a lightweight badge read
-- manual sync actions from global, project, and issue toolbar surfaces
-- a GitHub detail tab on synced Paperclip issues that stays hidden for Paperclip issues with no linked GitHub issue
+- manual sync actions from global, project, and issue surfaces
+- a GitHub detail tab on synced Paperclip issues that stays hidden for Paperclip issues with no linked GitHub issue and includes GitHub-marked action buttons plus the GitHub issue creator with avatar
 - GitHub link annotations on sync-generated status transition comments when the host supports comment annotations
 
 ## How it works

--- a/SPEC.md
+++ b/SPEC.md
@@ -116,6 +116,8 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 - The plugin MUST expose a settings page contribution.
 - The plugin SHOULD expose an issue detail contribution for GitHub metadata.
 - The issue detail contribution SHOULD hide itself when the current Paperclip issue has no linked GitHub issue instead of rendering an unlinked empty-state placeholder.
+- The issue detail contribution SHOULD include GitHub-marked issue-scoped action buttons alongside the GitHub deep links so operators can refresh that imported issue from the same panel.
+- The issue detail contribution SHOULD show the GitHub issue creator with a compact avatar treatment consistent with the pull request page.
 - The plugin SHOULD expose a project sidebar item that opens a project-scoped Pull Requests page for the mapped repository and can show the current open pull request count for mapped projects through a lightweight count read instead of the heavier summary-card metrics path.
 - The project pull request sidebar count, page, and metrics reads SHOULD tolerate saved mappings that are missing either the company id or the project id when the active Paperclip project context still identifies the intended mapping safely, and they SHOULD also fall back to the active project's bound GitHub repository when no saved sync mapping exists but the project workspace already defines that repository.
 - The project Pull Requests page SHOULD render live open pull request data for the mapped repository, including checks, an explicit up-to-date branch state, target branch badges, review summary, unresolved review-thread state, non-review comment counts, last-updated timestamps, Paperclip issue linkage, and quick actions.

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -12722,8 +12722,7 @@ function GitHubSyncToolbarButtonSurface(props: {
   });
   const buttonController = useGitHubSyncButtonController({
     ...props,
-    resolvedIssueId: resolvedIssue.issueId,
-    loadingIssueId: resolvedIssue.loading
+    resolvedIssueId: resolvedIssue.issueId
   });
 
   useEffect(() => {
@@ -12745,7 +12744,7 @@ function GitHubSyncToolbarButtonSurface(props: {
       hostWrapper.style.marginLeft = previousMarginLeft;
       hostWrapper.style.marginInlineStart = previousMarginInlineStart;
     };
-  });
+  }, [props.entityType]);
 
   if (!buttonController.visible) {
     return null;
@@ -12785,7 +12784,6 @@ function useGitHubSyncButtonController(props: {
   companyId?: string | null;
   projectId?: string | null;
   resolvedIssueId?: string | null;
-  loadingIssueId?: boolean;
   forceVisible?: boolean;
 }): {
   visible: boolean;
@@ -13101,7 +13099,6 @@ function GitHubSyncIssueDetailTabContent(props: {
     entityId: props.issueId,
     entityType: 'issue',
     resolvedIssueId: props.issueId,
-    loadingIssueId: props.loadingIssueId,
     forceVisible: true
   });
 

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -153,6 +153,17 @@ function LoadingSkeleton(props: {
   return <span aria-hidden="true" className={['ghsync__skeleton', props.className].filter(Boolean).join(' ')} style={props.style} />;
 }
 
+function GitHubButtonLabel(props: {
+  label: string;
+}): React.JSX.Element {
+  return (
+    <span className="ghsync__button-content">
+      <GitHubMarkIcon className="ghsync-prs-icon" />
+      <span>{props.label}</span>
+    </span>
+  );
+}
+
 interface RepositoryMapping {
   id: string;
   repositoryUrl: string;
@@ -260,6 +271,7 @@ interface GitHubIssueDetailsData {
   githubIssueNumber: number;
   githubIssueUrl: string;
   repositoryUrl: string;
+  creator?: PreviewPullRequestPerson;
   githubIssueState?: 'open' | 'closed';
   githubIssueStateReason?: 'completed' | 'not_planned' | 'duplicate';
   commentsCount?: number;
@@ -4275,6 +4287,42 @@ const EXTENSION_SURFACE_STYLES = `
     justify-content: space-between;
     gap: 12px;
     align-items: start;
+  }
+
+  .ghsync-issue-detail__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+    justify-content: flex-end;
+  }
+
+  .ghsync-issue-detail__headline {
+    display: grid;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  .ghsync-issue-detail__creator-row {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .ghsync-issue-detail__creator-label {
+    color: var(--ghsync-muted);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    line-height: 1;
+    text-transform: uppercase;
+  }
+
+  .ghsync-issue-detail__creator .ghsync-prs-avatar {
+    width: 20px;
+    height: 20px;
+    font-size: 10px;
   }
 
   .ghsync-extension-heading h3,
@@ -12662,10 +12710,9 @@ function GitHubSyncToolbarButtonSurface(props: {
   companyId?: string | null;
   projectId?: string | null;
 }): React.JSX.Element | null {
-  const toast = usePluginToast();
-  const runSyncNow = usePluginAction('sync.runNow');
-  const cancelSync = usePluginAction('sync.cancel');
-  const pluginIdFromLocation = getPluginIdFromLocation();
+  const themeMode = useResolvedThemeMode();
+  const theme = themeMode === 'light' ? LIGHT_PALETTE : DARK_PALETTE;
+  const themeVars = buildThemeVars(theme, themeMode);
   const surfaceRef = useRef<HTMLDivElement | null>(null);
   const resolvedIssue = useResolvedIssueId({
     companyId: props.companyId,
@@ -12673,9 +12720,89 @@ function GitHubSyncToolbarButtonSurface(props: {
     entityId: props.entityId,
     entityType: props.entityType
   });
+  const buttonController = useGitHubSyncButtonController({
+    ...props,
+    resolvedIssueId: resolvedIssue.issueId,
+    loadingIssueId: resolvedIssue.loading
+  });
+
+  useEffect(() => {
+    if (!props.entityType) {
+      return;
+    }
+
+    const hostWrapper = surfaceRef.current?.parentElement;
+    if (!hostWrapper) {
+      return;
+    }
+
+    const previousMarginLeft = hostWrapper.style.marginLeft;
+    const previousMarginInlineStart = hostWrapper.style.marginInlineStart;
+    hostWrapper.style.marginLeft = 'auto';
+    hostWrapper.style.marginInlineStart = 'auto';
+
+    return () => {
+      hostWrapper.style.marginLeft = previousMarginLeft;
+      hostWrapper.style.marginInlineStart = previousMarginInlineStart;
+    };
+  });
+
+  if (!buttonController.visible) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={surfaceRef}
+      className={`ghsync-toolbar-button${props.entityType ? ' ghsync-toolbar-button--entity' : ''}`}
+      style={themeVars}
+      title={buttonController.title}
+    >
+      <style>{EXTENSION_SURFACE_STYLES}</style>
+      <button
+        type="button"
+        data-slot="button"
+        data-variant="outline"
+        data-size="sm"
+        className={props.entityType ? HOST_ENTITY_BUTTON_CLASSNAME : HOST_GLOBAL_BUTTON_CLASSNAME}
+        disabled={buttonController.disabled}
+        onClick={buttonController.onClick}
+      >
+        <LoadingButtonContent
+          busy={buttonController.busy}
+          label={buttonController.label}
+          busyLabel={buttonController.busyLabel}
+          icon={<GitHubMarkIcon className="h-3.5 w-3.5" />}
+        />
+      </button>
+    </div>
+  );
+}
+
+function useGitHubSyncButtonController(props: {
+  entityType?: 'project' | 'issue';
+  entityId?: string | null;
+  companyId?: string | null;
+  projectId?: string | null;
+  resolvedIssueId?: string | null;
+  loadingIssueId?: boolean;
+  forceVisible?: boolean;
+}): {
+  visible: boolean;
+  title: string;
+  busy: boolean;
+  disabled: boolean;
+  label: string;
+  busyLabel: string;
+  onClick: () => Promise<void>;
+} {
+  const toast = usePluginToast();
+  const runSyncNow = usePluginAction('sync.runNow');
+  const cancelSync = usePluginAction('sync.cancel');
+  const pluginIdFromLocation = getPluginIdFromLocation();
   const effectiveEntityId =
     props.entityType === 'issue'
-      ? resolvedIssue.issueId ?? '__ghsync_unresolved_issue__'
+      ? props.resolvedIssueId ?? '__ghsync_unresolved_issue__'
       : props.entityId;
   const toolbarState = usePluginData<SyncToolbarStateData>('sync.toolbarState', {
     ...(props.companyId ? { companyId: props.companyId } : {}),
@@ -12689,10 +12816,7 @@ function GitHubSyncToolbarButtonSurface(props: {
   const [runningSync, setRunningSync] = useState(false);
   const [cancellingSync, setCancellingSync] = useState(false);
   const [syncStateOverride, setSyncStateOverride] = useState<SyncRunState | null>(null);
-  const themeMode = useResolvedThemeMode();
   const boardAccessRequirement = usePaperclipBoardAccessRequirement();
-  const theme = themeMode === 'light' ? LIGHT_PALETTE : DARK_PALETTE;
-  const themeVars = buildThemeVars(theme, themeMode);
   const state = toolbarState.data ?? {
     kind: props.entityType ?? 'global',
     visible: !props.entityType,
@@ -12744,9 +12868,7 @@ function GitHubSyncToolbarButtonSurface(props: {
     disabled: toolbarButtonDisabled,
     label: toolbarButtonLabel,
     busyLabel: toolbarButtonBusyLabel,
-    syncPersistedRunning,
-    syncStartPending,
-    cancellationRequested
+    syncPersistedRunning
   } = toolbarButtonState;
   const armSyncCompletionToast = useSyncCompletionToast(effectiveSyncState, toast);
 
@@ -12833,31 +12955,6 @@ function GitHubSyncToolbarButtonSurface(props: {
     };
   }, [toolbarState.refresh, settingsRegistration.refresh, props.companyId, effectiveEntityId, props.entityType]);
 
-  useEffect(() => {
-    if (!props.entityType) {
-      return;
-    }
-
-    const hostWrapper = surfaceRef.current?.parentElement;
-    if (!hostWrapper) {
-      return;
-    }
-
-    const previousMarginLeft = hostWrapper.style.marginLeft;
-    const previousMarginInlineStart = hostWrapper.style.marginInlineStart;
-    hostWrapper.style.marginLeft = 'auto';
-    hostWrapper.style.marginInlineStart = 'auto';
-
-    return () => {
-      hostWrapper.style.marginLeft = previousMarginLeft;
-      hostWrapper.style.marginInlineStart = previousMarginInlineStart;
-    };
-  });
-
-  if (!state.visible) {
-    return null;
-  }
-
   async function handleRunSync(): Promise<void> {
     try {
       if (!effectiveCanRun) {
@@ -12870,7 +12967,7 @@ function GitHubSyncToolbarButtonSurface(props: {
         waitForCompletion: false,
         ...(props.companyId ? { companyId: props.companyId } : {}),
         ...(props.entityType === 'project' && props.entityId ? { projectId: props.entityId } : {}),
-        ...(props.entityType === 'issue' && resolvedIssue.issueId ? { issueId: resolvedIssue.issueId } : {}),
+        ...(props.entityType === 'issue' && props.resolvedIssueId ? { issueId: props.resolvedIssueId } : {}),
         ...(trustedPaperclipApiBaseUrl ? { paperclipApiBaseUrl: trustedPaperclipApiBaseUrl } : {})
       }) as {
         syncState?: SyncRunState;
@@ -12949,32 +13046,15 @@ function GitHubSyncToolbarButtonSurface(props: {
     }
   }
 
-  return (
-    <div
-      ref={surfaceRef}
-      className={`ghsync-toolbar-button${props.entityType ? ' ghsync-toolbar-button--entity' : ''}`}
-      style={themeVars}
-      title={toolbarState.error?.message ?? effectiveMessage}
-    >
-      <style>{EXTENSION_SURFACE_STYLES}</style>
-      <button
-        type="button"
-        data-slot="button"
-        data-variant="outline"
-        data-size="sm"
-        className={props.entityType ? HOST_ENTITY_BUTTON_CLASSNAME : HOST_GLOBAL_BUTTON_CLASSNAME}
-        disabled={toolbarButtonDisabled}
-        onClick={syncPersistedRunning && allowToolbarCancellation ? handleCancelSync : handleRunSync}
-      >
-        <LoadingButtonContent
-          busy={toolbarButtonBusy}
-          label={toolbarButtonLabel}
-          busyLabel={toolbarButtonBusyLabel}
-          icon={<GitHubMarkIcon className="h-3.5 w-3.5" />}
-        />
-      </button>
-    </div>
-  );
+  return {
+    visible: props.forceVisible ? true : state.visible,
+    title: toolbarState.error?.message ?? effectiveMessage ?? 'GitHub sync',
+    busy: toolbarButtonBusy,
+    disabled: toolbarButtonDisabled,
+    label: toolbarButtonLabel,
+    busyLabel: toolbarButtonBusyLabel,
+    onClick: syncPersistedRunning && allowToolbarCancellation ? handleCancelSync : handleRunSync
+  };
 }
 
 export function GitHubSyncGlobalToolbarButton(): React.JSX.Element | null {
@@ -13016,6 +13096,14 @@ function GitHubSyncIssueDetailTabContent(props: {
     detailsError: Boolean(details.error),
     issueDetails
   });
+  const issueSyncButton = useGitHubSyncButtonController({
+    companyId: props.companyId,
+    entityId: props.issueId,
+    entityType: 'issue',
+    resolvedIssueId: props.issueId,
+    loadingIssueId: props.loadingIssueId,
+    forceVisible: true
+  });
 
   useEffect(() => {
     if (!props.companyId || !props.issueId) {
@@ -13043,22 +13131,61 @@ function GitHubSyncIssueDetailTabContent(props: {
       {detailTabState === 'ready' && issueDetails ? (
         <>
           <div className="ghsync-extension-heading">
-            <div>
+            <div className="ghsync-issue-detail__headline">
               <h4>Issue #{issueDetails.githubIssueNumber}</h4>
               <p>{formatGitHubRepositoryLabel(issueDetails.repositoryUrl)}</p>
+              {issueDetails.creator ? (
+                <div className="ghsync-issue-detail__creator-row">
+                  <span className="ghsync-issue-detail__creator-label">Creator</span>
+                  <a
+                    href={issueDetails.creator.profileUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="ghsync-prs-table__person ghsync-issue-detail__creator"
+                  >
+                    <PreviewAvatar person={issueDetails.creator} />
+                    <span className="ghsync-prs-table__person-copy">
+                      <span className="ghsync-prs-table__person-name">{issueDetails.creator.name}</span>
+                      <span className="ghsync-prs-table__person-handle">{issueDetails.creator.handle}</span>
+                    </span>
+                  </a>
+                </div>
+              ) : null}
             </div>
-            <a
-              href={issueDetails.githubIssueUrl}
-              target="_blank"
-              rel="noreferrer"
-              className={getPluginActionClassName({
-                variant: 'secondary',
-                size: 'sm',
-                extraClassName: 'ghsync-extension-link'
-              })}
-            >
-              Open on GitHub
-            </a>
+            <div className="ghsync-issue-detail__actions">
+              {issueSyncButton.visible ? (
+                <button
+                  type="button"
+                  className={getPluginActionClassName({
+                    variant: 'secondary',
+                    size: 'sm',
+                    extraClassName: 'ghsync-extension-link'
+                  })}
+                  disabled={issueSyncButton.disabled}
+                  onClick={issueSyncButton.onClick}
+                  title={issueSyncButton.title}
+                >
+                  <LoadingButtonContent
+                    busy={issueSyncButton.busy}
+                    label={issueSyncButton.label}
+                    busyLabel={issueSyncButton.busyLabel}
+                    icon={<GitHubMarkIcon className="ghsync-prs-icon" />}
+                  />
+                </button>
+              ) : null}
+              <a
+                href={issueDetails.githubIssueUrl}
+                target="_blank"
+                rel="noreferrer"
+                className={getPluginActionClassName({
+                  variant: 'secondary',
+                  size: 'sm',
+                  extraClassName: 'ghsync-extension-link'
+                })}
+              >
+                <GitHubButtonLabel label="Open on GitHub" />
+              </a>
+            </div>
           </div>
 
           <div className="ghsync-extension-grid">
@@ -13096,7 +13223,7 @@ function GitHubSyncIssueDetailTabContent(props: {
                       extraClassName: 'ghsync-extension-link'
                     })}
                   >
-                    PR #{pullRequestNumber}
+                    <GitHubButtonLabel label={`PR #${pullRequestNumber}`} />
                   </a>
                 ))}
               </div>
@@ -13122,7 +13249,7 @@ function GitHubSyncIssueDetailTabContent(props: {
 
           {issueDetails.source !== 'entity' ? (
             <div className="ghsync-extension-note">
-              GitHub Sync recovered this link from older sync metadata. Run sync once to refresh GitHub state, labels, and linked PRs in this panel.
+              GitHub Sync recovered this link from older sync metadata. Run sync once to refresh the creator, GitHub state, labels, and linked PRs in this panel.
             </div>
           ) : null}
         </>
@@ -13214,7 +13341,7 @@ export function GitHubSyncCommentAnnotation(): React.JSX.Element | null {
               extraClassName: 'ghsync-extension-link'
             })}
           >
-            {link.label}
+            <GitHubButtonLabel label={link.label} />
           </a>
         ))}
       </div>

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -274,6 +274,9 @@ interface GitHubIssueLinkEntityData {
   githubIssueId: number;
   githubIssueNumber: number;
   githubIssueUrl: string;
+  creatorLogin?: string;
+  creatorUrl?: string;
+  creatorAvatarUrl?: string;
   githubIssueState: 'open' | 'closed';
   githubIssueStateReason?: GitHubIssueStateReason;
   commentsCount: number;
@@ -506,6 +509,8 @@ interface GitHubIssueRecord {
   body: string | null;
   htmlUrl: string;
   authorLogin?: string;
+  authorUrl?: string;
+  authorAvatarUrl?: string;
   authorAssociation?: string;
   labels: GitHubIssueLabelRecord[];
   state: 'open' | 'closed';
@@ -549,6 +554,8 @@ interface GitHubApiIssueRecord {
   html_url: string;
   user?: {
     login?: string | null;
+    html_url?: string | null;
+    avatar_url?: string | null;
   } | null;
   state: string;
   comments?: number;
@@ -3598,6 +3605,15 @@ async function buildIssueGitHubDetails(
       githubIssueNumber: entityMatch.data.githubIssueNumber,
       githubIssueUrl: entityMatch.data.githubIssueUrl,
       repositoryUrl: entityMatch.data.repositoryUrl,
+      ...(entityMatch.data.creatorLogin
+        ? {
+            creator: buildProjectPullRequestPerson({
+              login: entityMatch.data.creatorLogin,
+              url: entityMatch.data.creatorUrl,
+              avatarUrl: entityMatch.data.creatorAvatarUrl
+            })
+          }
+        : {}),
       githubIssueState: entityMatch.data.githubIssueState,
       githubIssueStateReason: entityMatch.data.githubIssueStateReason,
       commentsCount: entityMatch.data.commentsCount,
@@ -5333,13 +5349,23 @@ function normalizeGitHubIssueLabels(value: GitHubApiIssueRecord['labels']): GitH
 }
 
 function normalizeGitHubIssueRecord(issue: GitHubApiIssueRecord): GitHubIssueRecord {
+  const authorLogin = normalizeGitHubUsername(issue.user?.login);
+  const authorUrl =
+    typeof issue.user?.html_url === 'string' && issue.user.html_url.trim() ? issue.user.html_url.trim() : undefined;
+  const authorAvatarUrl =
+    typeof issue.user?.avatar_url === 'string' && issue.user.avatar_url.trim()
+      ? issue.user.avatar_url.trim()
+      : undefined;
+
   return {
     id: issue.id,
     number: issue.number,
     title: stripNullBytes(issue.title),
     body: typeof issue.body === 'string' ? stripNullBytes(issue.body) : null,
     htmlUrl: issue.html_url,
-    ...(normalizeGitHubUsername(issue.user?.login) ? { authorLogin: normalizeGitHubUsername(issue.user?.login) } : {}),
+    ...(authorLogin ? { authorLogin } : {}),
+    ...(authorUrl ? { authorUrl } : {}),
+    ...(authorAvatarUrl ? { authorAvatarUrl } : {}),
     ...(normalizeGitHubLowercaseString(issue.author_association)
       ? { authorAssociation: normalizeGitHubLowercaseString(issue.author_association) }
       : {}),
@@ -7213,6 +7239,14 @@ function normalizeGitHubIssueLinkEntityData(value: unknown): GitHubIssueLinkEnti
     typeof record.githubIssueNumber === 'number' && record.githubIssueNumber > 0 ? Math.floor(record.githubIssueNumber) : undefined;
   const githubIssueUrl =
     typeof record.githubIssueUrl === 'string' ? normalizeGitHubIssueHtmlUrl(record.githubIssueUrl) : undefined;
+  const creatorLogin =
+    typeof record.creatorLogin === 'string' ? normalizeGitHubUsername(record.creatorLogin) : undefined;
+  const creatorUrl =
+    typeof record.creatorUrl === 'string' && record.creatorUrl.trim() ? record.creatorUrl.trim() : undefined;
+  const creatorAvatarUrl =
+    typeof record.creatorAvatarUrl === 'string' && record.creatorAvatarUrl.trim()
+      ? record.creatorAvatarUrl.trim()
+      : undefined;
   const githubIssueState = record.githubIssueState === 'closed' ? 'closed' : record.githubIssueState === 'open' ? 'open' : undefined;
   const commentsCount =
     typeof record.commentsCount === 'number' && record.commentsCount >= 0 ? Math.floor(record.commentsCount) : 0;
@@ -7235,6 +7269,9 @@ function normalizeGitHubIssueLinkEntityData(value: unknown): GitHubIssueLinkEnti
     githubIssueId,
     githubIssueNumber,
     githubIssueUrl,
+    ...(creatorLogin ? { creatorLogin } : {}),
+    ...(creatorUrl ? { creatorUrl } : {}),
+    ...(creatorAvatarUrl ? { creatorAvatarUrl } : {}),
     githubIssueState,
     ...(githubIssueStateReason ? { githubIssueStateReason } : {}),
     commentsCount,
@@ -7533,6 +7570,9 @@ function buildGitHubIssueLinkRecord(
       githubIssueId: githubIssue.id,
       githubIssueNumber: githubIssue.number,
       githubIssueUrl,
+      ...(githubIssue.authorLogin ? { creatorLogin: githubIssue.authorLogin } : {}),
+      ...(githubIssue.authorUrl ? { creatorUrl: githubIssue.authorUrl } : {}),
+      ...(githubIssue.authorAvatarUrl ? { creatorAvatarUrl: githubIssue.authorAvatarUrl } : {}),
       githubIssueState: githubIssue.state,
       ...(githubIssue.stateReason ? { githubIssueStateReason: githubIssue.stateReason } : {}),
       commentsCount: githubIssue.commentsCount,

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -6120,6 +6120,9 @@ test('worker issue.githubDetails returns issue-scoped GitHub detail payloads', a
       githubIssueId: 20202,
       githubIssueNumber: 202,
       githubIssueUrl: 'https://github.com/paperclipai/example-repo/issues/202',
+      creatorLogin: 'octocat',
+      creatorUrl: 'https://github.com/octocat',
+      creatorAvatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4',
       githubIssueState: 'closed',
       githubIssueStateReason: 'completed',
       commentsCount: 4,
@@ -6141,6 +6144,12 @@ test('worker issue.githubDetails returns issue-scoped GitHub detail payloads', a
     paperclipIssueId: string;
     githubIssueNumber: number;
     linkedPullRequestNumbers: number[];
+    creator?: {
+      name: string;
+      handle: string;
+      profileUrl: string;
+      avatarUrl?: string;
+    };
   } | null>('issue.githubDetails', {
     companyId: 'company-1',
     issueId: secondIssue.id
@@ -6152,6 +6161,12 @@ test('worker issue.githubDetails returns issue-scoped GitHub detail payloads', a
   assert.equal(secondDetails?.paperclipIssueId, secondIssue.id);
   assert.equal(secondDetails?.githubIssueNumber, 202);
   assert.deepEqual(secondDetails?.linkedPullRequestNumbers, [2020, 2021]);
+  assert.deepEqual(secondDetails?.creator, {
+    name: 'octocat',
+    handle: '@octocat',
+    profileUrl: 'https://github.com/octocat',
+    avatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4'
+  });
 });
 
 test('worker filters issue-scoped GitHub link records even when entities.list ignores scopeId', async () => {


### PR DESCRIPTION
### Summary
- Issue detail actions and GitHub refs now render the GitHub mark for visual consistency.
- The issue detail tab now shows the GitHub creator with a compact avatar, and the worker persists creator metadata for synced issues.

### Testing
- Added unit coverage for issue creator metadata and issue-detail payloads.
- Local test suite passed.

### Model Used
- GPT-5
- Context window size: not provided in the thread context
- Capability details: tool-assisted code editing, repository inspection, and local verification