### PR TITLE
Fix task detail avatar sizing

### DIFF
--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -2836,6 +2836,7 @@ const PROJECT_PULL_REQUESTS_PAGE_STYLES = `
   font-weight: 700;
   letter-spacing: 0.02em;
   flex: 0 0 auto;
+  overflow: hidden;
 }
 
 .ghsync-prs-avatar img,
@@ -7439,34 +7440,39 @@ function PreviewAvatar(props: {
 }): React.JSX.Element {
   const backgroundColor = getPreviewAvatarColor(props.person.handle);
   const className = props.stacked ? 'ghsync-prs-avatar-stack__item' : 'ghsync-prs-avatar';
-  const avatarSizePx = props.size === 'sm' ? 20 : 28;
-  const fontSizePx = props.size === 'sm' ? 10 : 11;
   const labels = resolvePreviewPersonLabels(props.person);
   const initialsSource = props.person.name.trim() || props.person.handle.replace(/^@/, '').trim();
   const title = labels.secondary ? `${labels.primary} (${labels.secondary})` : labels.primary;
   const avatarStyle: React.CSSProperties = {
-    backgroundColor,
-    width: avatarSizePx,
-    height: avatarSizePx,
-    fontSize: fontSizePx,
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: 999,
-    color: 'white',
-    fontWeight: 700,
-    letterSpacing: '0.02em',
-    lineHeight: 1,
-    flex: '0 0 auto',
-    overflow: 'hidden'
+    backgroundColor
   };
-  const imageStyle: React.CSSProperties = {
-    width: '100%',
-    height: '100%',
-    borderRadius: 'inherit',
-    objectFit: 'cover',
-    display: 'block'
-  };
+  const imageStyle =
+    props.size === 'sm'
+      ? {
+          width: '100%',
+          height: '100%',
+          borderRadius: 'inherit',
+          objectFit: 'cover' as const,
+          display: 'block'
+        }
+      : undefined;
+
+  if (props.size === 'sm') {
+    Object.assign(avatarStyle, {
+      width: 20,
+      height: 20,
+      fontSize: 10,
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: 999,
+      color: 'white',
+      fontWeight: 700,
+      letterSpacing: '0.02em',
+      flex: '0 0 auto',
+      overflow: 'hidden'
+    } satisfies React.CSSProperties);
+  }
 
   return (
     <span

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -7444,21 +7444,39 @@ function PreviewAvatar(props: {
   const labels = resolvePreviewPersonLabels(props.person);
   const initialsSource = props.person.name.trim() || props.person.handle.replace(/^@/, '').trim();
   const title = labels.secondary ? `${labels.primary} (${labels.secondary})` : labels.primary;
+  const avatarStyle: React.CSSProperties = {
+    backgroundColor,
+    width: avatarSizePx,
+    height: avatarSizePx,
+    fontSize: fontSizePx,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 999,
+    color: 'white',
+    fontWeight: 700,
+    letterSpacing: '0.02em',
+    lineHeight: 1,
+    flex: '0 0 auto',
+    overflow: 'hidden'
+  };
+  const imageStyle: React.CSSProperties = {
+    width: '100%',
+    height: '100%',
+    borderRadius: 'inherit',
+    objectFit: 'cover',
+    display: 'block'
+  };
 
   return (
     <span
       className={className}
-      style={{
-        backgroundColor,
-        width: avatarSizePx,
-        height: avatarSizePx,
-        fontSize: fontSizePx
-      }}
+      style={avatarStyle}
       title={title}
       aria-hidden="true"
     >
       {props.person.avatarUrl ? (
-        <img src={props.person.avatarUrl} alt="" loading="lazy" />
+        <img src={props.person.avatarUrl} alt="" loading="lazy" style={imageStyle} />
       ) : (
         getInitials(initialsSource)
       )}


### PR DESCRIPTION
## Summary
- Make the shared avatar component apply its own inline sizing, clipping, and image-fit rules so the issue task-detail creator avatar stays compact and circular.
- Keep the avatar treatment consistent with the PR list.

## Testing
- Unit tests passed.
- Verified in a disposable Paperclip host with Playwright: the synced issue task detail renders a compact creator avatar, and the PR list avatar remains unchanged.

## Model Used
- GPT-5 Codex; exact model ID and context window were not exposed in this thread; medium reasoning; tool use enabled.