### PR TITLE
[codex] Add configurable GitHub sync handoff assignees

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ With this plugin, you can:
 
 The plugin adds a full in-host workflow instead of a one-off import script:
 
-- a hosted settings page for GitHub auth, repository mappings, company defaults, and sync controls
+- a hosted settings page for GitHub auth, repository mappings, company defaults, execution-policy handoff fallbacks, and sync controls
 - authenticated-only setup controls for Paperclip board access and company-scoped agent token propagation
 - a dashboard widget that shows readiness, sync status, and last-run results
 - saved sync diagnostics that let operators inspect the latest per-issue failures, raw errors, and suggested next steps
@@ -45,7 +45,7 @@ The plugin adds a full in-host workflow instead of a one-off import script:
 
 During sync, the plugin imports one top-level Paperclip issue per GitHub issue, updates already imported issues instead of recreating them, maps GitHub labels into Paperclip labels, and keeps GitHub-specific metadata in dedicated Paperclip surfaces rather than stuffing everything into the issue description.
 
-When the host exposes plugin issue creation, imported GitHub issues are created through the Paperclip plugin SDK path so they are not attributed to the connected board user. The worker still uses direct local Paperclip REST calls for label sync and for description or status repair paths when those routes are available.
+When the host exposes plugin issue creation, imported GitHub issues are created through the Paperclip plugin SDK path so they are not attributed to the connected board user. The worker still uses direct local Paperclip REST calls for label sync and for description, assignee, or status repair paths when those routes are available.
 
 Long-running syncs continue in the background, so quick actions do not have to wait for the whole import to finish. Once a sync has started, the settings page, dashboard widget, and toolbar actions can request cancellation; the worker stops cooperatively after the current repository or issue step finishes. If the worker restarts mid-run, GitHub Sync now recovers that orphaned `running` state on the next read or control action instead of leaving the UI stuck in `running` or silently restarting the old run.
 
@@ -111,7 +111,7 @@ npx paperclipai plugin install --local "$PWD"
 4. If the deployment is authenticated, choose which agents in the current company should receive the saved GitHub token as `GITHUB_TOKEN`.
 5. Add one or more repository mappings for the current company.
 6. For each mapping, either choose an existing GitHub-linked Paperclip project or enter the project name that should receive synced issues.
-7. Optionally configure company-wide defaults for imported issues, including the default assignee, the default Paperclip status, and ignored GitHub usernames. Bot aliases such as `renovate[bot]` are matched when you save `renovate`.
+7. Optionally configure company-wide defaults for imported issues, including the default assignee, the default Paperclip status, executor/reviewer/approver handoff assignees for sync-driven transitions, and ignored GitHub usernames. When Paperclip board access is connected, each assignee dropdown also offers `Me` for the connected board user. `Automatic routing` means GitHub Sync follows the issue's Paperclip execution policy first and only uses the saved fallback when Paperclip does not expose the next reviewer, approver, or return assignee yet. Bot aliases such as `renovate[bot]` are matched when you save `renovate`.
 8. Choose the automatic sync interval in minutes.
 9. Save the settings and run the first manual sync.
 10. Repeat inside other companies if they need their own mappings, defaults, board access, or agent token propagation.
@@ -136,7 +136,7 @@ When the local Paperclip API is available, the plugin also syncs labels by name,
 | Open issue with no linked pull request, created by a repository maintainer | `todo` on first import |
 | Open issue with no linked pull request | Configured default status, which defaults to `backlog` |
 | Open issue with a linked pull request and unfinished CI | `in_progress` |
-| Open issue with failing CI or unresolved review threads | `todo` |
+| Open issue with failing CI or unresolved review threads | `todo`, or `in_progress` when GitHub Sync can hand the work back to an executor |
 | Open issue with green CI and all review threads resolved | `in_review` |
 | Closed issue completed as finished work | `done` |
 | Closed issue closed as `not_planned` or `duplicate` | `cancelled` |
@@ -144,10 +144,14 @@ When the local Paperclip API is available, the plugin also syncs labels by name,
 Additional behavior:
 
 - Open issues with no linked pull request that are created by a verified repository maintainer/admin bypass the default imported status and start in `todo`.
+- When Paperclip board access is connected for a company, the advanced assignee dropdowns list both company agents and `Me` for the connected board user.
 - Newly imported issues that finish sync in `todo` and are assigned to an agent enqueue an assignee wakeup so the agent can pick them up promptly.
+- When sync moves work into `in_review`, GitHub Sync first follows the Paperclip issue execution policy's current reviewer or approver when that stage is visible on the issue. If Paperclip does not expose that participant yet, the plugin falls back to the configured reviewer or approver handoff assignee.
+- When sync moves work back into active execution, GitHub Sync first follows the Paperclip issue execution policy `returnAssignee` when it is available. Otherwise it falls back to the configured executor handoff assignee and then to the default imported assignee.
+- Sync-driven handoffs to agent assignees best-effort enqueue an explicit wakeup so the next reviewer, approver, or executor can pick the issue up even when their agent is not running heartbeats.
 - Open imported issues that are already in `backlog` stay in `backlog` until someone changes them in Paperclip.
 - If an imported issue is `done` or `cancelled` and GitHub shows it open again with no linked pull request, sync moves it to `todo` so agents can pick it up again.
-- Trusted new GitHub comments from the original issue author or a verified maintainer/admin can move an open imported issue back to `todo`.
+- Trusted new GitHub comments from the original issue author or a verified maintainer/admin can move an open imported issue back into active work, using `in_progress` when GitHub Sync can route the issue to an executor and otherwise `todo`.
 - When the sync changes a Paperclip issue status, it adds a Paperclip comment explaining what changed and why.
 
 ## Security and authentication

--- a/SPEC.md
+++ b/SPEC.md
@@ -11,7 +11,7 @@ The plugin MUST provide a settings page inside Paperclip where an operator can c
 - Paperclip board access, which is optional on unauthenticated deployments and required when the Paperclip deployment reports `deploymentMode: "authenticated"`
 - on authenticated deployments, a company-scoped multi-select of agents that should receive `GITHUB_TOKEN` propagation from the saved GitHub token secret
 - one or more GitHub repository mappings
-- company-scoped advanced defaults for imported issues: default assignee, default Paperclip status, and ignored GitHub issue authors, where a saved username such as `renovate` also matches GitHub bot logins such as `renovate[bot]`
+- company-scoped advanced defaults for imported issues: default assignee, default Paperclip status, executor/reviewer/approver handoff assignees for sync-driven status transitions, and ignored GitHub issue authors, where a saved username such as `renovate` also matches GitHub bot logins such as `renovate[bot]`
 - the frequency for automatic scheduled sync runs for that company
 - a Paperclip project name per mapping where synchronized issues should be created, including existing Paperclip projects that are already bound to a GitHub repository workspace
 
@@ -24,6 +24,8 @@ The settings page MUST allow saving mappings and triggering a manual sync.
 - The settings page MUST only render the Paperclip board-access connect controls and the agent token-propagation selector when the current Paperclip deployment reports `deploymentMode: "authenticated"`.
 - When the settings page successfully validates a saved GitHub token, it SHOULD persist the validated GitHub login as non-secret display metadata so later visits can continue showing `Authenticated as ...` instead of falling back to a generic ready state.
 - When the settings page successfully connects Paperclip board access for a company, it SHOULD persist a company-scoped non-secret identity label so later visits can continue showing `Connected as ...` instead of falling back to a generic connected state.
+- When the active company has a saved Paperclip board-access user id, every advanced-settings assignee dropdown MUST include a `Me` option that maps to that connected board user alongside the available agents.
+- Execution-policy fallback dropdown copy SHOULD use operator-facing language such as `Automatic routing` and explain that Paperclip execution-policy participants and `returnAssignee` win before company-level reviewer, approver, or executor fallbacks.
 - The plugin SHOULD also expose manual sync entry points from Paperclip toolbar surfaces when the SDK supports them.
 - When a manual sync will outlive a quick action response, the worker MUST persist a `running` sync state immediately and complete the sync asynchronously.
 - Once a sync is running, the settings page, dashboard widget, and toolbar sync entry points MUST provide a way to request cancellation, and the worker MUST stop cooperatively after the current repository or issue step finishes.
@@ -63,7 +65,7 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 - The sync flow MUST ignore GitHub issues whose author username matches a configured ignored username for that mapping company.
 - The sync flow MUST create one top-level Paperclip issue per imported GitHub issue when the target mapping has a resolved Paperclip project identifier.
 - When the Paperclip runtime exposes plugin issue creation, the sync flow SHOULD prefer `ctx.issues.create(...)` for imported issue creation and reserve direct Paperclip REST issue calls for repair or update paths so imported issues are not attributed to the connected board user.
-- When the mapping company has a configured default assignee, the sync flow MUST assign newly created imported Paperclip issues to that Paperclip agent.
+- When the mapping company has a configured default assignee, the sync flow MUST assign newly created imported Paperclip issues to that Paperclip assignee, whether the saved principal is a Paperclip agent or the connected board user.
 - Imported Paperclip issues MUST keep the original GitHub issue title without adding a `[GitHub]` prefix.
 - Imported issue descriptions SHOULD contain the normalized GitHub body when present and MUST normalize the GitHub raw HTML constructs that Paperclip cannot render in multiline descriptions.
 - Imported issue descriptions MUST also retain a machine-readable hidden marker for the source GitHub issue URL so agents and repair paths can still recognize imported issues when plugin-owned entity or registry state is missing.
@@ -86,16 +88,20 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 - An open GitHub issue without a linked PR that was created by a repository maintainer/admin MUST map to Paperclip `todo` when it is first imported.
 - An open GitHub issue without a linked PR MUST otherwise map to the configured default Paperclip status when it is first imported, and that default MUST be `backlog` when the company has not chosen another status.
 - When a newly imported GitHub issue finishes sync in Paperclip `todo` and is assigned to an agent, the worker MUST best-effort enqueue an assignment wakeup for that assignee using the imported Paperclip issue as wake context.
+- When sync moves a Paperclip issue into `in_review`, the worker MUST prefer the current reviewer or approver from the issue execution policy and execution state when Paperclip exposes that participant, and it MUST otherwise fall back to the configured reviewer or approver handoff assignee when one is saved.
+- When sync moves a Paperclip issue back into active execution (`todo` or `in_progress`), the worker MUST prefer the issue execution policy `returnAssignee` when Paperclip exposes it, and it MUST otherwise fall back to the configured executor handoff assignee when one is saved before falling back to the default imported assignee.
+- Configured default, reviewer, approver, and executor handoff assignees MAY target either a Paperclip agent or the connected board user for that company.
+- When sync moves an assigned issue into an actionable agent-owned state because of a sync-driven status transition, the worker MUST best-effort enqueue an explicit assignment wakeup for that assignee using the imported Paperclip issue as wake context.
 - If an imported Paperclip issue is currently `backlog` and its linked GitHub issue is still open, the sync flow MUST preserve `backlog`; only a manual Paperclip transition may move it out of `backlog`.
 - If a Paperclip issue that came from an open GitHub issue without a linked PR is later moved out of `backlog`, the sync flow SHOULD preserve that Paperclip status until another open-issue GitHub rule applies.
 - If that Paperclip issue is currently `done` or `cancelled` while the linked GitHub issue is open with no linked PR, the sync flow MUST move it to `todo` instead of `backlog` so it re-enters the active queue.
 - An open GitHub issue with a linked PR that still has unfinished CI jobs MUST map to Paperclip `in_progress`.
-- An open GitHub issue with a linked PR that has red CI jobs or unresolved review threads MUST map to Paperclip `todo`.
+- An open GitHub issue with a linked PR that has red CI jobs or unresolved review threads MUST map to Paperclip `todo`, unless the worker can route the issue back to an executor through execution-policy or configured handoff data, in which case it MUST map to `in_progress`.
 - An open GitHub issue with a linked PR that has green CI and all review threads resolved MUST map to Paperclip `in_review`.
 - A closed GitHub issue completed as finished work MUST map to Paperclip `done`.
 - A closed GitHub issue closed as not planned or duplicate MUST map to Paperclip `cancelled`.
-- A new GitHub issue comment on an open imported issue MUST move the corresponding Paperclip issue back to `todo` only when at least one newly added comment since the last sync was written by the original GitHub issue author or by a repository maintainer/admin that the worker can verify through the GitHub API.
-- A new GitHub issue comment from any other GitHub account MUST NOT move the corresponding Paperclip issue back to `todo`.
+- A new GitHub issue comment on an open imported issue MUST move the corresponding Paperclip issue back into active work only when at least one newly added comment since the last sync was written by the original GitHub issue author or by a repository maintainer/admin that the worker can verify through the GitHub API, and that active-work status MUST be `in_progress` when the worker can route the issue back to an executor through execution-policy or configured handoff data and `todo` otherwise.
+- A new GitHub issue comment from any other GitHub account MUST NOT move the corresponding Paperclip issue back into active work.
 - If that Paperclip issue is currently `backlog`, trusted GitHub comments MUST still leave it in `backlog`.
 - Whenever the sync flow changes a Paperclip issue status, it MUST add a Paperclip issue comment that explains the old status, the new status, and the GitHub condition that caused the transition.
 - When the SDK supports comment annotations, the plugin SHOULD render the referenced GitHub issue and PR links as a comment annotation attached to those sync-created comments.

--- a/src/ui/assignees.ts
+++ b/src/ui/assignees.ts
@@ -1,4 +1,5 @@
 export interface GitHubSyncAssigneeOption {
+  kind: 'agent' | 'user';
   id: string;
   name: string;
   title?: string;
@@ -17,6 +18,7 @@ export function normalizeCompanyAssigneeOptionsResponse(response: unknown): GitH
       }
 
       const record = entry as Record<string, unknown>;
+      const kind = record.kind === 'user' ? 'user' : 'agent';
       const id = typeof record.id === 'string' ? record.id.trim() : '';
       const name = typeof record.name === 'string' ? record.name.trim() : '';
       const status = typeof record.status === 'string' ? record.status.trim() : '';
@@ -27,6 +29,7 @@ export function normalizeCompanyAssigneeOptionsResponse(response: unknown): GitH
       }
 
       return {
+        kind,
         id,
         name,
         ...(title ? { title } : {}),
@@ -34,5 +37,11 @@ export function normalizeCompanyAssigneeOptionsResponse(response: unknown): GitH
       };
     })
     .filter((entry): entry is GitHubSyncAssigneeOption => entry !== null)
-    .sort((left, right) => left.name.localeCompare(right.name));
+    .sort((left, right) => {
+      if (left.kind !== right.kind) {
+        return left.kind === 'user' ? -1 : 1;
+      }
+
+      return left.name.localeCompare(right.name);
+    });
 }

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -232,6 +232,13 @@ type PaperclipIssueStatus = 'backlog' | 'todo' | 'in_progress' | 'in_review' | '
 
 interface GitHubSyncAdvancedSettings {
   defaultAssigneeAgentId?: string;
+  defaultAssigneeUserId?: string;
+  executorAssigneeAgentId?: string;
+  executorAssigneeUserId?: string;
+  reviewerAssigneeAgentId?: string;
+  reviewerAssigneeUserId?: string;
+  approverAssigneeAgentId?: string;
+  approverAssigneeUserId?: string;
   defaultStatus: PaperclipIssueStatus;
   ignoredIssueAuthorUsernames: string[];
   githubTokenPropagationAgentIds?: string[];
@@ -252,6 +259,11 @@ interface GitHubSyncSettings {
   paperclipBoardAccessConfigSyncRef?: string;
   totalSyncedIssuesCount?: number;
   updatedAt?: string;
+}
+
+interface GitHubSyncAssigneePrincipal {
+  kind: 'agent' | 'user';
+  id: string;
 }
 
 interface SyncToolbarStateData {
@@ -323,11 +335,15 @@ interface CliAuthChallengePollResponse {
 }
 
 interface CliAuthIdentityResponse {
+  id?: string | null;
+  userId?: string | null;
   login?: string | null;
   email?: string | null;
   displayName?: string | null;
   name?: string | null;
   user?: {
+    id?: string | null;
+    userId?: string | null;
     login?: string | null;
     email?: string | null;
     displayName?: string | null;
@@ -1786,9 +1802,15 @@ const PAGE_STYLES = `
 
 .ghsync__picker {
   position: relative;
+  min-width: 0;
+}
+
+.ghsync__picker--full {
+  width: 100%;
 }
 
 .ghsync__picker-trigger {
+  box-sizing: border-box;
   width: fit-content;
   max-width: 100%;
   min-height: 0;
@@ -1819,6 +1841,10 @@ const PAGE_STYLES = `
 
 .ghsync__picker-trigger:hover {
   background: var(--ghsync-surfaceRaised);
+}
+
+.ghsync__picker--full .ghsync__picker-trigger {
+  width: 100%;
 }
 
 .ghsync__picker-trigger--assignee {
@@ -1871,6 +1897,7 @@ const PAGE_STYLES = `
 }
 
 .ghsync__picker-panel {
+  box-sizing: border-box;
   position: absolute;
   top: calc(100% + 8px);
   left: 0;
@@ -1883,7 +1910,8 @@ const PAGE_STYLES = `
 }
 
 .ghsync__picker-panel--assignee {
-  width: min(20rem, calc(100vw - 2rem));
+  width: min(20rem, 100%);
+  max-width: calc(100vw - 2rem);
 }
 
 .ghsync__picker-panel--status {
@@ -4513,19 +4541,60 @@ function normalizeAgentIds(value: unknown): string[] {
   )].sort((left, right) => left.localeCompare(right));
 }
 
+function normalizeAdvancedSettingsAssigneeOverride(
+  record: Record<string, unknown>,
+  keys: {
+    agentId: keyof GitHubSyncAdvancedSettings;
+    userId: keyof GitHubSyncAdvancedSettings;
+  }
+): Partial<GitHubSyncAdvancedSettings> {
+  const rawUserId = record[keys.userId as string];
+  const userId = typeof rawUserId === 'string' && rawUserId.trim()
+    ? rawUserId.trim()
+    : undefined;
+  if (userId) {
+    return {
+      [keys.userId]: userId
+    } as Partial<GitHubSyncAdvancedSettings>;
+  }
+
+  const rawAgentId = record[keys.agentId as string];
+  const agentId = typeof rawAgentId === 'string' && rawAgentId.trim()
+    ? rawAgentId.trim()
+    : undefined;
+  if (agentId) {
+    return {
+      [keys.agentId]: agentId
+    } as Partial<GitHubSyncAdvancedSettings>;
+  }
+
+  return {};
+}
+
 function normalizeAdvancedSettings(value: unknown): GitHubSyncAdvancedSettings {
   if (!value || typeof value !== 'object') {
     return DEFAULT_ADVANCED_SETTINGS;
   }
 
   const record = value as Record<string, unknown>;
-  const defaultAssigneeAgentId =
-    typeof record.defaultAssigneeAgentId === 'string' && record.defaultAssigneeAgentId.trim()
-      ? record.defaultAssigneeAgentId.trim()
-      : undefined;
 
   return {
-    ...(defaultAssigneeAgentId ? { defaultAssigneeAgentId } : {}),
+    ...normalizeAdvancedSettingsAssigneeOverride(record, {
+      agentId: 'defaultAssigneeAgentId',
+      userId: 'defaultAssigneeUserId'
+    }),
+    ...normalizeAdvancedSettingsAssigneeOverride(record, {
+      agentId: 'executorAssigneeAgentId',
+      userId: 'executorAssigneeUserId'
+    }),
+    ...normalizeAdvancedSettingsAssigneeOverride(record, {
+      agentId: 'reviewerAssigneeAgentId',
+      userId: 'reviewerAssigneeUserId'
+    }),
+    ...normalizeAdvancedSettingsAssigneeOverride(record, {
+      agentId: 'approverAssigneeAgentId',
+      userId: 'approverAssigneeUserId'
+    }),
     defaultStatus: normalizePaperclipIssueStatus(record.defaultStatus),
     ignoredIssueAuthorUsernames:
       'ignoredIssueAuthorUsernames' in record
@@ -4554,6 +4623,13 @@ function getComparableAdvancedSettings(value: GitHubSyncAdvancedSettings | null 
 
   return {
     ...(settings.defaultAssigneeAgentId ? { defaultAssigneeAgentId: settings.defaultAssigneeAgentId } : {}),
+    ...(settings.defaultAssigneeUserId ? { defaultAssigneeUserId: settings.defaultAssigneeUserId } : {}),
+    ...(settings.executorAssigneeAgentId ? { executorAssigneeAgentId: settings.executorAssigneeAgentId } : {}),
+    ...(settings.executorAssigneeUserId ? { executorAssigneeUserId: settings.executorAssigneeUserId } : {}),
+    ...(settings.reviewerAssigneeAgentId ? { reviewerAssigneeAgentId: settings.reviewerAssigneeAgentId } : {}),
+    ...(settings.reviewerAssigneeUserId ? { reviewerAssigneeUserId: settings.reviewerAssigneeUserId } : {}),
+    ...(settings.approverAssigneeAgentId ? { approverAssigneeAgentId: settings.approverAssigneeAgentId } : {}),
+    ...(settings.approverAssigneeUserId ? { approverAssigneeUserId: settings.approverAssigneeUserId } : {}),
     defaultStatus: settings.defaultStatus,
     ignoredIssueAuthorUsernames: [...settings.ignoredIssueAuthorUsernames].sort((left, right) => left.localeCompare(right)),
     ...(settings.githubTokenPropagationAgentIds?.length
@@ -4568,39 +4644,156 @@ function formatAssigneeOptionLabel(option: GitHubSyncAssigneeOption): string {
     : option.name;
 }
 
-function getAvailableAssigneeOptions(
-  options: GitHubSyncAssigneeOption[] | null | undefined,
-  selectedAgentId?: string
-): GitHubSyncAssigneeOption[] {
-  const normalizedOptions = [...(options ?? [])];
+function getAssigneeOptionKey(option: Pick<GitHubSyncAssigneeOption, 'kind' | 'id'>): string {
+  return `${option.kind}:${option.id}`;
+}
 
-  if (selectedAgentId && !normalizedOptions.some((option) => option.id === selectedAgentId)) {
-    normalizedOptions.push({
-      id: selectedAgentId,
-      name: 'Unavailable agent'
-    });
+function getAssigneeOptionValue(option: Pick<GitHubSyncAssigneeOption, 'kind' | 'id'>): string {
+  return getAssigneeOptionKey(option);
+}
+
+function parseAssigneeOptionValue(value: string | null | undefined): GitHubSyncAssigneePrincipal | null {
+  const trimmedValue = typeof value === 'string' ? value.trim() : '';
+  if (!trimmedValue) {
+    return null;
   }
 
-  return normalizedOptions;
+  if (trimmedValue.startsWith('agent:')) {
+    const id = trimmedValue.slice('agent:'.length).trim();
+    return id ? { kind: 'agent', id } : null;
+  }
+
+  if (trimmedValue.startsWith('user:')) {
+    const id = trimmedValue.slice('user:'.length).trim();
+    return id ? { kind: 'user', id } : null;
+  }
+
+  return { kind: 'agent', id: trimmedValue };
+}
+
+function getAdvancedSettingsAssigneePrincipal(
+  advancedSettings: GitHubSyncAdvancedSettings,
+  role: 'default' | 'executor' | 'reviewer' | 'approver'
+): GitHubSyncAssigneePrincipal | null {
+  switch (role) {
+    case 'default':
+      return advancedSettings.defaultAssigneeUserId
+        ? { kind: 'user', id: advancedSettings.defaultAssigneeUserId }
+        : advancedSettings.defaultAssigneeAgentId
+          ? { kind: 'agent', id: advancedSettings.defaultAssigneeAgentId }
+          : null;
+    case 'executor':
+      return advancedSettings.executorAssigneeUserId
+        ? { kind: 'user', id: advancedSettings.executorAssigneeUserId }
+        : advancedSettings.executorAssigneeAgentId
+          ? { kind: 'agent', id: advancedSettings.executorAssigneeAgentId }
+          : null;
+    case 'reviewer':
+      return advancedSettings.reviewerAssigneeUserId
+        ? { kind: 'user', id: advancedSettings.reviewerAssigneeUserId }
+        : advancedSettings.reviewerAssigneeAgentId
+          ? { kind: 'agent', id: advancedSettings.reviewerAssigneeAgentId }
+          : null;
+    case 'approver':
+      return advancedSettings.approverAssigneeUserId
+        ? { kind: 'user', id: advancedSettings.approverAssigneeUserId }
+        : advancedSettings.approverAssigneeAgentId
+          ? { kind: 'agent', id: advancedSettings.approverAssigneeAgentId }
+          : null;
+  }
+}
+
+function setAdvancedSettingsAssigneePrincipal(
+  advancedSettings: GitHubSyncAdvancedSettings,
+  role: 'default' | 'executor' | 'reviewer' | 'approver',
+  principal: GitHubSyncAssigneePrincipal | null
+): GitHubSyncAdvancedSettings {
+  switch (role) {
+    case 'default':
+      return {
+        ...advancedSettings,
+        defaultAssigneeAgentId: principal?.kind === 'agent' ? principal.id : undefined,
+        defaultAssigneeUserId: principal?.kind === 'user' ? principal.id : undefined
+      };
+    case 'executor':
+      return {
+        ...advancedSettings,
+        executorAssigneeAgentId: principal?.kind === 'agent' ? principal.id : undefined,
+        executorAssigneeUserId: principal?.kind === 'user' ? principal.id : undefined
+      };
+    case 'reviewer':
+      return {
+        ...advancedSettings,
+        reviewerAssigneeAgentId: principal?.kind === 'agent' ? principal.id : undefined,
+        reviewerAssigneeUserId: principal?.kind === 'user' ? principal.id : undefined
+      };
+    case 'approver':
+      return {
+        ...advancedSettings,
+        approverAssigneeAgentId: principal?.kind === 'agent' ? principal.id : undefined,
+        approverAssigneeUserId: principal?.kind === 'user' ? principal.id : undefined
+      };
+  }
+}
+
+function getSelectedAssigneeOptionValue(
+  advancedSettings: GitHubSyncAdvancedSettings,
+  role: 'default' | 'executor' | 'reviewer' | 'approver'
+): string {
+  const principal = getAdvancedSettingsAssigneePrincipal(advancedSettings, role);
+  return principal ? getAssigneeOptionValue(principal) : '';
+}
+
+function compareAssigneeOptions(left: GitHubSyncAssigneeOption, right: GitHubSyncAssigneeOption): number {
+  if (left.kind !== right.kind) {
+    return left.kind === 'user' ? -1 : 1;
+  }
+
+  return left.name.localeCompare(right.name);
+}
+
+function getAvailableAssigneeOptions(
+  options: GitHubSyncAssigneeOption[] | null | undefined,
+  selectedAssignees?: GitHubSyncAssigneePrincipal | Array<GitHubSyncAssigneePrincipal | null | undefined> | null
+): GitHubSyncAssigneeOption[] {
+  const normalizedOptions = [...(options ?? [])];
+  const selectedPrincipals = Array.isArray(selectedAssignees)
+    ? selectedAssignees.filter((selectedAssignee): selectedAssignee is GitHubSyncAssigneePrincipal => Boolean(selectedAssignee))
+    : selectedAssignees
+      ? [selectedAssignees]
+      : [];
+
+  for (const selectedPrincipal of selectedPrincipals) {
+    if (!normalizedOptions.some((option) => getAssigneeOptionKey(option) === getAssigneeOptionKey(selectedPrincipal))) {
+      normalizedOptions.push({
+        kind: selectedPrincipal.kind,
+        id: selectedPrincipal.id,
+        name: selectedPrincipal.kind === 'user' ? 'Unavailable user' : 'Unavailable agent'
+      });
+    }
+  }
+
+  return normalizedOptions.sort(compareAssigneeOptions);
 }
 
 function getAvailablePropagationAgentOptions(
   options: GitHubSyncAssigneeOption[] | null | undefined,
   selectedAgentIds: string[] | null | undefined
 ): GitHubSyncAssigneeOption[] {
-  const normalizedOptions = [...(options ?? [])];
+  const normalizedOptions = [...(options ?? []).filter((option) => option.kind === 'agent')];
   const selectedIds = normalizeAgentIds(selectedAgentIds);
 
   for (const selectedAgentId of selectedIds) {
     if (!normalizedOptions.some((option) => option.id === selectedAgentId)) {
       normalizedOptions.push({
+        kind: 'agent',
         id: selectedAgentId,
         name: 'Unavailable agent'
       });
     }
   }
 
-  return normalizedOptions.sort((left, right) => left.name.localeCompare(right.name));
+  return normalizedOptions.sort(compareAssigneeOptions);
 }
 
 function formatAdvancedSettingsSummary(
@@ -4608,15 +4801,25 @@ function formatAdvancedSettingsSummary(
   availableAssignees: GitHubSyncAssigneeOption[],
   options?: { includePropagation?: boolean }
 ): string {
-  const assigneeLabel = advancedSettings.defaultAssigneeAgentId
-    ? formatAssigneeOptionLabel(
-      availableAssignees.find((option) => option.id === advancedSettings.defaultAssigneeAgentId)
-      ?? {
-        id: advancedSettings.defaultAssigneeAgentId,
-        name: 'Unavailable agent'
-      }
-    )
-    : 'Unassigned';
+  const resolveAssigneeLabel = (
+    principal: GitHubSyncAssigneePrincipal | null,
+    fallbackLabel = 'None'
+  ): string => {
+    return principal
+      ? formatAssigneeOptionLabel(
+        availableAssignees.find((option) => getAssigneeOptionKey(option) === getAssigneeOptionKey(principal))
+        ?? {
+          kind: principal.kind,
+          id: principal.id,
+          name: principal.kind === 'user' ? 'Unavailable user' : 'Unavailable agent'
+        }
+      )
+      : fallbackLabel;
+  };
+  const assigneeLabel = resolveAssigneeLabel(getAdvancedSettingsAssigneePrincipal(advancedSettings, 'default'), 'Unassigned');
+  const executorLabel = resolveAssigneeLabel(getAdvancedSettingsAssigneePrincipal(advancedSettings, 'executor'), 'Automatic routing');
+  const reviewerLabel = resolveAssigneeLabel(getAdvancedSettingsAssigneePrincipal(advancedSettings, 'reviewer'), 'Automatic routing');
+  const approverLabel = resolveAssigneeLabel(getAdvancedSettingsAssigneePrincipal(advancedSettings, 'approver'), 'Automatic routing');
   const statusLabel =
     PAPERCLIP_STATUS_OPTIONS.find((option) => option.value === advancedSettings.defaultStatus)?.label
     ?? 'Backlog';
@@ -4624,16 +4827,17 @@ function formatAdvancedSettingsSummary(
     advancedSettings.ignoredIssueAuthorUsernames.length > 0
       ? advancedSettings.ignoredIssueAuthorUsernames.join(', ')
       : 'none';
+  const handoffLabel = `Back to work: ${executorLabel} · Review: ${reviewerLabel} · Approval: ${approverLabel}`;
   if (options?.includePropagation) {
     const propagatedAgentsLabel =
       advancedSettings.githubTokenPropagationAgentIds?.length
         ? `${advancedSettings.githubTokenPropagationAgentIds.length} selected`
         : 'none';
 
-    return `Assignee: ${assigneeLabel} · Status: ${statusLabel} · Ignore: ${ignoredAuthorsLabel} · Propagate: ${propagatedAgentsLabel}`;
+    return `Import: ${assigneeLabel} · ${handoffLabel} · Status: ${statusLabel} · Ignore: ${ignoredAuthorsLabel} · Propagate: ${propagatedAgentsLabel}`;
   }
 
-  return `Assignee: ${assigneeLabel} · Status: ${statusLabel} · Ignore: ${ignoredAuthorsLabel}`;
+  return `Import: ${assigneeLabel} · ${handoffLabel} · Status: ${statusLabel} · Ignore: ${ignoredAuthorsLabel}`;
 }
 
 export function resolveSavedTokenUiState(params: {
@@ -4686,7 +4890,7 @@ interface SettingsSelectOption {
   value: string;
   label: string;
   tone?: SelectTone;
-  icon?: 'agent';
+  icon?: 'agent' | 'user';
 }
 
 function PickerChevronIcon(): React.JSX.Element {
@@ -4731,6 +4935,34 @@ function AgentIcon(): React.JSX.Element {
       />
     </svg>
   );
+}
+
+function UserIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <circle cx="8" cy="5.1" r="2.3" stroke="currentColor" strokeWidth="1.2" />
+      <path
+        d="M3.25 12.85C3.78 10.83 5.62 9.4 7.82 9.4H8.18C10.38 9.4 12.22 10.83 12.75 12.85"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function SettingsSelectIcon(props: {
+  icon?: SettingsSelectOption['icon'];
+}): React.JSX.Element | null {
+  if (props.icon === 'agent') {
+    return <AgentIcon />;
+  }
+
+  if (props.icon === 'user') {
+    return <UserIcon />;
+  }
+
+  return null;
 }
 
 function SettingsAssigneePicker(props: {
@@ -4793,7 +5025,7 @@ function SettingsAssigneePicker(props: {
   }, [disabled, open]);
 
   return (
-    <div className="ghsync__picker" ref={rootRef}>
+    <div className="ghsync__picker ghsync__picker--full" ref={rootRef}>
       <button
         id={id}
         type="button"
@@ -4810,9 +5042,9 @@ function SettingsAssigneePicker(props: {
         }}
       >
         <span className="ghsync__picker-trigger-main">
-          {selectedOption?.icon === 'agent' ? (
+          {selectedOption?.icon ? (
             <span className="ghsync__picker-agent-icon" aria-hidden="true">
-              <AgentIcon />
+              <SettingsSelectIcon icon={selectedOption.icon} />
             </span>
           ) : null}
           <span className="ghsync__picker-trigger-label">{selectedOption?.label ?? 'No assignee'}</span>
@@ -4861,9 +5093,9 @@ function SettingsAssigneePicker(props: {
                     }}
                   >
                     <span className="ghsync__picker-trigger-main">
-                      {option.icon === 'agent' ? (
+                      {option.icon ? (
                         <span className="ghsync__picker-agent-icon" aria-hidden="true">
-                          <AgentIcon />
+                          <SettingsSelectIcon icon={option.icon} />
                         </span>
                       ) : null}
                       <span className="ghsync__picker-option-label">{option.label}</span>
@@ -4946,7 +5178,7 @@ function SettingsAgentMultiPicker(props: {
   }, [disabled, open]);
 
   return (
-    <div className="ghsync__picker" ref={rootRef}>
+    <div className="ghsync__picker ghsync__picker--full" ref={rootRef}>
       <button
         id={id}
         type="button"
@@ -5014,9 +5246,9 @@ function SettingsAgentMultiPicker(props: {
                     }}
                   >
                     <span className="ghsync__picker-trigger-main">
-                      {option.icon === 'agent' ? (
+                      {option.icon ? (
                         <span className="ghsync__picker-agent-icon" aria-hidden="true">
-                          <AgentIcon />
+                          <SettingsSelectIcon icon={option.icon} />
                         </span>
                       ) : null}
                       <span className="ghsync__picker-option-label">{option.label}</span>
@@ -6469,6 +6701,23 @@ function getCliAuthIdentityLabel(identity: CliAuthIdentityResponse): string | nu
   return null;
 }
 
+function getCliAuthIdentityUserId(identity: CliAuthIdentityResponse): string | null {
+  const candidates = [
+    identity.user?.id,
+    identity.user?.userId,
+    identity.id,
+    identity.userId
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+
+  return null;
+}
+
 function waitForDuration(durationMs: number): Promise<void> {
   return new Promise((resolve) => {
     globalThis.setTimeout(resolve, durationMs);
@@ -6532,14 +6781,20 @@ async function waitForBoardAccessApproval(challenge: CliAuthChallengeResponse): 
   }
 }
 
-async function fetchBoardAccessIdentity(boardApiToken: string): Promise<string | null> {
+async function fetchBoardAccessIdentity(boardApiToken: string): Promise<{
+  label: string | null;
+  userId: string | null;
+}> {
   const identity = await fetchJson<CliAuthIdentityResponse>('/api/cli-auth/me', {
     headers: {
       authorization: `Bearer ${boardApiToken.trim()}`
     }
   });
 
-  return getCliAuthIdentityLabel(identity);
+  return {
+    label: getCliAuthIdentityLabel(identity),
+    userId: getCliAuthIdentityUserId(identity)
+  };
 }
 
 function getSyncStatus(syncState: SyncRunState, runningSync: boolean, syncUnlocked: boolean): { label: string; tone: Tone } {
@@ -10567,7 +10822,12 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
     (currentSettings?.availableAssignees?.length ? currentSettings.availableAssignees : null)
     ?? (form.availableAssignees?.length ? form.availableAssignees : null)
     ?? browserAvailableAssignees,
-    form.advancedSettings.defaultAssigneeAgentId
+    [
+      getAdvancedSettingsAssigneePrincipal(form.advancedSettings, 'default'),
+      getAdvancedSettingsAssigneePrincipal(form.advancedSettings, 'executor'),
+      getAdvancedSettingsAssigneePrincipal(form.advancedSettings, 'reviewer'),
+      getAdvancedSettingsAssigneePrincipal(form.advancedSettings, 'approver')
+    ]
   );
   const propagationAgents = getAvailablePropagationAgentOptions(
     (currentSettings?.availableAssignees?.length ? currentSettings.availableAssignees : null)
@@ -10705,9 +10965,17 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
   const assigneeSelectOptions: SettingsSelectOption[] = [
     { value: '', label: 'Unassigned' },
     ...availableAssignees.map((option) => ({
-      value: option.id,
+      value: getAssigneeOptionValue(option),
       label: formatAssigneeOptionLabel(option),
-      icon: 'agent' as const
+      icon: option.kind
+    }))
+  ];
+  const transitionAssigneeSelectOptions: SettingsSelectOption[] = [
+    { value: '', label: 'Automatic routing' },
+    ...availableAssignees.map((option) => ({
+      value: getAssigneeOptionValue(option),
+      label: formatAssigneeOptionLabel(option),
+      icon: option.kind
     }))
   ];
   const propagationAgentOptions: SettingsSelectOption[] = propagationAgents.map((option) => ({
@@ -11079,7 +11347,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
       }
 
       const boardApiToken = await waitForBoardAccessApproval(challenge);
-      const identity = await fetchBoardAccessIdentity(boardApiToken);
+      const boardIdentity = await fetchBoardAccessIdentity(boardApiToken);
       const secretName = `paperclip_board_api_${companyId.replace(/[^a-z0-9]+/gi, '_').toLowerCase()}`;
       const secret = await resolveOrCreateCompanySecret(companyId, secretName, boardApiToken);
 
@@ -11091,16 +11359,17 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
       await updateBoardAccess({
         companyId,
         paperclipBoardApiTokenRef: secret.id,
-        paperclipBoardAccessIdentity: identity ?? ''
+        paperclipBoardAccessIdentity: boardIdentity.label ?? '',
+        paperclipBoardAccessUserId: boardIdentity.userId ?? ''
       });
 
-      setBoardAccessIdentity(identity);
+      setBoardAccessIdentity(boardIdentity.label);
       setForm((current) => ({
         ...current,
         paperclipBoardAccessConfigured: true
       }));
       toast({
-        title: identity ? `Paperclip board access connected as ${identity}` : 'Paperclip board access connected',
+        title: boardIdentity.label ? `Paperclip board access connected as ${boardIdentity.label}` : 'Paperclip board access connected',
         body: 'Direct Paperclip REST calls can now authenticate in authenticated deployments.',
         tone: 'success'
       });
@@ -11797,16 +12066,17 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
                     <label htmlFor="advanced-default-assignee">Default assignee</label>
                     <SettingsAssigneePicker
                       id="advanced-default-assignee"
-                      value={form.advancedSettings.defaultAssigneeAgentId ?? ''}
+                      value={getSelectedAssigneeOptionValue(form.advancedSettings, 'default')}
                       options={assigneeSelectOptions}
                       disabled={settingsMutationsLocked}
                       onChange={(nextValue) => {
                         setForm((current) => ({
                           ...current,
-                          advancedSettings: {
-                            ...current.advancedSettings,
-                            ...(nextValue ? { defaultAssigneeAgentId: nextValue } : { defaultAssigneeAgentId: undefined })
-                          }
+                          advancedSettings: setAdvancedSettingsAssigneePrincipal(
+                            current.advancedSettings,
+                            'default',
+                            parseAssigneeOptionValue(nextValue)
+                          )
                         }));
                       }}
                     />
@@ -11830,7 +12100,86 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
                       }}
                     />
                   </div>
+
+                  <div className="ghsync__field">
+                    <label htmlFor="advanced-executor-assignee">Executor handoff</label>
+                    <SettingsAssigneePicker
+                      id="advanced-executor-assignee"
+                      value={getSelectedAssigneeOptionValue(form.advancedSettings, 'executor')}
+                      options={transitionAssigneeSelectOptions}
+                      disabled={settingsMutationsLocked}
+                      onChange={(nextValue) => {
+                        setForm((current) => ({
+                          ...current,
+                          advancedSettings: setAdvancedSettingsAssigneePrincipal(
+                            current.advancedSettings,
+                            'executor',
+                            parseAssigneeOptionValue(nextValue)
+                          )
+                        }));
+                      }}
+                    />
+                    <p className="ghsync__hint">
+                      The assignee that resumes work when GitHub Sync sends an issue back to active execution, such as failing CI,
+                      unresolved review threads, or a trusted new GitHub comment.
+                    </p>
+                  </div>
+
+                  <div className="ghsync__field">
+                    <label htmlFor="advanced-reviewer-assignee">Reviewer handoff</label>
+                    <SettingsAssigneePicker
+                      id="advanced-reviewer-assignee"
+                      value={getSelectedAssigneeOptionValue(form.advancedSettings, 'reviewer')}
+                      options={transitionAssigneeSelectOptions}
+                      disabled={settingsMutationsLocked}
+                      onChange={(nextValue) => {
+                        setForm((current) => ({
+                          ...current,
+                          advancedSettings: setAdvancedSettingsAssigneePrincipal(
+                            current.advancedSettings,
+                            'reviewer',
+                            parseAssigneeOptionValue(nextValue)
+                          )
+                        }));
+                      }}
+                    />
+                    <p className="ghsync__hint">
+                      The assignee that reviews work when GitHub Sync moves an issue into `in_review` because linked pull requests
+                      are green and all review threads are resolved.
+                    </p>
+                  </div>
+
+                  <div className="ghsync__field">
+                    <label htmlFor="advanced-approver-assignee">Approver handoff</label>
+                    <SettingsAssigneePicker
+                      id="advanced-approver-assignee"
+                      value={getSelectedAssigneeOptionValue(form.advancedSettings, 'approver')}
+                      options={transitionAssigneeSelectOptions}
+                      disabled={settingsMutationsLocked}
+                      onChange={(nextValue) => {
+                        setForm((current) => ({
+                          ...current,
+                          advancedSettings: setAdvancedSettingsAssigneePrincipal(
+                            current.advancedSettings,
+                            'approver',
+                            parseAssigneeOptionValue(nextValue)
+                          )
+                        }));
+                      }}
+                    />
+                    <p className="ghsync__hint">
+                      The assignee that approves work for the same `in_review` handoff when Paperclip&apos;s execution policy says the
+                      current stage is approval instead of review.
+                    </p>
+                  </div>
                 </div>
+
+                <p className="ghsync__hint">
+                  Choose &quot;Automatic routing&quot; to let GitHub Sync follow the issue&apos;s Paperclip execution policy and
+                  built-in fallback behavior. Pick a specific assignee only when you want a company-wide fallback for missing
+                  reviewer, approver, or return-assignee data. When Paperclip board access is connected for this company, each
+                  assignee picker also includes &quot;Me&quot; so the connected board user can take the handoff instead of an agent.
+                </p>
 
                 <div className="ghsync__field">
                   <label htmlFor="advanced-ignored-authors">Ignore issues from GitHub usernames</label>

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -77,6 +77,7 @@ const MISSING_BOARD_ACCESS_SYNC_MESSAGE =
 const MISSING_BOARD_ACCESS_SYNC_ACTION =
   'Open plugin settings for each mapped company that sync will touch, connect Paperclip board access, approve the flow, and then run sync again.';
 const IMPORTED_ISSUE_WAKE_REASON = 'GitHub Sync imported an assigned issue that is ready for work.';
+const STATUS_TRANSITION_WAKE_REASON = 'GitHub Sync moved an assigned issue into its next active state.';
 const ISSUE_LINK_ENTITY_TYPE = 'paperclip-github-plugin.issue-link';
 const PULL_REQUEST_LINK_ENTITY_TYPE = 'paperclip-github-plugin.pull-request-link';
 const COMMENT_ANNOTATION_ENTITY_TYPE = 'paperclip-github-plugin.comment-annotation';
@@ -101,6 +102,7 @@ type GitHubTokenRefs = Record<string, string>;
 type PaperclipBoardApiTokenRefs = Record<string, string>;
 type GitHubTokenLoginByCompanyId = Record<string, string>;
 type PaperclipBoardAccessIdentityByCompanyId = Record<string, string>;
+type PaperclipBoardAccessUserIdByCompanyId = Record<string, string>;
 type CompanyAdvancedSettingsByCompanyId = Record<string, GitHubSyncAdvancedSettings>;
 type ProjectPullRequestFilter = 'all' | 'mergeable' | 'reviewable' | 'failing';
 type ProjectPullRequestUpToDateStatus = 'up_to_date' | 'can_update' | 'conflicts' | 'unknown';
@@ -159,16 +161,65 @@ interface RepositoryMapping {
 
 interface GitHubSyncAdvancedSettings {
   defaultAssigneeAgentId?: string;
+  defaultAssigneeUserId?: string;
+  executorAssigneeAgentId?: string;
+  executorAssigneeUserId?: string;
+  reviewerAssigneeAgentId?: string;
+  reviewerAssigneeUserId?: string;
+  approverAssigneeAgentId?: string;
+  approverAssigneeUserId?: string;
   defaultStatus: PaperclipIssueStatus;
   ignoredIssueAuthorUsernames: string[];
   githubTokenPropagationAgentIds?: string[];
 }
 
 interface GitHubSyncAssigneeOption {
+  kind: 'agent' | 'user';
   id: string;
   name: string;
   title?: string;
   status?: PaperclipAgentStatus;
+}
+
+type PaperclipIssueExecutionStageType = 'review' | 'approval';
+
+type PaperclipIssueAssigneePrincipal =
+  | { kind: 'agent'; id: string }
+  | { kind: 'user'; id: string };
+
+interface PaperclipIssueExecutionStage {
+  id?: string;
+  type: PaperclipIssueExecutionStageType;
+  participants: PaperclipIssueAssigneePrincipal[];
+}
+
+interface PaperclipIssueExecutionPolicy {
+  stages: PaperclipIssueExecutionStage[];
+}
+
+interface PaperclipIssueExecutionState {
+  status?: string;
+  currentStageId: string | null;
+  currentStageIndex: number | null;
+  currentStageType: PaperclipIssueExecutionStageType | null;
+  currentParticipant: PaperclipIssueAssigneePrincipal | null;
+  returnAssignee: PaperclipIssueAssigneePrincipal | null;
+  completedStageIds: string[];
+  lastDecisionId?: string | null;
+  lastDecisionOutcome?: string | null;
+}
+
+interface PaperclipIssueSyncContext {
+  assignee: PaperclipIssueAssigneePrincipal | null;
+  executionPolicy: PaperclipIssueExecutionPolicy | null;
+  executionState: PaperclipIssueExecutionState | null;
+}
+
+type SyncTransitionAssigneeRole = 'executor' | 'reviewer' | 'approver';
+
+interface SyncTransitionAssigneeResolution {
+  principal: PaperclipIssueAssigneePrincipal;
+  role: SyncTransitionAssigneeRole;
 }
 
 interface PaperclipIssueDrawerAgentSummary {
@@ -361,6 +412,7 @@ interface GitHubSyncSettings {
   githubTokenLogin?: string;
   paperclipBoardApiTokenRefs?: PaperclipBoardApiTokenRefs;
   paperclipBoardAccessIdentityByCompanyId?: PaperclipBoardAccessIdentityByCompanyId;
+  paperclipBoardAccessUserIdByCompanyId?: PaperclipBoardAccessUserIdByCompanyId;
   companyAdvancedSettingsByCompanyId?: CompanyAdvancedSettingsByCompanyId;
   totalSyncedIssuesCount?: number;
   updatedAt?: string;
@@ -3802,6 +3854,7 @@ function getPublicSettings(
   | 'githubTokenRef'
   | 'paperclipBoardApiTokenRefs'
   | 'paperclipBoardAccessIdentityByCompanyId'
+  | 'paperclipBoardAccessUserIdByCompanyId'
   | 'companyAdvancedSettingsByCompanyId'
   | 'syncStateByCompanyId'
   | 'scheduleFrequencyMinutesByCompanyId'
@@ -3813,6 +3866,7 @@ function getPublicSettings(
     githubTokenRef: _githubTokenRef,
     paperclipBoardApiTokenRefs: _paperclipBoardApiTokenRefs,
     paperclipBoardAccessIdentityByCompanyId: _paperclipBoardAccessIdentityByCompanyId,
+    paperclipBoardAccessUserIdByCompanyId: _paperclipBoardAccessUserIdByCompanyId,
     companyAdvancedSettingsByCompanyId: _companyAdvancedSettingsByCompanyId,
     syncStateByCompanyId: _syncStateByCompanyId,
     scheduleFrequencyMinutesByCompanyId: _scheduleFrequencyMinutesByCompanyId,
@@ -3847,6 +3901,18 @@ function getPaperclipBoardAccessIdentity(
   return normalizeOptionalString(settings.paperclipBoardAccessIdentityByCompanyId?.[normalizedCompanyId]);
 }
 
+function getPaperclipBoardAccessUserId(
+  settings: Pick<GitHubSyncSettings, 'paperclipBoardAccessUserIdByCompanyId'>,
+  companyId?: string
+): string | undefined {
+  const normalizedCompanyId = normalizeCompanyId(companyId);
+  if (!normalizedCompanyId) {
+    return undefined;
+  }
+
+  return normalizeOptionalString(settings.paperclipBoardAccessUserIdByCompanyId?.[normalizedCompanyId]);
+}
+
 function getPublicSettingsForScope(
   settings: GitHubSyncSettings,
   companyId?: string
@@ -3857,6 +3923,7 @@ function getPublicSettingsForScope(
   | 'githubTokenRef'
   | 'paperclipBoardApiTokenRefs'
   | 'paperclipBoardAccessIdentityByCompanyId'
+  | 'paperclipBoardAccessUserIdByCompanyId'
   | 'companyAdvancedSettingsByCompanyId'
   | 'syncStateByCompanyId'
   | 'scheduleFrequencyMinutesByCompanyId'
@@ -3879,31 +3946,79 @@ function getPublicSettingsForScope(
   };
 }
 
+function compareGitHubSyncAssigneeOptions(
+  left: GitHubSyncAssigneeOption,
+  right: GitHubSyncAssigneeOption
+): number {
+  if (left.kind !== right.kind) {
+    return left.kind === 'user' ? -1 : 1;
+  }
+
+  return left.name.localeCompare(right.name);
+}
+
+function sortGitHubSyncAssigneeOptions(
+  options: GitHubSyncAssigneeOption[]
+): GitHubSyncAssigneeOption[] {
+  return [...options].sort(compareGitHubSyncAssigneeOptions);
+}
+
+function getConnectedBoardUserAssigneeOption(
+  settings: Pick<GitHubSyncSettings, 'paperclipBoardAccessIdentityByCompanyId' | 'paperclipBoardAccessUserIdByCompanyId'>,
+  companyId: string
+): GitHubSyncAssigneeOption | null {
+  const userId = getPaperclipBoardAccessUserId(settings, companyId);
+  if (!userId) {
+    return null;
+  }
+
+  const identityLabel = getPaperclipBoardAccessIdentity(settings, companyId);
+  return {
+    kind: 'user',
+    id: userId,
+    name: 'Me',
+    ...(identityLabel ? { title: identityLabel } : {})
+  };
+}
+
 async function listAvailableAssignees(
   ctx: PluginSetupContext,
-  companyId: string
+  companyId: string,
+  settings?: Pick<GitHubSyncSettings, 'paperclipBoardAccessIdentityByCompanyId' | 'paperclipBoardAccessUserIdByCompanyId'>
 ): Promise<GitHubSyncAssigneeOption[]> {
+  const connectedBoardUserOption = settings
+    ? getConnectedBoardUserAssigneeOption(settings, companyId)
+    : null;
+
   try {
     const agents = await ctx.agents.list({
       companyId,
       limit: 500
     });
 
-    return agents
+    const assignees: GitHubSyncAssigneeOption[] = agents
       .filter((agent) => agent.status !== 'terminated')
       .map((agent) => ({
+        kind: 'agent' as const,
         id: agent.id,
         name: agent.name,
         ...(agent.title?.trim() ? { title: agent.title.trim() } : {}),
         ...(agent.status ? { status: agent.status } : {})
-      }))
-      .sort((left, right) => left.name.localeCompare(right.name));
+      }));
+
+    if (connectedBoardUserOption) {
+      assignees.push(connectedBoardUserOption);
+    }
+
+    return sortGitHubSyncAssigneeOptions(
+      [...new Map(assignees.map((assignee) => [`${assignee.kind}:${assignee.id}`, assignee] as const)).values()]
+    );
   } catch (error) {
     ctx.logger.warn('Unable to list company agents for GitHub Sync advanced settings.', {
       companyId,
       error: getErrorMessage(error)
     });
-    return [];
+    return connectedBoardUserOption ? [connectedBoardUserOption] : [];
   }
 }
 
@@ -4578,6 +4693,30 @@ function normalizePaperclipBoardAccessIdentityByCompanyId(
   return Object.fromEntries(entries);
 }
 
+function normalizePaperclipBoardAccessUserIdByCompanyId(
+  value: unknown
+): PaperclipBoardAccessUserIdByCompanyId | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .map(([companyId, userId]) => {
+      const normalizedCompanyId = normalizeCompanyId(companyId);
+      const normalizedUserId = normalizeOptionalString(userId);
+      return normalizedCompanyId && normalizedUserId
+        ? [normalizedCompanyId, normalizedUserId] as const
+        : null;
+    })
+    .filter((entry): entry is readonly [string, string] => entry !== null);
+
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(entries);
+}
+
 function normalizeSyncCancellationRequest(value: unknown): SyncCancellationRequest | null {
   if (!value || typeof value !== 'object') {
     return null;
@@ -4706,13 +4845,36 @@ function normalizeAgentIds(value: unknown): string[] {
   return [...new Set(entries)].sort((left, right) => left.localeCompare(right));
 }
 
+function normalizeAdvancedSettingsAssigneeOverride(
+  record: Record<string, unknown>,
+  keys: {
+    agentId: keyof GitHubSyncAdvancedSettings;
+    userId: keyof GitHubSyncAdvancedSettings;
+  }
+): Partial<GitHubSyncAdvancedSettings> {
+  const userId = normalizeOptionalString(record[keys.userId as string]);
+  if (userId) {
+    return {
+      [keys.userId]: userId
+    } as Partial<GitHubSyncAdvancedSettings>;
+  }
+
+  const agentId = normalizeOptionalString(record[keys.agentId as string]);
+  if (agentId) {
+    return {
+      [keys.agentId]: agentId
+    } as Partial<GitHubSyncAdvancedSettings>;
+  }
+
+  return {};
+}
+
 function normalizeAdvancedSettings(value: unknown): GitHubSyncAdvancedSettings {
   if (!value || typeof value !== 'object') {
     return DEFAULT_ADVANCED_SETTINGS;
   }
 
   const record = value as Record<string, unknown>;
-  const defaultAssigneeAgentId = normalizeOptionalString(record.defaultAssigneeAgentId);
   const defaultStatus =
     'defaultStatus' in record
       ? coercePaperclipIssueStatus(record.defaultStatus)
@@ -4727,7 +4889,22 @@ function normalizeAdvancedSettings(value: unknown): GitHubSyncAdvancedSettings {
       : [];
 
   return {
-    ...(defaultAssigneeAgentId ? { defaultAssigneeAgentId } : {}),
+    ...normalizeAdvancedSettingsAssigneeOverride(record, {
+      agentId: 'defaultAssigneeAgentId',
+      userId: 'defaultAssigneeUserId'
+    }),
+    ...normalizeAdvancedSettingsAssigneeOverride(record, {
+      agentId: 'executorAssigneeAgentId',
+      userId: 'executorAssigneeUserId'
+    }),
+    ...normalizeAdvancedSettingsAssigneeOverride(record, {
+      agentId: 'reviewerAssigneeAgentId',
+      userId: 'reviewerAssigneeUserId'
+    }),
+    ...normalizeAdvancedSettingsAssigneeOverride(record, {
+      agentId: 'approverAssigneeAgentId',
+      userId: 'approverAssigneeUserId'
+    }),
     defaultStatus,
     ignoredIssueAuthorUsernames,
     ...(githubTokenPropagationAgentIds.length > 0 ? { githubTokenPropagationAgentIds } : {})
@@ -4962,6 +5139,9 @@ function normalizeSettings(value: unknown): GitHubSyncSettings {
   const paperclipBoardAccessIdentityByCompanyId = normalizePaperclipBoardAccessIdentityByCompanyId(
     record.paperclipBoardAccessIdentityByCompanyId
   );
+  const paperclipBoardAccessUserIdByCompanyId = normalizePaperclipBoardAccessUserIdByCompanyId(
+    record.paperclipBoardAccessUserIdByCompanyId
+  );
   const companyAdvancedSettingsByCompanyId = normalizeCompanyAdvancedSettingsByCompanyId(record.companyAdvancedSettingsByCompanyId);
 
   return {
@@ -4978,6 +5158,7 @@ function normalizeSettings(value: unknown): GitHubSyncSettings {
     ...(githubTokenLogin ? { githubTokenLogin } : {}),
     ...(paperclipBoardApiTokenRefs ? { paperclipBoardApiTokenRefs } : {}),
     ...(paperclipBoardAccessIdentityByCompanyId ? { paperclipBoardAccessIdentityByCompanyId } : {}),
+    ...(paperclipBoardAccessUserIdByCompanyId ? { paperclipBoardAccessUserIdByCompanyId } : {}),
     ...(companyAdvancedSettingsByCompanyId ? { companyAdvancedSettingsByCompanyId } : {}),
     updatedAt: typeof record.updatedAt === 'string' ? record.updatedAt : undefined
   };
@@ -5910,10 +6091,13 @@ function classifyGitHubPullRequestCiState(contexts: GitHubCiContextRecord[]): Gi
 }
 
 function resolvePaperclipStatusFromLinkedPullRequests(
-  linkedPullRequests: GitHubPullRequestStatusSnapshot[]
+  linkedPullRequests: GitHubPullRequestStatusSnapshot[],
+  options?: {
+    preferInProgress?: boolean;
+  }
 ): PaperclipIssueStatus {
   if (linkedPullRequests.some((pullRequest) => pullRequest.hasUnresolvedReviewThreads || pullRequest.ciState === 'red')) {
-    return 'todo';
+    return options?.preferInProgress ? 'in_progress' : 'todo';
   }
 
   if (
@@ -5953,6 +6137,534 @@ function normalizePaperclipIssueStatus(value: unknown): PaperclipIssueStatus | u
   return PAPERCLIP_ISSUE_STATUSES.includes(value as PaperclipIssueStatus)
     ? value as PaperclipIssueStatus
     : undefined;
+}
+
+function normalizePaperclipIssueExecutionStageType(value: unknown): PaperclipIssueExecutionStageType | undefined {
+  return value === 'review' || value === 'approval' ? value : undefined;
+}
+
+function normalizePaperclipIssueAssigneePrincipal(value: unknown): PaperclipIssueAssigneePrincipal | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const principalType = normalizeOptionalString(record.type);
+  const agentId = normalizeOptionalString(record.agentId);
+  const userId = normalizeOptionalString(record.userId);
+
+  if ((principalType === undefined || principalType === 'agent') && agentId) {
+    return {
+      kind: 'agent',
+      id: agentId
+    };
+  }
+
+  if ((principalType === undefined || principalType === 'user') && userId) {
+    return {
+      kind: 'user',
+      id: userId
+    };
+  }
+
+  return null;
+}
+
+function normalizePaperclipIssueExecutionStage(value: unknown): PaperclipIssueExecutionStage | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const type = normalizePaperclipIssueExecutionStageType(record.type);
+  const participants = Array.isArray(record.participants)
+    ? record.participants
+      .map((participant) => normalizePaperclipIssueAssigneePrincipal(participant))
+      .filter((participant): participant is PaperclipIssueAssigneePrincipal => participant !== null)
+    : [];
+
+  if (!type || participants.length === 0) {
+    return null;
+  }
+
+  const id = normalizeOptionalString(record.id);
+
+  return {
+    ...(id ? { id } : {}),
+    type,
+    participants
+  };
+}
+
+function normalizePaperclipIssueExecutionPolicy(value: unknown): PaperclipIssueExecutionPolicy | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const rawStages = (value as { stages?: unknown }).stages;
+  const stages = Array.isArray(rawStages)
+    ? rawStages
+      .map((stage) => normalizePaperclipIssueExecutionStage(stage))
+      .filter((stage): stage is PaperclipIssueExecutionStage => stage !== null)
+    : [];
+
+  return stages.length > 0
+    ? {
+        stages
+      }
+    : null;
+}
+
+function normalizePaperclipIssueExecutionState(value: unknown): PaperclipIssueExecutionState | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const status = normalizeOptionalString(record.status);
+  const currentStageId = normalizeOptionalString(record.currentStageId) ?? null;
+  const currentStageIndex =
+    typeof record.currentStageIndex === 'number' && Number.isInteger(record.currentStageIndex)
+      ? record.currentStageIndex
+      : null;
+  const currentStageType = normalizePaperclipIssueExecutionStageType(record.currentStageType) ?? null;
+  const currentParticipant = normalizePaperclipIssueAssigneePrincipal(record.currentParticipant);
+  const returnAssignee = normalizePaperclipIssueAssigneePrincipal(record.returnAssignee);
+  const lastDecisionId = normalizeOptionalString(record.lastDecisionId) ?? null;
+  const lastDecisionOutcome = normalizeOptionalString(record.lastDecisionOutcome) ?? null;
+  const completedStageIds = Array.isArray(record.completedStageIds)
+    ? record.completedStageIds
+      .map((stageId) => normalizeOptionalString(stageId))
+      .filter((stageId): stageId is string => Boolean(stageId))
+    : [];
+
+  if (
+    !status
+    && currentStageId === null
+    && currentStageIndex === null
+    && currentStageType === null
+    && currentParticipant === null
+    && returnAssignee === null
+    && completedStageIds.length === 0
+    && lastDecisionId === null
+    && lastDecisionOutcome === null
+  ) {
+    return null;
+  }
+
+  return {
+    ...(status ? { status } : {}),
+    currentStageId,
+    currentStageIndex,
+    currentStageType,
+    currentParticipant,
+    returnAssignee,
+    completedStageIds,
+    ...(lastDecisionId !== null ? { lastDecisionId } : {}),
+    ...(lastDecisionOutcome !== null ? { lastDecisionOutcome } : {})
+  };
+}
+
+function getPaperclipIssueAssigneePrincipal(issue: Issue): PaperclipIssueAssigneePrincipal | null {
+  const record = issue as unknown as Record<string, unknown>;
+  const assigneeAgentId = normalizeOptionalString(record.assigneeAgentId);
+
+  if (assigneeAgentId) {
+    return {
+      kind: 'agent',
+      id: assigneeAgentId
+    };
+  }
+
+  const assigneeUserId = normalizeOptionalString(record.assigneeUserId);
+  return assigneeUserId
+    ? {
+        kind: 'user',
+        id: assigneeUserId
+      }
+    : null;
+}
+
+function getPaperclipIssueSyncContext(issue: Issue): PaperclipIssueSyncContext {
+  const record = issue as unknown as Record<string, unknown>;
+
+  return {
+    assignee: getPaperclipIssueAssigneePrincipal(issue),
+    executionPolicy: normalizePaperclipIssueExecutionPolicy(record.executionPolicy),
+    executionState: normalizePaperclipIssueExecutionState(record.executionState)
+  };
+}
+
+function isSamePaperclipIssueAssigneePrincipal(
+  left: PaperclipIssueAssigneePrincipal | null | undefined,
+  right: PaperclipIssueAssigneePrincipal | null | undefined
+): boolean {
+  if (!left || !right) {
+    return !left && !right;
+  }
+
+  return left.kind === right.kind && left.id === right.id;
+}
+
+function serializePaperclipIssueAssigneePrincipal(
+  principal: PaperclipIssueAssigneePrincipal | null
+): Record<string, string | null> | null {
+  if (!principal) {
+    return null;
+  }
+
+  return principal.kind === 'agent'
+    ? {
+        type: 'agent',
+        agentId: principal.id,
+        userId: null
+      }
+    : {
+        type: 'user',
+        agentId: null,
+        userId: principal.id
+      };
+}
+
+function selectPaperclipIssueExecutionStageParticipant(
+  stage: PaperclipIssueExecutionStage,
+  options: {
+    preferred?: PaperclipIssueAssigneePrincipal | null;
+    exclude?: PaperclipIssueAssigneePrincipal | null;
+  } = {}
+): PaperclipIssueAssigneePrincipal | null {
+  const participants = stage.participants.filter((participant) => !isSamePaperclipIssueAssigneePrincipal(
+    participant,
+    options.exclude
+  ));
+  if (participants.length === 0) {
+    return null;
+  }
+
+  if (options.preferred) {
+    const preferredParticipant = participants.find((participant) => isSamePaperclipIssueAssigneePrincipal(
+      participant,
+      options.preferred
+    ));
+    if (preferredParticipant) {
+      return preferredParticipant;
+    }
+  }
+
+  return participants[0] ?? null;
+}
+
+function findPaperclipIssueExecutionStageMatch(
+  executionPolicy: PaperclipIssueExecutionPolicy | null,
+  executionState: PaperclipIssueExecutionState | null
+): { stage: PaperclipIssueExecutionStage; index: number } | null {
+  const stages = executionPolicy?.stages ?? [];
+  if (stages.length === 0) {
+    return null;
+  }
+
+  const currentStageId = executionState?.currentStageId;
+  if (currentStageId) {
+    const matchedStageIndex = stages.findIndex((stage) => stage.id === currentStageId);
+    if (matchedStageIndex >= 0) {
+      const matchedStage = stages[matchedStageIndex];
+      if (matchedStage) {
+        return {
+          stage: matchedStage,
+          index: matchedStageIndex
+        };
+      }
+    }
+  }
+
+  const currentStageIndex = executionState?.currentStageIndex;
+  if (
+    typeof currentStageIndex === 'number'
+    && currentStageIndex >= 0
+    && currentStageIndex < stages.length
+  ) {
+    const matchedStage = stages[currentStageIndex];
+    if (matchedStage) {
+      return {
+        stage: matchedStage,
+        index: currentStageIndex
+      };
+    }
+  }
+
+  const completedStageIds = new Set(executionState?.completedStageIds ?? []);
+  for (const [stageIndex, stage] of stages.entries()) {
+    if (!stage.id || !completedStageIds.has(stage.id)) {
+      return {
+        stage,
+        index: stageIndex
+      };
+    }
+  }
+
+  const firstStage = stages[0];
+  return firstStage
+    ? {
+        stage: firstStage,
+        index: 0
+      }
+    : null;
+}
+
+function findPaperclipIssueExecutionStage(
+  executionPolicy: PaperclipIssueExecutionPolicy | null,
+  executionState: PaperclipIssueExecutionState | null
+): PaperclipIssueExecutionStage | null {
+  return findPaperclipIssueExecutionStageMatch(executionPolicy, executionState)?.stage ?? null;
+}
+
+function getConfiguredAdvancedAssigneePrincipal(
+  advancedSettings: GitHubSyncAdvancedSettings,
+  role: 'default' | SyncTransitionAssigneeRole
+): PaperclipIssueAssigneePrincipal | null {
+  switch (role) {
+    case 'default':
+      return advancedSettings.defaultAssigneeUserId
+        ? { kind: 'user', id: advancedSettings.defaultAssigneeUserId }
+        : advancedSettings.defaultAssigneeAgentId
+          ? { kind: 'agent', id: advancedSettings.defaultAssigneeAgentId }
+          : null;
+    case 'executor':
+      return advancedSettings.executorAssigneeUserId
+        ? { kind: 'user', id: advancedSettings.executorAssigneeUserId }
+        : advancedSettings.executorAssigneeAgentId
+          ? { kind: 'agent', id: advancedSettings.executorAssigneeAgentId }
+          : null;
+    case 'reviewer':
+      return advancedSettings.reviewerAssigneeUserId
+        ? { kind: 'user', id: advancedSettings.reviewerAssigneeUserId }
+        : advancedSettings.reviewerAssigneeAgentId
+          ? { kind: 'agent', id: advancedSettings.reviewerAssigneeAgentId }
+          : null;
+    case 'approver':
+      return advancedSettings.approverAssigneeUserId
+        ? { kind: 'user', id: advancedSettings.approverAssigneeUserId }
+        : advancedSettings.approverAssigneeAgentId
+          ? { kind: 'agent', id: advancedSettings.approverAssigneeAgentId }
+          : null;
+  }
+}
+
+function resolvePaperclipIssueReviewAssignee(
+  syncContext: PaperclipIssueSyncContext,
+  advancedSettings: GitHubSyncAdvancedSettings
+): SyncTransitionAssigneeResolution | null {
+  const currentParticipant = syncContext.executionState?.currentParticipant;
+  const currentStageType = syncContext.executionState?.currentStageType;
+
+  if (currentParticipant && currentStageType) {
+    return {
+      principal: currentParticipant,
+      role: currentStageType === 'approval' ? 'approver' : 'reviewer'
+    };
+  }
+
+  const nextStageMatch = findPaperclipIssueExecutionStageMatch(syncContext.executionPolicy, syncContext.executionState);
+  const nextStage = nextStageMatch?.stage ?? null;
+  const nextStageParticipant = nextStage
+    ? selectPaperclipIssueExecutionStageParticipant(nextStage, {
+        exclude: syncContext.executionState?.returnAssignee ?? syncContext.assignee
+      })
+    : null;
+  if (nextStage && nextStageParticipant) {
+    return {
+      principal: nextStageParticipant,
+      role: nextStage.type === 'approval' ? 'approver' : 'reviewer'
+    };
+  }
+
+  const approverOverride = getConfiguredAdvancedAssigneePrincipal(advancedSettings, 'approver');
+  if (nextStage?.type === 'approval' && approverOverride) {
+    return {
+      principal: approverOverride,
+      role: 'approver'
+    };
+  }
+
+  const reviewerOverride = getConfiguredAdvancedAssigneePrincipal(advancedSettings, 'reviewer');
+  if (reviewerOverride) {
+    return {
+      principal: reviewerOverride,
+      role: 'reviewer'
+    };
+  }
+
+  if (approverOverride) {
+    return {
+      principal: approverOverride,
+      role: 'approver'
+    };
+  }
+
+  return null;
+}
+
+function resolvePaperclipIssueExecutorAssignee(
+  syncContext: PaperclipIssueSyncContext,
+  advancedSettings: GitHubSyncAdvancedSettings
+): SyncTransitionAssigneeResolution | null {
+  const returnAssignee = syncContext.executionState?.returnAssignee;
+  if (returnAssignee) {
+    return {
+      principal: returnAssignee,
+      role: 'executor'
+    };
+  }
+
+  const executorOverride = getConfiguredAdvancedAssigneePrincipal(advancedSettings, 'executor');
+  if (executorOverride) {
+    return {
+      principal: executorOverride,
+      role: 'executor'
+    };
+  }
+
+  const defaultOverride = getConfiguredAdvancedAssigneePrincipal(advancedSettings, 'default');
+  if (defaultOverride) {
+    return {
+      principal: defaultOverride,
+      role: 'executor'
+    };
+  }
+
+  return null;
+}
+
+function resolveSyncTransitionAssignee(params: {
+  nextStatus: PaperclipIssueStatus;
+  syncContext: PaperclipIssueSyncContext;
+  advancedSettings: GitHubSyncAdvancedSettings;
+}): SyncTransitionAssigneeResolution | null {
+  const { nextStatus, syncContext, advancedSettings } = params;
+
+  if (nextStatus === 'in_review') {
+    return resolvePaperclipIssueReviewAssignee(syncContext, advancedSettings);
+  }
+
+  if (nextStatus === 'todo' || nextStatus === 'in_progress') {
+    return resolvePaperclipIssueExecutorAssignee(syncContext, advancedSettings);
+  }
+
+  return null;
+}
+
+function doesPaperclipIssueAssigneeMatch(
+  currentAssignee: PaperclipIssueAssigneePrincipal | null,
+  nextAssignee: PaperclipIssueAssigneePrincipal | null
+): boolean {
+  return isSamePaperclipIssueAssigneePrincipal(currentAssignee, nextAssignee);
+}
+
+function isActionablePaperclipIssueStatus(status: PaperclipIssueStatus): boolean {
+  return status === 'todo' || status === 'in_progress' || status === 'in_review';
+}
+
+function buildPaperclipPendingExecutionState(params: {
+  previousState: PaperclipIssueExecutionState | null;
+  stage: PaperclipIssueExecutionStage;
+  stageIndex: number;
+  participant: PaperclipIssueAssigneePrincipal;
+  returnAssignee: PaperclipIssueAssigneePrincipal | null;
+}): Record<string, unknown> {
+  const { previousState, stage, stageIndex, participant, returnAssignee } = params;
+
+  return {
+    status: 'pending',
+    currentStageId: stage.id ?? null,
+    currentStageIndex: stageIndex,
+    currentStageType: stage.type,
+    currentParticipant: serializePaperclipIssueAssigneePrincipal(participant),
+    returnAssignee: serializePaperclipIssueAssigneePrincipal(returnAssignee),
+    completedStageIds: [...(previousState?.completedStageIds ?? [])],
+    lastDecisionId: previousState?.lastDecisionId ?? null,
+    lastDecisionOutcome: previousState?.lastDecisionOutcome ?? null
+  };
+}
+
+function buildPaperclipChangesRequestedExecutionState(params: {
+  previousState: PaperclipIssueExecutionState;
+  stage: PaperclipIssueExecutionStage;
+  stageIndex: number;
+}): Record<string, unknown> {
+  const { previousState, stage, stageIndex } = params;
+
+  return {
+    status: 'changes_requested',
+    currentStageId: stage.id ?? previousState.currentStageId ?? null,
+    currentStageIndex: stageIndex,
+    currentStageType: stage.type,
+    currentParticipant: serializePaperclipIssueAssigneePrincipal(previousState.currentParticipant),
+    returnAssignee: serializePaperclipIssueAssigneePrincipal(previousState.returnAssignee),
+    completedStageIds: [...previousState.completedStageIds],
+    lastDecisionId: previousState.lastDecisionId ?? null,
+    lastDecisionOutcome: 'changes_requested'
+  };
+}
+
+function buildSyncFallbackExecutionStatePatch(params: {
+  currentStatus: PaperclipIssueStatus;
+  nextStatus: PaperclipIssueStatus;
+  syncContext: PaperclipIssueSyncContext;
+  nextAssignee?: PaperclipIssueAssigneePrincipal | null;
+}): Record<string, unknown> | null | undefined {
+  const { currentStatus, nextStatus, syncContext, nextAssignee } = params;
+  const previousState = syncContext.executionState;
+
+  if (
+    (currentStatus === 'done' || currentStatus === 'cancelled')
+    && nextStatus !== 'done'
+    && nextStatus !== 'cancelled'
+  ) {
+    return previousState ? null : undefined;
+  }
+
+  if (nextStatus === 'in_review' && syncContext.executionPolicy) {
+    const nextStageMatch = findPaperclipIssueExecutionStageMatch(syncContext.executionPolicy, previousState);
+    if (!nextStageMatch) {
+      return previousState ? null : undefined;
+    }
+
+    const returnAssignee = previousState?.returnAssignee ?? syncContext.assignee;
+    const participant = selectPaperclipIssueExecutionStageParticipant(nextStageMatch.stage, {
+      preferred:
+        previousState?.status === 'changes_requested'
+          ? nextAssignee ?? previousState.currentParticipant
+          : nextAssignee ?? previousState?.currentParticipant,
+      exclude: returnAssignee
+    });
+
+    if (!participant) {
+      return previousState ? null : undefined;
+    }
+
+    return buildPaperclipPendingExecutionState({
+      previousState,
+      stage: nextStageMatch.stage,
+      stageIndex: nextStageMatch.index,
+      participant,
+      returnAssignee
+    });
+  }
+
+  if ((nextStatus === 'todo' || nextStatus === 'in_progress') && currentStatus === 'in_review') {
+    const currentStageMatch = findPaperclipIssueExecutionStageMatch(syncContext.executionPolicy, previousState);
+    if (previousState?.status === 'pending' && previousState.returnAssignee && currentStageMatch) {
+      return buildPaperclipChangesRequestedExecutionState({
+        previousState,
+        stage: currentStageMatch.stage,
+        stageIndex: currentStageMatch.index
+      });
+    }
+
+    return previousState ? null : undefined;
+  }
+
+  return undefined;
 }
 
 function describeGitHubStatusTransitionReason(params: {
@@ -6078,6 +6790,7 @@ function resolvePaperclipIssueStatus(params: {
   wasImportedThisRun: boolean;
   defaultImportedStatus: PaperclipIssueStatus;
   maintainerAuthoredImportedIssue?: boolean;
+  hasExecutorHandoffTarget?: boolean;
 }): PaperclipIssueStatus {
   const {
     currentStatus,
@@ -6086,7 +6799,8 @@ function resolvePaperclipIssueStatus(params: {
     hasTrustedNewComment,
     wasImportedThisRun,
     defaultImportedStatus,
-    maintainerAuthoredImportedIssue
+    maintainerAuthoredImportedIssue,
+    hasExecutorHandoffTarget
   } = params;
 
   if (snapshot.state === 'closed') {
@@ -6102,11 +6816,13 @@ function resolvePaperclipIssueStatus(params: {
 
   const baselineCommentCount = previousCommentCount ?? snapshot.commentCount;
   if (snapshot.commentCount > baselineCommentCount && hasTrustedNewComment) {
-    return 'todo';
+    return hasExecutorHandoffTarget ? 'in_progress' : 'todo';
   }
 
   if (snapshot.linkedPullRequests.length > 0) {
-    return resolvePaperclipStatusFromLinkedPullRequests(snapshot.linkedPullRequests);
+    return resolvePaperclipStatusFromLinkedPullRequests(snapshot.linkedPullRequests, {
+      preferInProgress: hasExecutorHandoffTarget
+    });
   }
 
   if (wasImportedThisRun) {
@@ -7821,13 +8537,17 @@ async function detectPaperclipBoardAccessRequirement(paperclipApiBaseUrl?: strin
   }
 }
 
-async function wakePaperclipAssigneeForImportedIssue(
+async function wakePaperclipIssueAssignee(
   ctx: PluginSetupContext,
   params: {
     assigneeAgentId?: string | null;
     paperclipIssueId: string;
     companyId?: string;
     paperclipApiBaseUrl?: string;
+    reason: string;
+    mutation: 'import' | 'status_transition';
+    previousStatus?: PaperclipIssueStatus;
+    nextStatus?: PaperclipIssueStatus;
   }
 ): Promise<void> {
   if (!params.assigneeAgentId || !params.paperclipApiBaseUrl) {
@@ -7846,10 +8566,12 @@ async function wakePaperclipAssigneeForImportedIssue(
         body: JSON.stringify({
           source: 'assignment',
           triggerDetail: 'system',
-          reason: IMPORTED_ISSUE_WAKE_REASON,
+          reason: params.reason,
           payload: {
             issueId: params.paperclipIssueId,
-            mutation: 'import'
+            mutation: params.mutation,
+            ...(params.previousStatus ? { previousStatus: params.previousStatus } : {}),
+            ...(params.nextStatus ? { nextStatus: params.nextStatus } : {})
           }
         })
       },
@@ -7862,11 +8584,12 @@ async function wakePaperclipAssigneeForImportedIssue(
       throw new Error(`Wakeup request failed with status ${response.status}.`);
     }
   } catch (error) {
-    ctx.logger.warn('GitHub sync could not wake the assignee for an imported Paperclip issue.', {
+    ctx.logger.warn('GitHub sync could not wake the assignee for a Paperclip issue.', {
       issueId: params.paperclipIssueId,
       agentId: params.assigneeAgentId,
       companyId: params.companyId,
       paperclipApiBaseUrl: params.paperclipApiBaseUrl,
+      mutation: params.mutation,
       error: error instanceof Error ? error.message : String(error)
     });
   }
@@ -8876,20 +9599,46 @@ function doIssueNumberListsMatch(left: number[], right: number[]): boolean {
   return left.every((value, index) => value === right[index]);
 }
 
-async function updatePaperclipIssueStatus(
+async function updatePaperclipIssueState(
   ctx: PluginSetupContext,
   params: {
     companyId: string;
     issueId: string;
+    currentStatus: PaperclipIssueStatus;
+    syncContext: PaperclipIssueSyncContext;
     nextStatus: PaperclipIssueStatus;
+    nextAssignee?: PaperclipIssueAssigneePrincipal | null;
     transitionComment: string;
     transitionCommentAnnotation?: StoredStatusTransitionCommentAnnotation;
     paperclipApiBaseUrl?: string;
   }
 ): Promise<void> {
-  const { companyId, issueId, nextStatus, transitionComment, transitionCommentAnnotation, paperclipApiBaseUrl } = params;
+  const {
+    companyId,
+    issueId,
+    currentStatus,
+    syncContext,
+    nextStatus,
+    nextAssignee,
+    transitionComment,
+    transitionCommentAnnotation,
+    paperclipApiBaseUrl
+  } = params;
   const trimmedTransitionComment = transitionComment.trim();
-  let statusUpdated = false;
+  let issueUpdated = false;
+  const issuePatch: Record<string, unknown> = {
+    status: nextStatus
+  };
+
+  if (nextAssignee) {
+    if (nextAssignee.kind === 'agent') {
+      issuePatch.assigneeAgentId = nextAssignee.id;
+      issuePatch.assigneeUserId = null;
+    } else {
+      issuePatch.assigneeAgentId = null;
+      issuePatch.assigneeUserId = nextAssignee.id;
+    }
+  }
 
   if (paperclipApiBaseUrl) {
     try {
@@ -8901,9 +9650,7 @@ async function updatePaperclipIssueStatus(
             accept: 'application/json',
             'content-type': 'application/json'
           },
-          body: JSON.stringify({
-            status: nextStatus
-          })
+          body: JSON.stringify(issuePatch)
         },
         {
           companyId
@@ -8916,7 +9663,7 @@ async function updatePaperclipIssueStatus(
       });
 
       if (!payloadResult.failure) {
-        statusUpdated = true;
+        issueUpdated = true;
       }
 
       if (payloadResult.failure && (payloadResult.failure.status ?? response.status) !== 404 && (payloadResult.failure.status ?? response.status) !== 405) {
@@ -8940,8 +9687,41 @@ async function updatePaperclipIssueStatus(
     }
   }
 
-  if (!statusUpdated) {
-    await ctx.issues.update(issueId, { status: nextStatus }, companyId);
+  if (!issueUpdated) {
+    const fallbackExecutionStatePatch = buildSyncFallbackExecutionStatePatch({
+      currentStatus,
+      nextStatus,
+      syncContext,
+      nextAssignee
+    });
+    const preserveExistingUserAssigneeWithoutLocalApi = nextAssignee?.kind === 'user' && !paperclipApiBaseUrl;
+    const sdkIssuePatch: Record<string, unknown> = {
+      ...issuePatch
+    };
+    if (!preserveExistingUserAssigneeWithoutLocalApi || fallbackExecutionStatePatch === null) {
+      if (fallbackExecutionStatePatch !== undefined) {
+        sdkIssuePatch.executionState = fallbackExecutionStatePatch;
+      }
+    }
+
+    if (preserveExistingUserAssigneeWithoutLocalApi) {
+      ctx.logger.warn('GitHub sync could not reassign a Paperclip issue to a user without the local Paperclip API. Preserving the existing assignee.', {
+        companyId,
+        issueId,
+        nextStatus,
+        assigneeUserId: nextAssignee.id
+      });
+      await ctx.issues.update(
+        issueId,
+        {
+          status: nextStatus,
+          ...(fallbackExecutionStatePatch === null ? { executionState: null } : {})
+        } as unknown as PaperclipIssueUpdatePatchWithLabels,
+        companyId
+      );
+    } else {
+      await ctx.issues.update(issueId, sdkIssuePatch as PaperclipIssueUpdatePatchWithLabels, companyId);
+    }
   }
   if (trimmedTransitionComment && typeof ctx.issues.createComment === 'function') {
     const createdComment = await ctx.issues.createComment(issueId, trimmedTransitionComment, companyId);
@@ -9024,6 +9804,63 @@ function shouldIgnoreGitHubIssue(
   );
 }
 
+async function assignImportedPaperclipIssueToUser(
+  ctx: PluginSetupContext,
+  params: {
+    companyId: string;
+    issueId: string;
+    assigneeUserId: string;
+    paperclipApiBaseUrl?: string;
+  }
+): Promise<void> {
+  if (!params.paperclipApiBaseUrl) {
+    ctx.logger.warn('GitHub sync could not assign a newly imported Paperclip issue to a user without the local Paperclip API. Preserving the imported issue assignment.', {
+      companyId: params.companyId,
+      issueId: params.issueId,
+      assigneeUserId: params.assigneeUserId
+    });
+    return;
+  }
+
+  try {
+    const response = await fetchPaperclipApi(
+      getPaperclipIssueEndpoint(params.paperclipApiBaseUrl, params.issueId),
+      {
+        method: 'PATCH',
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          assigneeAgentId: null,
+          assigneeUserId: params.assigneeUserId
+        })
+      },
+      {
+        companyId: params.companyId
+      }
+    );
+
+    const payloadResult = await readPaperclipApiJsonResponse<unknown>(response, {
+      operationLabel: 'issue update',
+      bodyRequired: false
+    });
+    if (!payloadResult.failure) {
+      return;
+    }
+
+    throw new Error(payloadResult.failure.errorMessage ?? `Issue update failed with status ${payloadResult.failure.status ?? response.status}.`);
+  } catch (error) {
+    ctx.logger.warn('GitHub sync could not assign a newly imported Paperclip issue to a Paperclip user.', {
+      companyId: params.companyId,
+      issueId: params.issueId,
+      assigneeUserId: params.assigneeUserId,
+      paperclipApiBaseUrl: params.paperclipApiBaseUrl,
+      error: getErrorMessage(error)
+    });
+  }
+}
+
 async function createPaperclipIssue(
   ctx: PluginSetupContext,
   mapping: RepositoryMapping,
@@ -9039,18 +9876,30 @@ async function createPaperclipIssue(
 
   const title = issue.title;
   const description = buildPaperclipIssueDescription(issue);
+  const defaultAssignee = getConfiguredAdvancedAssigneePrincipal(advancedSettings, 'default');
   const createdIssue = await ctx.issues.create({
     companyId: mapping.companyId,
     projectId: mapping.paperclipProjectId,
     title,
     ...(description ? { description } : {}),
-    ...(advancedSettings.defaultAssigneeAgentId
-      ? { assigneeAgentId: advancedSettings.defaultAssigneeAgentId }
+    ...(defaultAssignee?.kind === 'agent'
+      ? { assigneeAgentId: defaultAssignee.id }
+      : defaultAssignee?.kind === 'user'
+        ? { assigneeUserId: defaultAssignee.id }
       : {})
   });
   const ensuredCreatedIssueId = createdIssue.id;
   const normalizedCreatedIssueDescription = createdIssue.description ?? undefined;
   const createPath: IssueDescriptionUpdatePath = 'sdk';
+
+  if (defaultAssignee?.kind === 'user') {
+    await assignImportedPaperclipIssueToUser(ctx, {
+      companyId: mapping.companyId,
+      issueId: ensuredCreatedIssueId,
+      assigneeUserId: defaultAssignee.id,
+      paperclipApiBaseUrl
+    });
+  }
 
   if (normalizeIssueDescriptionValue(normalizedCreatedIssueDescription) !== description) {
     logIssueDescriptionDiagnostic(
@@ -9251,9 +10100,13 @@ async function synchronizePaperclipIssueStatuses(
   let updatedDescriptionsCount = 0;
   let completedIssueCount = 0;
   const totalIssueCount = importedIssues.length;
-  const queuedImportedIssueWakeups: Array<{
+  const queuedIssueWakeups: Array<{
     assigneeAgentId?: string | null;
     paperclipIssueId: string;
+    reason: string;
+    mutation: 'import' | 'status_transition';
+    previousStatus?: PaperclipIssueStatus;
+    nextStatus?: PaperclipIssueStatus;
   }> = [];
 
   for (const importedIssue of importedIssues) {
@@ -9404,6 +10257,11 @@ async function synchronizePaperclipIssueStatuses(
               maintainerCache: repositoryMaintainerCache
             })
           : false;
+      const paperclipIssueSyncContext = getPaperclipIssueSyncContext(paperclipIssue);
+      const executorTransitionAssignee = resolvePaperclipIssueExecutorAssignee(
+        paperclipIssueSyncContext,
+        advancedSettings
+      );
       const nextStatus = resolvePaperclipIssueStatus({
         currentStatus: paperclipIssue.status,
         snapshot,
@@ -9411,19 +10269,38 @@ async function synchronizePaperclipIssueStatuses(
         hasTrustedNewComment,
         wasImportedThisRun,
         defaultImportedStatus: advancedSettings.defaultStatus,
-        maintainerAuthoredImportedIssue
+        maintainerAuthoredImportedIssue,
+        hasExecutorHandoffTarget: Boolean(executorTransitionAssignee)
       });
+      const nextTransitionAssignee = resolveSyncTransitionAssignee({
+        nextStatus,
+        syncContext: paperclipIssueSyncContext,
+        advancedSettings
+      });
+      const nextAssigneeChanged = nextTransitionAssignee
+        ? !doesPaperclipIssueAssigneeMatch(paperclipIssueSyncContext.assignee, nextTransitionAssignee.principal)
+        : false;
       const shouldWakeImportedAssignee =
-        wasImportedThisRun && nextStatus === 'todo' && Boolean(paperclipIssue.assigneeAgentId);
+        wasImportedThisRun
+        && paperclipIssue.status === nextStatus
+        && nextStatus === 'todo'
+        && paperclipIssueSyncContext.assignee?.kind === 'agent';
+      const shouldWakeTransitionAssignee =
+        paperclipIssue.status !== nextStatus
+        && nextTransitionAssignee?.principal.kind === 'agent'
+        && isActionablePaperclipIssueStatus(nextStatus)
+        && (nextAssigneeChanged || paperclipIssue.status !== nextStatus);
 
       importedIssue.githubIssueNumber = githubIssue.number;
       importedIssue.lastSeenCommentCount = snapshot.commentCount;
 
       if (paperclipIssue.status === nextStatus) {
         if (shouldWakeImportedAssignee) {
-          queuedImportedIssueWakeups.push({
-            assigneeAgentId: paperclipIssue.assigneeAgentId,
-            paperclipIssueId: importedIssue.paperclipIssueId
+          queuedIssueWakeups.push({
+            assigneeAgentId: paperclipIssueSyncContext.assignee?.kind === 'agent' ? paperclipIssueSyncContext.assignee.id : null,
+            paperclipIssueId: importedIssue.paperclipIssueId,
+            reason: IMPORTED_ISSUE_WAKE_REASON,
+            mutation: 'import'
           });
         }
         continue;
@@ -9444,20 +10321,27 @@ async function synchronizePaperclipIssueStatuses(
         repositoryUrl: repository.url,
         githubIssueNumber: githubIssue.number
       });
-      await updatePaperclipIssueStatus(ctx, {
+      await updatePaperclipIssueState(ctx, {
         companyId: mapping.companyId,
         issueId: importedIssue.paperclipIssueId,
+        currentStatus: paperclipIssue.status,
+        syncContext: paperclipIssueSyncContext,
         nextStatus,
+        ...(nextTransitionAssignee ? { nextAssignee: nextTransitionAssignee.principal } : {}),
         transitionComment: transitionComment.body,
         transitionCommentAnnotation: transitionComment.annotation,
         paperclipApiBaseUrl
       });
       updatedStatusesCount += 1;
 
-      if (shouldWakeImportedAssignee) {
-        queuedImportedIssueWakeups.push({
-          assigneeAgentId: paperclipIssue.assigneeAgentId,
-          paperclipIssueId: importedIssue.paperclipIssueId
+      if (shouldWakeTransitionAssignee && nextTransitionAssignee?.principal.kind === 'agent') {
+        queuedIssueWakeups.push({
+          assigneeAgentId: nextTransitionAssignee.principal.id,
+          paperclipIssueId: importedIssue.paperclipIssueId,
+          reason: STATUS_TRANSITION_WAKE_REASON,
+          mutation: 'status_transition',
+          previousStatus: paperclipIssue.status,
+          nextStatus
         });
       }
     } catch (error) {
@@ -9482,13 +10366,17 @@ async function synchronizePaperclipIssueStatuses(
   }
 
   await mapWithConcurrency(
-    queuedImportedIssueWakeups,
+    queuedIssueWakeups,
     IMPORTED_ISSUE_WAKEUP_CONCURRENCY,
-    async (queuedWakeup) => wakePaperclipAssigneeForImportedIssue(ctx, {
+    async (queuedWakeup) => wakePaperclipIssueAssignee(ctx, {
       assigneeAgentId: queuedWakeup.assigneeAgentId,
       paperclipIssueId: queuedWakeup.paperclipIssueId,
       companyId: mapping.companyId,
-      paperclipApiBaseUrl
+      paperclipApiBaseUrl,
+      reason: queuedWakeup.reason,
+      mutation: queuedWakeup.mutation,
+      previousStatus: queuedWakeup.previousStatus,
+      nextStatus: queuedWakeup.nextStatus
     })
   );
 
@@ -15319,7 +16207,7 @@ const plugin = definePlugin({
 
       const scopedMappings = filterMappingsByCompany(settingsForResponse.mappings, requestedCompanyId);
       const availableAssignees = includeAssignees && requestedCompanyId
-        ? await listAvailableAssignees(ctx, requestedCompanyId)
+        ? await listAvailableAssignees(ctx, requestedCompanyId, settingsForResponse)
         : [];
 
       return {
@@ -15465,6 +16353,7 @@ const plugin = definePlugin({
         ...(githubTokenLogin ? { githubTokenLogin } : {}),
         paperclipBoardApiTokenRefs: previous.paperclipBoardApiTokenRefs,
         paperclipBoardAccessIdentityByCompanyId: previous.paperclipBoardAccessIdentityByCompanyId,
+        paperclipBoardAccessUserIdByCompanyId: previous.paperclipBoardAccessUserIdByCompanyId,
         ...(Object.keys(nextCompanyAdvancedSettingsByCompanyId).length > 0
           ? { companyAdvancedSettingsByCompanyId: nextCompanyAdvancedSettingsByCompanyId }
           : {}),
@@ -15501,6 +16390,9 @@ const plugin = definePlugin({
         ...(current.paperclipBoardAccessIdentityByCompanyId
           ? { paperclipBoardAccessIdentityByCompanyId: current.paperclipBoardAccessIdentityByCompanyId }
           : {}),
+        ...(current.paperclipBoardAccessUserIdByCompanyId
+          ? { paperclipBoardAccessUserIdByCompanyId: current.paperclipBoardAccessUserIdByCompanyId }
+          : {}),
         ...(current.companyAdvancedSettingsByCompanyId
           ? { companyAdvancedSettingsByCompanyId: current.companyAdvancedSettingsByCompanyId }
           : {}),
@@ -15521,7 +16413,7 @@ const plugin = definePlugin({
         ...getPublicSettingsForScope(next, requestedCompanyId),
         ...(scopedGitHubTokenLogin ? { githubTokenLogin: scopedGitHubTokenLogin } : {}),
         availableAssignees: requestedCompanyId
-          ? await listAvailableAssignees(ctx, requestedCompanyId)
+          ? await listAvailableAssignees(ctx, requestedCompanyId, next)
           : []
       };
     });
@@ -15542,12 +16434,16 @@ const plugin = definePlugin({
       const nextPaperclipBoardAccessIdentityByCompanyId = {
         ...(previous.paperclipBoardAccessIdentityByCompanyId ?? {})
       };
+      const nextPaperclipBoardAccessUserIdByCompanyId = {
+        ...(previous.paperclipBoardAccessUserIdByCompanyId ?? {})
+      };
 
       if (nextSecretRef) {
         nextPaperclipBoardApiTokenRefs[companyId] = nextSecretRef;
       } else {
         delete nextPaperclipBoardApiTokenRefs[companyId];
         delete nextPaperclipBoardAccessIdentityByCompanyId[companyId];
+        delete nextPaperclipBoardAccessUserIdByCompanyId[companyId];
       }
 
       if ('paperclipBoardAccessIdentity' in record) {
@@ -15559,9 +16455,19 @@ const plugin = definePlugin({
         }
       }
 
+      if ('paperclipBoardAccessUserId' in record) {
+        const nextUserId = normalizeOptionalString(record.paperclipBoardAccessUserId);
+        if (nextUserId) {
+          nextPaperclipBoardAccessUserIdByCompanyId[companyId] = nextUserId;
+        } else {
+          delete nextPaperclipBoardAccessUserIdByCompanyId[companyId];
+        }
+      }
+
       const {
         paperclipBoardApiTokenRefs: _previousPaperclipBoardApiTokenRefs,
         paperclipBoardAccessIdentityByCompanyId: _previousPaperclipBoardAccessIdentityByCompanyId,
+        paperclipBoardAccessUserIdByCompanyId: _previousPaperclipBoardAccessUserIdByCompanyId,
         ...previousWithoutBoardAccess
       } = previous;
       const nextBase = sanitizeSettingsForCurrentSetup({
@@ -15571,6 +16477,9 @@ const plugin = definePlugin({
           : {}),
         ...(Object.keys(nextPaperclipBoardAccessIdentityByCompanyId).length > 0
           ? { paperclipBoardAccessIdentityByCompanyId: nextPaperclipBoardAccessIdentityByCompanyId }
+          : {}),
+        ...(Object.keys(nextPaperclipBoardAccessUserIdByCompanyId).length > 0
+          ? { paperclipBoardAccessUserIdByCompanyId: nextPaperclipBoardAccessUserIdByCompanyId }
           : {}),
         updatedAt: new Date().toISOString()
       }, {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -9696,32 +9696,22 @@ async function updatePaperclipIssueState(
     });
     const preserveExistingUserAssigneeWithoutLocalApi = nextAssignee?.kind === 'user' && !paperclipApiBaseUrl;
     const sdkIssuePatch: Record<string, unknown> = {
-      ...issuePatch
+      ...issuePatch,
+      ...(fallbackExecutionStatePatch !== undefined ? { executionState: fallbackExecutionStatePatch } : {})
     };
-    if (!preserveExistingUserAssigneeWithoutLocalApi || fallbackExecutionStatePatch === null) {
-      if (fallbackExecutionStatePatch !== undefined) {
-        sdkIssuePatch.executionState = fallbackExecutionStatePatch;
-      }
-    }
 
     if (preserveExistingUserAssigneeWithoutLocalApi) {
+      delete sdkIssuePatch.assigneeAgentId;
+      delete sdkIssuePatch.assigneeUserId;
       ctx.logger.warn('GitHub sync could not reassign a Paperclip issue to a user without the local Paperclip API. Preserving the existing assignee.', {
         companyId,
         issueId,
         nextStatus,
         assigneeUserId: nextAssignee.id
       });
-      await ctx.issues.update(
-        issueId,
-        {
-          status: nextStatus,
-          ...(fallbackExecutionStatePatch === null ? { executionState: null } : {})
-        } as unknown as PaperclipIssueUpdatePatchWithLabels,
-        companyId
-      );
-    } else {
-      await ctx.issues.update(issueId, sdkIssuePatch as PaperclipIssueUpdatePatchWithLabels, companyId);
     }
+
+    await ctx.issues.update(issueId, sdkIssuePatch as PaperclipIssueUpdatePatchWithLabels, companyId);
   }
   if (trimmedTransitionComment && typeof ctx.issues.createComment === 'function') {
     const createdComment = await ctx.issues.createComment(issueId, trimmedTransitionComment, companyId);

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -15273,6 +15273,314 @@ test('worker preserves execution-policy changes-requested state when the local P
   }
 });
 
+test('worker preserves execution-policy changes-requested state when a user handoff falls back through the SDK without the local Paperclip API', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubTokenRef: 'github-secret-ref'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+
+  await harness.performAction('settings.saveRegistration', {
+    companyId: 'company-1',
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  const originalUpdate = harness.ctx.issues.update;
+  const importedIssue = await harness.ctx.issues.create({
+    companyId: 'company-1',
+    projectId: 'project-1',
+    title: 'User handoff SDK fallback preserves changes requested state',
+    description: '* GitHub issue: [#46](https://github.com/paperclipai/example-repo/issues/46)\n\n---\n\nBody'
+  });
+  await originalUpdate(
+    importedIssue.id,
+    {
+      status: 'in_review',
+      assigneeAgentId: 'agent-2',
+      executionPolicy: {
+        mode: 'normal',
+        commentRequired: true,
+        stages: [
+          {
+            id: 'review-stage',
+            type: 'review',
+            participants: [{ type: 'agent', agentId: 'agent-2' }]
+          }
+        ]
+      },
+      executionState: {
+        status: 'pending',
+        currentStageId: 'review-stage',
+        currentStageIndex: 0,
+        currentStageType: 'review',
+        currentParticipant: { type: 'agent', agentId: 'agent-2' },
+        returnAssignee: { type: 'user', userId: 'user-1' },
+        completedStageIds: []
+      }
+    } as never,
+    'company-1'
+  );
+
+  await harness.ctx.state.set(
+    {
+      scopeKind: 'instance',
+      stateKey: 'paperclip-github-plugin-import-registry'
+    },
+    [
+      {
+        mappingId: 'mapping-a',
+        githubIssueId: 4601,
+        githubIssueNumber: 46,
+        paperclipIssueId: importedIssue.id,
+        importedAt: '2026-04-09T09:00:00.000Z',
+        lastSeenCommentCount: 0,
+        repositoryUrl: 'https://github.com/paperclipai/example-repo',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ]
+  );
+
+  const directStatusUpdateCalls: Array<{ issueId: string; patch: Record<string, unknown> }> = [];
+  harness.ctx.issues.update = async (issueId, patch, companyId) => {
+    directStatusUpdateCalls.push({
+      issueId,
+      patch: (patch ?? {}) as Record<string, unknown>
+    });
+
+    return originalUpdate(issueId, patch, companyId);
+  };
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    const rawUrl = getRequestUrl(input);
+    const url = new URL(rawUrl);
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues' && ['all', 'open'].includes(url.searchParams.get('state') ?? '')) {
+      return jsonResponse([
+        {
+          id: 4601,
+          number: 46,
+          title: 'User handoff SDK fallback preserves changes requested state',
+          body: 'Body',
+          html_url: 'https://github.com/paperclipai/example-repo/issues/46',
+          state: 'open',
+          comments: 0
+        }
+      ]);
+    }
+
+    if (url.pathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      const issueNumber = typeof variables.issueNumber === 'number' ? variables.issueNumber : undefined;
+      const pullRequestNumber =
+        typeof variables.pullRequestNumber === 'number' ? variables.pullRequestNumber : undefined;
+
+      if (query.includes('query GitHubIssueParentRelationships')) {
+        return graphqlIssueParentRelationshipsResponse([
+          {
+            issueNumber: 46
+          }
+        ]);
+      }
+
+      if (query.includes('query GitHubRepositoryOpenIssueLinkedPullRequests')) {
+        return graphqlResponse({
+          repository: {
+            issues: {
+              pageInfo: {
+                hasNextPage: false,
+                endCursor: null
+              },
+              nodes: [
+                {
+                  number: 46,
+                  closedByPullRequestsReferences: {
+                    pageInfo: {
+                      hasNextPage: false,
+                      endCursor: null
+                    },
+                    nodes: [
+                      {
+                        number: 460,
+                        state: 'OPEN'
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubRepositoryOpenPullRequestStatuses')) {
+        return graphqlResponse({
+          repository: {
+            pullRequests: {
+              pageInfo: {
+                hasNextPage: false,
+                endCursor: null
+              },
+              nodes: [
+                {
+                  number: 460,
+                  reviewThreads: {
+                    pageInfo: {
+                      hasNextPage: false,
+                      endCursor: null
+                    },
+                    nodes: [{ isResolved: false }]
+                  },
+                  statusCheckRollup: {
+                    contexts: {
+                      pageInfo: {
+                        hasNextPage: false,
+                        endCursor: null
+                      },
+                      nodes: [
+                        {
+                          __typename: 'StatusContext',
+                          state: 'SUCCESS'
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && issueNumber === 46) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: 46,
+              state: 'OPEN',
+              stateReason: null,
+              comments: {
+                totalCount: 0
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: [
+                  {
+                    number: 460,
+                    state: 'OPEN'
+                  }
+                ]
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubPullRequestReviewThreads') && pullRequestNumber === 460) {
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: [{ isResolved: false }]
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubPullRequestCiContexts') && pullRequestNumber === 460) {
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              statusCheckRollup: {
+                contexts: {
+                  pageInfo: {
+                    hasNextPage: false,
+                    endCursor: null
+                  },
+                  nodes: [
+                    {
+                      __typename: 'StatusContext',
+                      state: 'SUCCESS'
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    const sync = await harness.performAction('sync.runNow', {
+      waitForCompletion: true
+    }) as {
+      syncState: { status: string };
+    };
+
+    assert.equal(sync.syncState.status, 'success');
+    const directStatusPatches = directStatusUpdateCalls.filter((call) => typeof call.patch.status === 'string');
+    assert.equal(directStatusPatches.length, 1);
+    assert.equal(directStatusPatches[0]?.patch.status, 'in_progress');
+    assert.equal('assigneeAgentId' in (directStatusPatches[0]?.patch ?? {}), false);
+    assert.equal('assigneeUserId' in (directStatusPatches[0]?.patch ?? {}), false);
+    assert.deepEqual(directStatusPatches[0]?.patch.executionState, {
+      status: 'changes_requested',
+      currentStageId: 'review-stage',
+      currentStageIndex: 0,
+      currentStageType: 'review',
+      currentParticipant: { type: 'agent', agentId: 'agent-2', userId: null },
+      returnAssignee: { type: 'user', agentId: null, userId: 'user-1' },
+      completedStageIds: [],
+      lastDecisionId: null,
+      lastDecisionOutcome: 'changes_requested'
+    });
+
+    const updatedIssue = await harness.ctx.issues.get(importedIssue.id, 'company-1') as Record<string, any> | null;
+    assert.equal(updatedIssue?.status, 'in_progress');
+    assert.equal(updatedIssue?.assigneeAgentId, 'agent-2');
+    assert.equal(updatedIssue?.assigneeUserId ?? null, null);
+    assert.deepEqual(updatedIssue?.executionState, {
+      status: 'changes_requested',
+      currentStageId: 'review-stage',
+      currentStageIndex: 0,
+      currentStageType: 'review',
+      currentParticipant: { type: 'agent', agentId: 'agent-2', userId: null },
+      returnAssignee: { type: 'user', agentId: null, userId: 'user-1' },
+      completedStageIds: [],
+      lastDecisionId: null,
+      lastDecisionOutcome: 'changes_requested'
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('worker moves reopened imported issues with no linked pull requests from done back to todo', async () => {
   const harness = createTestHarness({
     manifest,

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -280,6 +280,7 @@ async function createGitHubAgentToolHarness() {
   });
   await plugin.definition.setup(harness.ctx);
   await harness.performAction('settings.saveRegistration', {
+    companyId: 'company-1',
     mappings: [
       {
         id: 'mapping-a',
@@ -967,12 +968,14 @@ test('normalizeCompanyAssigneeOptionsResponse keeps assignable agents and trims 
     ]),
     [
       {
+        kind: 'agent',
         id: 'agent-2',
         name: 'Bailey',
         title: 'Operator',
         status: 'idle'
       },
       {
+        kind: 'agent',
         id: 'agent-3',
         name: 'Casey'
       }
@@ -5138,6 +5141,7 @@ test('project.pullRequests.count recovers mappings missing a saved company id wh
   await plugin.definition.setup(harness.ctx);
 
   await harness.performAction('settings.saveRegistration', {
+    companyId: 'company-1',
     mappings: [
       {
         id: 'mapping-a',
@@ -5860,6 +5864,7 @@ test('worker exposes toolbar sync state for global, project, and issue surfaces'
   await plugin.definition.setup(harness.ctx);
 
   await harness.performAction('settings.saveRegistration', {
+    companyId: 'company-1',
     mappings: [
       {
         id: 'mapping-a',
@@ -6604,10 +6609,18 @@ test('worker scopes mapping saves and settings reads to the requested company', 
     }>;
     advancedSettings: {
       defaultAssigneeAgentId?: string;
+      defaultAssigneeUserId?: string;
+      executorAssigneeAgentId?: string;
+      executorAssigneeUserId?: string;
+      reviewerAssigneeAgentId?: string;
+      reviewerAssigneeUserId?: string;
+      approverAssigneeAgentId?: string;
+      approverAssigneeUserId?: string;
       defaultStatus: string;
       ignoredIssueAuthorUsernames: string[];
     };
     availableAssignees: Array<{
+      kind: string;
       id: string;
       name: string;
     }>;
@@ -6625,6 +6638,13 @@ test('worker scopes mapping saves and settings reads to the requested company', 
     }>;
     advancedSettings: {
       defaultAssigneeAgentId?: string;
+      defaultAssigneeUserId?: string;
+      executorAssigneeAgentId?: string;
+      executorAssigneeUserId?: string;
+      reviewerAssigneeAgentId?: string;
+      reviewerAssigneeUserId?: string;
+      approverAssigneeAgentId?: string;
+      approverAssigneeUserId?: string;
       defaultStatus: string;
       ignoredIssueAuthorUsernames: string[];
     };
@@ -6656,6 +6676,7 @@ test('worker scopes mapping saves and settings reads to the requested company', 
   });
   assert.deepEqual(companyOneBefore.availableAssignees, [
     {
+      kind: 'agent',
       id: 'agent-1',
       name: 'Alex',
       title: 'Engineer',
@@ -6679,7 +6700,10 @@ test('worker scopes mapping saves and settings reads to the requested company', 
       }
     ],
     advancedSettings: {
-      defaultAssigneeAgentId: 'agent-1',
+      defaultAssigneeUserId: 'user-1',
+      executorAssigneeUserId: 'user-2',
+      reviewerAssigneeAgentId: 'agent-1',
+      approverAssigneeUserId: 'user-3',
       defaultStatus: 'todo',
       ignoredIssueAuthorUsernames: ['renovate', 'dependabot']
     },
@@ -6696,6 +6720,13 @@ test('worker scopes mapping saves and settings reads to the requested company', 
     }>;
     advancedSettings: {
       defaultAssigneeAgentId?: string;
+      defaultAssigneeUserId?: string;
+      executorAssigneeAgentId?: string;
+      executorAssigneeUserId?: string;
+      reviewerAssigneeAgentId?: string;
+      reviewerAssigneeUserId?: string;
+      approverAssigneeAgentId?: string;
+      approverAssigneeUserId?: string;
       defaultStatus: string;
       ignoredIssueAuthorUsernames: string[];
     };
@@ -6711,7 +6742,10 @@ test('worker scopes mapping saves and settings reads to the requested company', 
     }
   ]);
   assert.deepEqual(companyOneSaveResult.advancedSettings, {
-    defaultAssigneeAgentId: 'agent-1',
+    defaultAssigneeUserId: 'user-1',
+    executorAssigneeUserId: 'user-2',
+    reviewerAssigneeAgentId: 'agent-1',
+    approverAssigneeUserId: 'user-3',
     defaultStatus: 'todo',
     ignoredIssueAuthorUsernames: ['renovate', 'dependabot']
   });
@@ -6729,6 +6763,13 @@ test('worker scopes mapping saves and settings reads to the requested company', 
     }>;
     companyAdvancedSettingsByCompanyId: Record<string, {
       defaultAssigneeAgentId?: string;
+      defaultAssigneeUserId?: string;
+      executorAssigneeAgentId?: string;
+      executorAssigneeUserId?: string;
+      reviewerAssigneeAgentId?: string;
+      reviewerAssigneeUserId?: string;
+      approverAssigneeAgentId?: string;
+      approverAssigneeUserId?: string;
       defaultStatus: string;
       ignoredIssueAuthorUsernames: string[];
     }>;
@@ -6752,7 +6793,10 @@ test('worker scopes mapping saves and settings reads to the requested company', 
   ]);
   assert.deepEqual(savedSettings.companyAdvancedSettingsByCompanyId, {
     'company-1': {
-      defaultAssigneeAgentId: 'agent-1',
+      defaultAssigneeUserId: 'user-1',
+      executorAssigneeUserId: 'user-2',
+      reviewerAssigneeAgentId: 'agent-1',
+      approverAssigneeUserId: 'user-3',
       defaultStatus: 'todo',
       ignoredIssueAuthorUsernames: ['renovate', 'dependabot']
     }
@@ -7222,14 +7266,25 @@ test('settings.registration reports company-specific board access without resolv
   assert.equal(resolveCount, 0);
 });
 
-test('settings.updateBoardAccess persists a company-specific board access identity label', async () => {
+test('settings.updateBoardAccess persists a company-specific board access identity label and exposes Me as an assignee option', async () => {
   const harness = createTestHarness({ manifest });
   await plugin.definition.setup(harness.ctx);
+  harness.seed({
+    agents: [
+      createAgentFixture({
+        id: 'agent-1',
+        companyId: 'company-1',
+        name: 'Alex',
+        title: 'Engineer'
+      })
+    ]
+  });
 
   const actionResult = await harness.performAction('settings.updateBoardAccess', {
     companyId: 'company-1',
     paperclipBoardApiTokenRef: 'board-secret-ref',
-    paperclipBoardAccessIdentity: 'Jane Operator'
+    paperclipBoardAccessIdentity: 'Jane Operator',
+    paperclipBoardAccessUserId: 'user-1'
   }) as {
     paperclipBoardAccessConfigured?: boolean;
     paperclipBoardAccessIdentity?: string;
@@ -7243,17 +7298,29 @@ test('settings.updateBoardAccess persists a company-specific board access identi
     stateKey: 'paperclip-github-plugin-settings'
   }) as {
     paperclipBoardAccessIdentityByCompanyId?: Record<string, string>;
+    paperclipBoardAccessUserIdByCompanyId?: Record<string, string>;
   };
 
   assert.deepEqual(savedSettings.paperclipBoardAccessIdentityByCompanyId, {
     'company-1': 'Jane Operator'
   });
+  assert.deepEqual(savedSettings.paperclipBoardAccessUserIdByCompanyId, {
+    'company-1': 'user-1'
+  });
 
   const companyOneResult = await harness.getData<{
     paperclipBoardAccessConfigured?: boolean;
     paperclipBoardAccessIdentity?: string;
+    availableAssignees?: Array<{
+      kind: string;
+      id: string;
+      name: string;
+      title?: string;
+      status?: string;
+    }>;
   }>('settings.registration', {
-    companyId: 'company-1'
+    companyId: 'company-1',
+    includeAssignees: true
   });
   const companyTwoResult = await harness.getData<{
     paperclipBoardAccessConfigured?: boolean;
@@ -7264,6 +7331,21 @@ test('settings.updateBoardAccess persists a company-specific board access identi
 
   assert.equal(companyOneResult.paperclipBoardAccessConfigured, true);
   assert.equal(companyOneResult.paperclipBoardAccessIdentity, 'Jane Operator');
+  assert.deepEqual(companyOneResult.availableAssignees, [
+    {
+      kind: 'user',
+      id: 'user-1',
+      name: 'Me',
+      title: 'Jane Operator'
+    },
+    {
+      kind: 'agent',
+      id: 'agent-1',
+      name: 'Alex',
+      title: 'Engineer',
+      status: 'idle'
+    }
+  ]);
   assert.equal(companyTwoResult.paperclipBoardAccessConfigured, false);
   assert.equal(companyTwoResult.paperclipBoardAccessIdentity, undefined);
 });
@@ -8051,6 +8133,140 @@ test('worker imports maintainer-authored open issues without linked pull request
       statusTransitionComments[0]?.body ?? '',
       /the GitHub issue is open with no linked pull requests/
     );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('worker passes a configured board-user default assignee through issue import creation', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+
+  await harness.performAction('settings.saveRegistration', {
+    companyId: 'company-1',
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    advancedSettings: {
+      defaultAssigneeUserId: 'user-1',
+      defaultStatus: 'backlog',
+      ignoredIssueAuthorUsernames: []
+    },
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  const originalUpdate = harness.ctx.issues.update.bind(harness.ctx.issues);
+  const assigneePatchRequests: Array<{ issueId: string; body: Record<string, unknown> | null }> = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (input, init) => {
+    const rawUrl = getRequestUrl(input);
+    const url = new URL(rawUrl);
+    const method = (init?.method ?? 'GET').toUpperCase();
+
+    if (url.origin === 'http://127.0.0.1:63675' && method === 'PATCH' && url.pathname.startsWith('/api/issues/')) {
+      const issueId = url.pathname.split('/').pop() ?? '';
+      const body = getJsonRequestBody(init);
+      assigneePatchRequests.push({ issueId, body });
+
+      const patch: Record<string, unknown> = {};
+      if (body && Object.prototype.hasOwnProperty.call(body, 'assigneeAgentId')) {
+        patch.assigneeAgentId = body.assigneeAgentId;
+      }
+      if (body && Object.prototype.hasOwnProperty.call(body, 'assigneeUserId')) {
+        patch.assigneeUserId = body.assigneeUserId;
+      }
+
+      await originalUpdate(issueId, patch as never, 'company-1');
+
+      return jsonResponse({
+        id: issueId,
+        assigneeAgentId: body?.assigneeAgentId ?? null,
+        assigneeUserId: body?.assigneeUserId ?? null
+      });
+    }
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues' && ['all', 'open'].includes(url.searchParams.get('state') ?? '')) {
+      return jsonResponse([
+        {
+          id: 2801,
+          number: 28,
+          title: 'Board user import assignee',
+          body: 'Ship this next',
+          html_url: 'https://github.com/paperclipai/example-repo/issues/28',
+          state: 'open',
+          comments: 0
+        }
+      ]);
+    }
+
+    if (url.pathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      const issueNumber = typeof variables.issueNumber === 'number' ? variables.issueNumber : undefined;
+
+      if (query.includes('query GitHubIssueParentRelationships')) {
+        return graphqlIssueParentRelationshipsResponse([
+          {
+            issueNumber: 28
+          }
+        ]);
+      }
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && issueNumber === 28) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: 28,
+              state: 'OPEN',
+              stateReason: null,
+              comments: {
+                totalCount: 0
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: []
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    const sync = await harness.performAction('sync.runNow', {}) as {
+      syncState: { status: string; createdIssuesCount?: number };
+    };
+
+    assert.equal(sync.syncState.status, 'success');
+    assert.equal(sync.syncState.createdIssuesCount, 1);
+    assert.ok(
+      assigneePatchRequests.some((request) => request.body?.assigneeUserId === 'user-1')
+    );
+
+    const importedIssue = (await harness.ctx.issues.list({
+      companyId: 'company-1'
+    })).find((issue) => issue.title === 'Board user import assignee');
+    assert.equal(importedIssue?.assigneeUserId, 'user-1');
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -12563,6 +12779,935 @@ test('worker maps GitHub issue and linked PR state onto Paperclip statuses while
   }
 });
 
+test('worker routes sync-driven review handoffs to execution-policy assignees and wakes those agents', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+  harness.seed({
+    agents: [
+      createAgentFixture({
+        id: 'agent-1',
+        companyId: 'company-1',
+        name: 'Elliot',
+        title: 'Engineer'
+      }),
+      createAgentFixture({
+        id: 'agent-2',
+        companyId: 'company-1',
+        name: 'Riley',
+        title: 'Reviewer'
+      }),
+      createAgentFixture({
+        id: 'agent-3',
+        companyId: 'company-1',
+        name: 'Avery',
+        title: 'Approver'
+      }),
+      createAgentFixture({
+        id: 'agent-4',
+        companyId: 'company-1',
+        name: 'Default',
+        title: 'Import Assignee'
+      }),
+      createAgentFixture({
+        id: 'agent-5',
+        companyId: 'company-1',
+        name: 'Fallback Exec',
+        title: 'Fallback Executor'
+      }),
+      createAgentFixture({
+        id: 'agent-6',
+        companyId: 'company-1',
+        name: 'Fallback Review',
+        title: 'Fallback Reviewer'
+      }),
+      createAgentFixture({
+        id: 'agent-7',
+        companyId: 'company-1',
+        name: 'Fallback Approver',
+        title: 'Fallback Approver'
+      })
+    ]
+  });
+
+  await harness.performAction('settings.saveRegistration', {
+    companyId: 'company-1',
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    advancedSettings: {
+      defaultAssigneeAgentId: 'agent-4',
+      executorAssigneeAgentId: 'agent-5',
+      reviewerAssigneeAgentId: 'agent-6',
+      approverAssigneeAgentId: 'agent-7',
+      defaultStatus: 'backlog',
+      ignoredIssueAuthorUsernames: ['renovate']
+    },
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  const reviewReadyIssue = await harness.ctx.issues.create({
+    companyId: 'company-1',
+    projectId: 'project-1',
+    title: 'Ready for approval'
+  });
+  const changesRequestedIssue = await harness.ctx.issues.create({
+    companyId: 'company-1',
+    projectId: 'project-1',
+    title: 'Needs another pass'
+  });
+
+  await harness.ctx.state.set(
+    {
+      scopeKind: 'instance',
+      stateKey: 'paperclip-github-plugin-import-registry'
+    },
+    [
+      {
+        mappingId: 'mapping-a',
+        githubIssueId: 9101,
+        githubIssueNumber: 91,
+        paperclipIssueId: reviewReadyIssue.id,
+        importedAt: '2026-04-09T09:00:00.000Z',
+        lastSeenCommentCount: 0,
+        repositoryUrl: 'https://github.com/paperclipai/example-repo',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      },
+      {
+        mappingId: 'mapping-a',
+        githubIssueId: 9201,
+        githubIssueNumber: 92,
+        paperclipIssueId: changesRequestedIssue.id,
+        importedAt: '2026-04-09T09:00:00.000Z',
+        lastSeenCommentCount: 0,
+        repositoryUrl: 'https://github.com/paperclipai/example-repo',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ]
+  );
+
+  const originalGet = harness.ctx.issues.get;
+  const originalUpdate = harness.ctx.issues.update;
+  harness.ctx.issues.get = async (issueId, companyId) => {
+    const issue = await originalGet(issueId, companyId);
+    if (!issue) {
+      return issue;
+    }
+
+    if (issueId === reviewReadyIssue.id) {
+      return {
+        ...issue,
+        status: 'todo',
+        assigneeAgentId: 'agent-4',
+        executionPolicy: {
+          mode: 'normal',
+          commentRequired: true,
+          stages: [
+            {
+              id: 'review-stage',
+              type: 'review',
+              participants: [{ type: 'agent', agentId: 'agent-2' }]
+            },
+            {
+              id: 'approval-stage',
+              type: 'approval',
+              participants: [{ type: 'agent', agentId: 'agent-3' }]
+            }
+          ]
+        },
+        executionState: {
+          status: 'pending',
+          currentStageId: 'approval-stage',
+          currentStageIndex: 1,
+          currentStageType: 'approval',
+          currentParticipant: { type: 'agent', agentId: 'agent-3' },
+          returnAssignee: { type: 'agent', agentId: 'agent-1' },
+          completedStageIds: ['review-stage']
+        }
+      } as unknown as typeof issue;
+    }
+
+    if (issueId === changesRequestedIssue.id) {
+      return {
+        ...issue,
+        status: 'in_review',
+        assigneeAgentId: 'agent-2',
+        executionPolicy: {
+          mode: 'normal',
+          commentRequired: true,
+          stages: [
+            {
+              id: 'review-stage',
+              type: 'review',
+              participants: [{ type: 'agent', agentId: 'agent-2' }]
+            }
+          ]
+        },
+        executionState: {
+          status: 'pending',
+          currentStageId: 'review-stage',
+          currentStageIndex: 0,
+          currentStageType: 'review',
+          currentParticipant: { type: 'agent', agentId: 'agent-2' },
+          returnAssignee: { type: 'agent', agentId: 'agent-1' },
+          completedStageIds: []
+        }
+      } as unknown as typeof issue;
+    }
+
+    return issue;
+  };
+
+  const statusPatchRequests: Array<{ issueId: string; body: Record<string, unknown> | null }> = [];
+  const wakeRequests: Array<{ agentId: string; body: Record<string, unknown> | null }> = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (input, init) => {
+    const rawUrl = getRequestUrl(input);
+    const url = new URL(rawUrl);
+    const method = (init?.method ?? 'GET').toUpperCase();
+
+    if (url.origin === 'http://127.0.0.1:63675' && url.pathname === '/api/health' && method === 'GET') {
+      return jsonResponse({
+        deploymentMode: 'local_trusted'
+      });
+    }
+
+    if (url.origin === 'http://127.0.0.1:63675' && method === 'PATCH' && url.pathname.startsWith('/api/issues/')) {
+      const issueId = url.pathname.split('/').pop() ?? '';
+      const body = getJsonRequestBody(init);
+      statusPatchRequests.push({ issueId, body });
+
+      const patch: Record<string, unknown> = {};
+      if (typeof body?.status === 'string') {
+        patch.status = body.status;
+      }
+      if (body && Object.prototype.hasOwnProperty.call(body, 'assigneeAgentId')) {
+        patch.assigneeAgentId = body.assigneeAgentId;
+      }
+      if (body && Object.prototype.hasOwnProperty.call(body, 'assigneeUserId')) {
+        patch.assigneeUserId = body.assigneeUserId;
+      }
+
+      await originalUpdate(issueId, patch as never, 'company-1');
+
+      return jsonResponse({
+        id: issueId,
+        status: body?.status ?? null,
+        assigneeAgentId: body?.assigneeAgentId ?? null,
+        assigneeUserId: body?.assigneeUserId ?? null
+      });
+    }
+
+    if (
+      url.origin === 'http://127.0.0.1:63675'
+      && method === 'POST'
+      && url.pathname.startsWith('/api/agents/')
+      && url.pathname.endsWith('/wakeup')
+    ) {
+      const agentId = url.pathname.split('/')[3] ?? '';
+      wakeRequests.push({
+        agentId,
+        body: getJsonRequestBody(init)
+      });
+
+      return jsonResponse({
+        id: `run-${wakeRequests.length}`,
+        agentId,
+        status: 'queued'
+      });
+    }
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues' && ['all', 'open'].includes(url.searchParams.get('state') ?? '')) {
+      return jsonResponse([
+        {
+          id: 9101,
+          number: 91,
+          title: 'Ready for approval',
+          body: null,
+          html_url: 'https://github.com/paperclipai/example-repo/issues/91',
+          state: 'open',
+          comments: 0
+        },
+        {
+          id: 9201,
+          number: 92,
+          title: 'Needs another pass',
+          body: null,
+          html_url: 'https://github.com/paperclipai/example-repo/issues/92',
+          state: 'open',
+          comments: 0
+        }
+      ]);
+    }
+
+    if (url.pathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      const issueNumber = typeof variables.issueNumber === 'number' ? variables.issueNumber : undefined;
+      const pullRequestNumber =
+        typeof variables.pullRequestNumber === 'number' ? variables.pullRequestNumber : undefined;
+
+      if (query.includes('query GitHubIssueParentRelationships')) {
+        return graphqlIssueParentRelationshipsResponse([
+          {
+            issueNumber: 91
+          },
+          {
+            issueNumber: 92
+          }
+        ]);
+      }
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && issueNumber === 91) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: 91,
+              state: 'OPEN',
+              stateReason: null,
+              comments: {
+                totalCount: 0
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: [
+                  {
+                    number: 910,
+                    state: 'OPEN'
+                  }
+                ]
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && issueNumber === 92) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: 92,
+              state: 'OPEN',
+              stateReason: null,
+              comments: {
+                totalCount: 0
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: [
+                  {
+                    number: 920,
+                    state: 'OPEN'
+                  }
+                ]
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubPullRequestReviewThreads') && pullRequestNumber === 910) {
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: [{ isResolved: true }]
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubPullRequestReviewThreads') && pullRequestNumber === 920) {
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: [{ isResolved: false }]
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubPullRequestCiContexts') && pullRequestNumber === 910) {
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              statusCheckRollup: {
+                contexts: {
+                  pageInfo: {
+                    hasNextPage: false,
+                    endCursor: null
+                  },
+                  nodes: [
+                    {
+                      __typename: 'StatusContext',
+                      state: 'SUCCESS'
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubPullRequestCiContexts') && pullRequestNumber === 920) {
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              statusCheckRollup: {
+                contexts: {
+                  pageInfo: {
+                    hasNextPage: false,
+                    endCursor: null
+                  },
+                  nodes: [
+                    {
+                      __typename: 'CheckRun',
+                      status: 'COMPLETED',
+                      conclusion: 'FAILURE'
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected request: ${method} ${url.toString()}`);
+  };
+
+  try {
+    const sync = await harness.performAction('sync.runNow', {
+      waitForCompletion: true,
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
+    }) as {
+      syncState: { status: string };
+    };
+
+    assert.equal(sync.syncState.status, 'success');
+
+    const updatedReviewReadyIssue = await originalGet(reviewReadyIssue.id, 'company-1');
+    const updatedChangesRequestedIssue = await originalGet(changesRequestedIssue.id, 'company-1');
+    const statusOnlyPatchRequests = statusPatchRequests.filter((request) => typeof request.body?.status === 'string');
+
+    assert.equal(updatedReviewReadyIssue?.status, 'in_review');
+    assert.equal(updatedReviewReadyIssue?.assigneeAgentId, 'agent-3');
+    assert.equal(updatedChangesRequestedIssue?.status, 'in_progress');
+    assert.equal(updatedChangesRequestedIssue?.assigneeAgentId, 'agent-1');
+    assert.equal(statusOnlyPatchRequests.length, 2);
+    assert.equal(statusOnlyPatchRequests.find((request) => request.issueId === reviewReadyIssue.id)?.body?.status, 'in_review');
+    assert.equal(statusOnlyPatchRequests.find((request) => request.issueId === reviewReadyIssue.id)?.body?.assigneeAgentId, 'agent-3');
+    assert.equal(statusOnlyPatchRequests.find((request) => request.issueId === changesRequestedIssue.id)?.body?.status, 'in_progress');
+    assert.equal(statusOnlyPatchRequests.find((request) => request.issueId === changesRequestedIssue.id)?.body?.assigneeAgentId, 'agent-1');
+    assert.deepEqual(
+      wakeRequests.map((request) => request.agentId).sort((left, right) => left.localeCompare(right)),
+      ['agent-1', 'agent-3']
+    );
+    assert.deepEqual(
+      wakeRequests.find((request) => request.agentId === 'agent-3')?.body?.payload,
+      {
+        issueId: reviewReadyIssue.id,
+        mutation: 'status_transition',
+        previousStatus: 'todo',
+        nextStatus: 'in_review'
+      }
+    );
+    assert.deepEqual(
+      wakeRequests.find((request) => request.agentId === 'agent-1')?.body?.payload,
+      {
+        issueId: changesRequestedIssue.id,
+        mutation: 'status_transition',
+        previousStatus: 'in_review',
+        nextStatus: 'in_progress'
+      }
+    );
+  } finally {
+    harness.ctx.issues.get = originalGet;
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('worker routes reviewer, approver, and executor fallback handoffs to a board user without waking agents', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+
+  await harness.performAction('settings.saveRegistration', {
+    companyId: 'company-1',
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    advancedSettings: {
+      defaultAssigneeUserId: 'user-import',
+      executorAssigneeUserId: 'user-executor',
+      reviewerAssigneeUserId: 'user-reviewer',
+      approverAssigneeUserId: 'user-approver',
+      defaultStatus: 'backlog',
+      ignoredIssueAuthorUsernames: []
+    },
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  const originalUpdate = harness.ctx.issues.update.bind(harness.ctx.issues);
+  const originalGet = harness.ctx.issues.get.bind(harness.ctx.issues);
+  const reviewIssue = await harness.ctx.issues.create({
+    companyId: 'company-1',
+    projectId: 'project-1',
+    title: 'Ready for reviewer fallback'
+  });
+  const approvalIssue = await harness.ctx.issues.create({
+    companyId: 'company-1',
+    projectId: 'project-1',
+    title: 'Ready for approver fallback'
+  });
+  const executorIssue = await harness.ctx.issues.create({
+    companyId: 'company-1',
+    projectId: 'project-1',
+    title: 'Needs executor fallback'
+  });
+
+  await originalUpdate(
+    reviewIssue.id,
+    {
+      status: 'todo',
+      assigneeAgentId: 'agent-review-stage',
+      executionPolicy: {
+        mode: 'normal',
+        commentRequired: true,
+        stages: [
+          {
+            id: 'review-stage',
+            type: 'review',
+            participants: [{ type: 'agent', agentId: 'agent-review-stage' }]
+          }
+        ]
+      }
+    } as never,
+    'company-1'
+  );
+  await originalUpdate(
+    approvalIssue.id,
+    {
+      status: 'todo',
+      assigneeAgentId: 'agent-approval-stage',
+      executionPolicy: {
+        mode: 'normal',
+        commentRequired: true,
+        stages: [
+          {
+            id: 'approval-stage',
+            type: 'approval',
+            participants: [{ type: 'agent', agentId: 'agent-approval-stage' }]
+          }
+        ]
+      }
+    } as never,
+    'company-1'
+  );
+  await originalUpdate(
+    executorIssue.id,
+    {
+      status: 'in_review'
+    } as never,
+    'company-1'
+  );
+
+  await harness.ctx.state.set(
+    {
+      scopeKind: 'instance',
+      stateKey: 'paperclip-github-plugin-import-registry'
+    },
+    [
+      {
+        mappingId: 'mapping-a',
+        githubIssueId: 10101,
+        githubIssueNumber: 101,
+        paperclipIssueId: reviewIssue.id,
+        importedAt: '2026-04-09T09:00:00.000Z',
+        lastSeenCommentCount: 0,
+        repositoryUrl: 'https://github.com/paperclipai/example-repo',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      },
+      {
+        mappingId: 'mapping-a',
+        githubIssueId: 10201,
+        githubIssueNumber: 102,
+        paperclipIssueId: approvalIssue.id,
+        importedAt: '2026-04-09T09:00:00.000Z',
+        lastSeenCommentCount: 0,
+        repositoryUrl: 'https://github.com/paperclipai/example-repo',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      },
+      {
+        mappingId: 'mapping-a',
+        githubIssueId: 10301,
+        githubIssueNumber: 103,
+        paperclipIssueId: executorIssue.id,
+        importedAt: '2026-04-09T09:00:00.000Z',
+        lastSeenCommentCount: 0,
+        repositoryUrl: 'https://github.com/paperclipai/example-repo',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ]
+  );
+
+  const statusPatchRequests: Array<{ issueId: string; body: Record<string, unknown> | null }> = [];
+  const wakeRequests: Array<{ agentId: string; body: Record<string, unknown> | null }> = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (input, init) => {
+    const rawUrl = getRequestUrl(input);
+    const url = new URL(rawUrl);
+    const method = (init?.method ?? 'GET').toUpperCase();
+
+    if (url.origin === 'http://127.0.0.1:63675' && url.pathname === '/api/health' && method === 'GET') {
+      return jsonResponse({
+        deploymentMode: 'local_trusted'
+      });
+    }
+
+    if (url.origin === 'http://127.0.0.1:63675' && method === 'PATCH' && url.pathname.startsWith('/api/issues/')) {
+      const issueId = url.pathname.split('/').pop() ?? '';
+      const body = getJsonRequestBody(init);
+      statusPatchRequests.push({ issueId, body });
+
+      const patch: Record<string, unknown> = {};
+      if (typeof body?.status === 'string') {
+        patch.status = body.status;
+      }
+      if (body && Object.prototype.hasOwnProperty.call(body, 'assigneeAgentId')) {
+        patch.assigneeAgentId = body.assigneeAgentId;
+      }
+      if (body && Object.prototype.hasOwnProperty.call(body, 'assigneeUserId')) {
+        patch.assigneeUserId = body.assigneeUserId;
+      }
+
+      await originalUpdate(issueId, patch as never, 'company-1');
+
+      return jsonResponse({
+        id: issueId,
+        status: body?.status ?? null,
+        assigneeAgentId: body?.assigneeAgentId ?? null,
+        assigneeUserId: body?.assigneeUserId ?? null
+      });
+    }
+
+    if (
+      url.origin === 'http://127.0.0.1:63675'
+      && method === 'POST'
+      && url.pathname.startsWith('/api/agents/')
+      && url.pathname.endsWith('/wakeup')
+    ) {
+      const agentId = url.pathname.split('/')[3] ?? '';
+      wakeRequests.push({
+        agentId,
+        body: getJsonRequestBody(init)
+      });
+
+      return jsonResponse({
+        id: `run-${wakeRequests.length}`,
+        agentId,
+        status: 'queued'
+      });
+    }
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues' && ['all', 'open'].includes(url.searchParams.get('state') ?? '')) {
+      return jsonResponse([
+        {
+          id: 10101,
+          number: 101,
+          title: 'Ready for reviewer fallback',
+          body: null,
+          html_url: 'https://github.com/paperclipai/example-repo/issues/101',
+          state: 'open',
+          comments: 0
+        },
+        {
+          id: 10201,
+          number: 102,
+          title: 'Ready for approver fallback',
+          body: null,
+          html_url: 'https://github.com/paperclipai/example-repo/issues/102',
+          state: 'open',
+          comments: 0
+        },
+        {
+          id: 10301,
+          number: 103,
+          title: 'Needs executor fallback',
+          body: null,
+          html_url: 'https://github.com/paperclipai/example-repo/issues/103',
+          state: 'open',
+          comments: 0
+        }
+      ]);
+    }
+
+    if (url.pathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      const issueNumber = typeof variables.issueNumber === 'number' ? variables.issueNumber : undefined;
+      const pullRequestNumber =
+        typeof variables.pullRequestNumber === 'number' ? variables.pullRequestNumber : undefined;
+
+      if (query.includes('query GitHubIssueParentRelationships')) {
+        return graphqlIssueParentRelationshipsResponse([
+          {
+            issueNumber: 101
+          },
+          {
+            issueNumber: 102
+          },
+          {
+            issueNumber: 103
+          }
+        ]);
+      }
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && issueNumber === 101) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: 101,
+              state: 'OPEN',
+              stateReason: null,
+              comments: {
+                totalCount: 0
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: [
+                  {
+                    number: 1010,
+                    state: 'OPEN'
+                  }
+                ]
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && issueNumber === 102) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: 102,
+              state: 'OPEN',
+              stateReason: null,
+              comments: {
+                totalCount: 0
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: [
+                  {
+                    number: 1020,
+                    state: 'OPEN'
+                  }
+                ]
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && issueNumber === 103) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: 103,
+              state: 'OPEN',
+              stateReason: null,
+              comments: {
+                totalCount: 0
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: [
+                  {
+                    number: 1030,
+                    state: 'OPEN'
+                  }
+                ]
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubPullRequestReviewThreads') && (pullRequestNumber === 1010 || pullRequestNumber === 1020 || pullRequestNumber === 1030)) {
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: [{ isResolved: true }]
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubPullRequestCiContexts') && (pullRequestNumber === 1010 || pullRequestNumber === 1020)) {
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              statusCheckRollup: {
+                contexts: {
+                  pageInfo: {
+                    hasNextPage: false,
+                    endCursor: null
+                  },
+                  nodes: [
+                    {
+                      __typename: 'StatusContext',
+                      state: 'SUCCESS'
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubPullRequestCiContexts') && pullRequestNumber === 1030) {
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              statusCheckRollup: {
+                contexts: {
+                  pageInfo: {
+                    hasNextPage: false,
+                    endCursor: null
+                  },
+                  nodes: [
+                    {
+                      __typename: 'CheckRun',
+                      status: 'COMPLETED',
+                      conclusion: 'FAILURE'
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected request: ${method} ${url.toString()}`);
+  };
+
+  try {
+    const sync = await harness.performAction('sync.runNow', {
+      waitForCompletion: true,
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
+    }) as {
+      syncState: { status: string };
+    };
+
+    assert.equal(sync.syncState.status, 'success');
+    assert.equal(wakeRequests.length, 0);
+    assert.ok(
+      statusPatchRequests.some((request) =>
+        request.issueId === reviewIssue.id
+        && request.body?.status === 'in_review'
+        && request.body?.assigneeUserId === 'user-reviewer'
+      )
+    );
+    assert.ok(
+      statusPatchRequests.some((request) =>
+        request.issueId === approvalIssue.id
+        && request.body?.status === 'in_review'
+        && request.body?.assigneeUserId === 'user-approver'
+      )
+    );
+    assert.ok(
+      statusPatchRequests.some((request) =>
+        request.issueId === executorIssue.id
+        && request.body?.status === 'in_progress'
+        && request.body?.assigneeUserId === 'user-executor'
+      )
+    );
+
+    const updatedReviewIssue = await originalGet(reviewIssue.id, 'company-1');
+    const updatedApprovalIssue = await originalGet(approvalIssue.id, 'company-1');
+    const updatedExecutorIssue = await originalGet(executorIssue.id, 'company-1');
+
+    assert.equal(updatedReviewIssue?.status, 'in_review');
+    assert.equal(updatedReviewIssue?.assigneeUserId, 'user-reviewer');
+    assert.equal(updatedApprovalIssue?.status, 'in_review');
+    assert.equal(updatedApprovalIssue?.assigneeUserId, 'user-approver');
+    assert.equal(updatedExecutorIssue?.status, 'in_progress');
+    assert.equal(updatedExecutorIssue?.assigneeUserId, 'user-executor');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('worker ignores linked pull requests from other repositories', async () => {
   const harness = createTestHarness({
     manifest,
@@ -13408,6 +14553,726 @@ test('worker falls back to the SDK bridge when the local Paperclip status PATCH 
   }
 });
 
+test('worker preserves execution-policy pending review state when the local Paperclip status PATCH returns an HTML sign-in page', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'https://board.example.com'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+  harness.ctx.http.fetch = async () => {
+    throw new Error('Local Paperclip issue API calls should use direct worker fetch, not ctx.http.fetch.');
+  };
+  harness.seed({
+    agents: [
+      createAgentFixture({
+        id: 'agent-1',
+        companyId: 'company-1',
+        name: 'Elliot',
+        title: 'Engineer'
+      }),
+      createAgentFixture({
+        id: 'agent-2',
+        companyId: 'company-1',
+        name: 'Riley',
+        title: 'Reviewer'
+      })
+    ]
+  });
+
+  await harness.performAction('settings.saveRegistration', {
+    companyId: 'company-1',
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    advancedSettings: {
+      defaultAssigneeAgentId: 'agent-1',
+      defaultStatus: 'backlog',
+      ignoredIssueAuthorUsernames: []
+    },
+    syncState: {
+      status: 'idle'
+    },
+    paperclipApiBaseUrl: 'https://board.example.com'
+  });
+
+  const originalUpdate = harness.ctx.issues.update;
+  const importedIssue = await harness.ctx.issues.create({
+    companyId: 'company-1',
+    projectId: 'project-1',
+    title: 'HTML login review fallback',
+    description: '* GitHub issue: [#43](https://github.com/paperclipai/example-repo/issues/43)\n\n---\n\nBody'
+  });
+  await originalUpdate(
+    importedIssue.id,
+    {
+      status: 'in_progress',
+      assigneeAgentId: 'agent-1',
+      executionPolicy: {
+        mode: 'normal',
+        commentRequired: true,
+        stages: [
+          {
+            id: 'review-stage',
+            type: 'review',
+            participants: [{ type: 'agent', agentId: 'agent-2' }]
+          }
+        ]
+      },
+      executionState: null
+    } as never,
+    'company-1'
+  );
+
+  await harness.ctx.state.set(
+    {
+      scopeKind: 'instance',
+      stateKey: 'paperclip-github-plugin-import-registry'
+    },
+    [
+      {
+        mappingId: 'mapping-a',
+        githubIssueId: 4301,
+        githubIssueNumber: 43,
+        paperclipIssueId: importedIssue.id,
+        importedAt: '2026-04-09T09:00:00.000Z',
+        lastSeenCommentCount: 0,
+        repositoryUrl: 'https://github.com/paperclipai/example-repo',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ]
+  );
+
+  const directStatusUpdateCalls: Array<{ issueId: string; patch: Record<string, unknown> }> = [];
+  harness.ctx.issues.update = async (issueId, patch, companyId) => {
+    directStatusUpdateCalls.push({
+      issueId,
+      patch: (patch ?? {}) as Record<string, unknown>
+    });
+
+    return originalUpdate(issueId, patch, companyId);
+  };
+
+  const patchRequests: Array<{ issueId: string; body: Record<string, unknown> | null }> = [];
+  const wakeRequests: Array<{ agentId: string; body: Record<string, unknown> | null }> = [];
+  const loginPage = '<!doctype html><html><body><h1>Sign in</h1></body></html>';
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (input, init) => {
+    const rawUrl = getRequestUrl(input);
+    const url = new URL(rawUrl);
+
+    if (url.pathname === `/api/issues/${importedIssue.id}`) {
+      patchRequests.push({
+        issueId: importedIssue.id,
+        body: getJsonRequestBody(init)
+      });
+      return htmlResponse(loginPage);
+    }
+
+    if (
+      url.pathname === '/api/agents/agent-2/wakeup'
+      && (init?.method ?? 'GET').toUpperCase() === 'POST'
+    ) {
+      wakeRequests.push({
+        agentId: 'agent-2',
+        body: getJsonRequestBody(init)
+      });
+      return jsonResponse({
+        id: 'run-review-fallback',
+        agentId: 'agent-2',
+        status: 'queued'
+      });
+    }
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues' && ['all', 'open'].includes(url.searchParams.get('state') ?? '')) {
+      return jsonResponse([
+        {
+          id: 4301,
+          number: 43,
+          title: 'HTML login review fallback',
+          body: 'Body',
+          html_url: 'https://github.com/paperclipai/example-repo/issues/43',
+          state: 'open',
+          comments: 0
+        }
+      ]);
+    }
+
+    if (url.pathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      const issueNumber = typeof variables.issueNumber === 'number' ? variables.issueNumber : undefined;
+      const pullRequestNumber =
+        typeof variables.pullRequestNumber === 'number' ? variables.pullRequestNumber : undefined;
+
+      if (query.includes('query GitHubIssueParentRelationships')) {
+        return graphqlIssueParentRelationshipsResponse([
+          {
+            issueNumber: 43
+          }
+        ]);
+      }
+
+      if (query.includes('query GitHubRepositoryOpenIssueLinkedPullRequests')) {
+        return graphqlResponse({
+          repository: {
+            issues: {
+              pageInfo: {
+                hasNextPage: false,
+                endCursor: null
+              },
+              nodes: [
+                {
+                  number: 43,
+                  closedByPullRequestsReferences: {
+                    pageInfo: {
+                      hasNextPage: false,
+                      endCursor: null
+                    },
+                    nodes: [
+                      {
+                        number: 430,
+                        state: 'OPEN'
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubRepositoryOpenPullRequestStatuses')) {
+        return graphqlResponse({
+          repository: {
+            pullRequests: {
+              pageInfo: {
+                hasNextPage: false,
+                endCursor: null
+              },
+              nodes: [
+                {
+                  number: 430,
+                  reviewThreads: {
+                    pageInfo: {
+                      hasNextPage: false,
+                      endCursor: null
+                    },
+                    nodes: [{ isResolved: true }]
+                  },
+                  statusCheckRollup: {
+                    contexts: {
+                      pageInfo: {
+                        hasNextPage: false,
+                        endCursor: null
+                      },
+                      nodes: [
+                        {
+                          __typename: 'StatusContext',
+                          state: 'SUCCESS'
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && issueNumber === 43) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: 43,
+              state: 'OPEN',
+              stateReason: null,
+              comments: {
+                totalCount: 0
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: [
+                  {
+                    number: 430,
+                    state: 'OPEN'
+                  }
+                ]
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubPullRequestReviewThreads') && pullRequestNumber === 430) {
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: [{ isResolved: true }]
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubPullRequestCiContexts') && pullRequestNumber === 430) {
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              statusCheckRollup: {
+                contexts: {
+                  pageInfo: {
+                    hasNextPage: false,
+                    endCursor: null
+                  },
+                  nodes: [
+                    {
+                      __typename: 'StatusContext',
+                      state: 'SUCCESS'
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    const sync = await harness.performAction('sync.runNow', {
+      waitForCompletion: true
+    }) as {
+      syncState: { status: string };
+    };
+
+    assert.equal(sync.syncState.status, 'success');
+    const statusPatchRequests = patchRequests.filter((request) => typeof request.body?.status === 'string');
+    const directStatusPatches = directStatusUpdateCalls.filter((call) => typeof call.patch.status === 'string');
+    assert.equal(statusPatchRequests.length, 1);
+    assert.equal(statusPatchRequests[0]?.body?.status, 'in_review');
+    assert.equal(directStatusPatches.length, 1);
+    assert.equal(directStatusPatches[0]?.patch.status, 'in_review');
+    assert.equal(directStatusPatches[0]?.patch.assigneeAgentId, 'agent-2');
+    assert.deepEqual(directStatusPatches[0]?.patch.executionState, {
+      status: 'pending',
+      currentStageId: 'review-stage',
+      currentStageIndex: 0,
+      currentStageType: 'review',
+      currentParticipant: { type: 'agent', agentId: 'agent-2', userId: null },
+      returnAssignee: { type: 'agent', agentId: 'agent-1', userId: null },
+      completedStageIds: [],
+      lastDecisionId: null,
+      lastDecisionOutcome: null
+    });
+    assert.equal(wakeRequests.length, 1);
+    assert.equal(wakeRequests[0]?.agentId, 'agent-2');
+
+    const updatedIssue = await harness.ctx.issues.get(importedIssue.id, 'company-1') as Record<string, any> | null;
+    assert.equal(updatedIssue?.status, 'in_review');
+    assert.equal(updatedIssue?.assigneeAgentId, 'agent-2');
+    assert.deepEqual(updatedIssue?.executionState, {
+      status: 'pending',
+      currentStageId: 'review-stage',
+      currentStageIndex: 0,
+      currentStageType: 'review',
+      currentParticipant: { type: 'agent', agentId: 'agent-2', userId: null },
+      returnAssignee: { type: 'agent', agentId: 'agent-1', userId: null },
+      completedStageIds: [],
+      lastDecisionId: null,
+      lastDecisionOutcome: null
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('worker preserves execution-policy changes-requested state when the local Paperclip status PATCH returns an HTML sign-in page', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'https://board.example.com'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+  harness.ctx.http.fetch = async () => {
+    throw new Error('Local Paperclip issue API calls should use direct worker fetch, not ctx.http.fetch.');
+  };
+  harness.seed({
+    agents: [
+      createAgentFixture({
+        id: 'agent-1',
+        companyId: 'company-1',
+        name: 'Elliot',
+        title: 'Engineer'
+      }),
+      createAgentFixture({
+        id: 'agent-2',
+        companyId: 'company-1',
+        name: 'Riley',
+        title: 'Reviewer'
+      })
+    ]
+  });
+
+  await harness.performAction('settings.saveRegistration', {
+    companyId: 'company-1',
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    advancedSettings: {
+      defaultAssigneeAgentId: 'agent-1',
+      defaultStatus: 'backlog',
+      ignoredIssueAuthorUsernames: []
+    },
+    syncState: {
+      status: 'idle'
+    },
+    paperclipApiBaseUrl: 'https://board.example.com'
+  });
+
+  const originalUpdate = harness.ctx.issues.update;
+  const importedIssue = await harness.ctx.issues.create({
+    companyId: 'company-1',
+    projectId: 'project-1',
+    title: 'HTML login changes requested fallback',
+    description: '* GitHub issue: [#44](https://github.com/paperclipai/example-repo/issues/44)\n\n---\n\nBody'
+  });
+  await originalUpdate(
+    importedIssue.id,
+    {
+      status: 'in_review',
+      assigneeAgentId: 'agent-2',
+      executionPolicy: {
+        mode: 'normal',
+        commentRequired: true,
+        stages: [
+          {
+            id: 'review-stage',
+            type: 'review',
+            participants: [{ type: 'agent', agentId: 'agent-2' }]
+          }
+        ]
+      },
+      executionState: {
+        status: 'pending',
+        currentStageId: 'review-stage',
+        currentStageIndex: 0,
+        currentStageType: 'review',
+        currentParticipant: { type: 'agent', agentId: 'agent-2' },
+        returnAssignee: { type: 'agent', agentId: 'agent-1' },
+        completedStageIds: []
+      }
+    } as never,
+    'company-1'
+  );
+
+  await harness.ctx.state.set(
+    {
+      scopeKind: 'instance',
+      stateKey: 'paperclip-github-plugin-import-registry'
+    },
+    [
+      {
+        mappingId: 'mapping-a',
+        githubIssueId: 4401,
+        githubIssueNumber: 44,
+        paperclipIssueId: importedIssue.id,
+        importedAt: '2026-04-09T09:00:00.000Z',
+        lastSeenCommentCount: 0,
+        repositoryUrl: 'https://github.com/paperclipai/example-repo',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ]
+  );
+
+  const directStatusUpdateCalls: Array<{ issueId: string; patch: Record<string, unknown> }> = [];
+  harness.ctx.issues.update = async (issueId, patch, companyId) => {
+    directStatusUpdateCalls.push({
+      issueId,
+      patch: (patch ?? {}) as Record<string, unknown>
+    });
+
+    return originalUpdate(issueId, patch, companyId);
+  };
+
+  const patchRequests: Array<{ issueId: string; body: Record<string, unknown> | null }> = [];
+  const wakeRequests: Array<{ agentId: string; body: Record<string, unknown> | null }> = [];
+  const loginPage = '<!doctype html><html><body><h1>Sign in</h1></body></html>';
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (input, init) => {
+    const rawUrl = getRequestUrl(input);
+    const url = new URL(rawUrl);
+
+    if (url.pathname === `/api/issues/${importedIssue.id}`) {
+      patchRequests.push({
+        issueId: importedIssue.id,
+        body: getJsonRequestBody(init)
+      });
+      return htmlResponse(loginPage);
+    }
+
+    if (
+      url.pathname === '/api/agents/agent-1/wakeup'
+      && (init?.method ?? 'GET').toUpperCase() === 'POST'
+    ) {
+      wakeRequests.push({
+        agentId: 'agent-1',
+        body: getJsonRequestBody(init)
+      });
+      return jsonResponse({
+        id: 'run-changes-fallback',
+        agentId: 'agent-1',
+        status: 'queued'
+      });
+    }
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues' && ['all', 'open'].includes(url.searchParams.get('state') ?? '')) {
+      return jsonResponse([
+        {
+          id: 4401,
+          number: 44,
+          title: 'HTML login changes requested fallback',
+          body: 'Body',
+          html_url: 'https://github.com/paperclipai/example-repo/issues/44',
+          state: 'open',
+          comments: 0
+        }
+      ]);
+    }
+
+    if (url.pathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      const issueNumber = typeof variables.issueNumber === 'number' ? variables.issueNumber : undefined;
+      const pullRequestNumber =
+        typeof variables.pullRequestNumber === 'number' ? variables.pullRequestNumber : undefined;
+
+      if (query.includes('query GitHubIssueParentRelationships')) {
+        return graphqlIssueParentRelationshipsResponse([
+          {
+            issueNumber: 44
+          }
+        ]);
+      }
+
+      if (query.includes('query GitHubRepositoryOpenIssueLinkedPullRequests')) {
+        return graphqlResponse({
+          repository: {
+            issues: {
+              pageInfo: {
+                hasNextPage: false,
+                endCursor: null
+              },
+              nodes: [
+                {
+                  number: 44,
+                  closedByPullRequestsReferences: {
+                    pageInfo: {
+                      hasNextPage: false,
+                      endCursor: null
+                    },
+                    nodes: [
+                      {
+                        number: 440,
+                        state: 'OPEN'
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubRepositoryOpenPullRequestStatuses')) {
+        return graphqlResponse({
+          repository: {
+            pullRequests: {
+              pageInfo: {
+                hasNextPage: false,
+                endCursor: null
+              },
+              nodes: [
+                {
+                  number: 440,
+                  reviewThreads: {
+                    pageInfo: {
+                      hasNextPage: false,
+                      endCursor: null
+                    },
+                    nodes: [{ isResolved: false }]
+                  },
+                  statusCheckRollup: {
+                    contexts: {
+                      pageInfo: {
+                        hasNextPage: false,
+                        endCursor: null
+                      },
+                      nodes: [
+                        {
+                          __typename: 'StatusContext',
+                          state: 'SUCCESS'
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && issueNumber === 44) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: 44,
+              state: 'OPEN',
+              stateReason: null,
+              comments: {
+                totalCount: 0
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: [
+                  {
+                    number: 440,
+                    state: 'OPEN'
+                  }
+                ]
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubPullRequestReviewThreads') && pullRequestNumber === 440) {
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: [{ isResolved: false }]
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubPullRequestCiContexts') && pullRequestNumber === 440) {
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              statusCheckRollup: {
+                contexts: {
+                  pageInfo: {
+                    hasNextPage: false,
+                    endCursor: null
+                  },
+                  nodes: [
+                    {
+                      __typename: 'StatusContext',
+                      state: 'SUCCESS'
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    const sync = await harness.performAction('sync.runNow', {
+      waitForCompletion: true
+    }) as {
+      syncState: { status: string };
+    };
+
+    assert.equal(sync.syncState.status, 'success');
+    const statusPatchRequests = patchRequests.filter((request) => typeof request.body?.status === 'string');
+    const directStatusPatches = directStatusUpdateCalls.filter((call) => typeof call.patch.status === 'string');
+    assert.equal(statusPatchRequests.length, 1);
+    assert.equal(statusPatchRequests[0]?.body?.status, 'in_progress');
+    assert.equal(directStatusPatches.length, 1);
+    assert.equal(directStatusPatches[0]?.patch.status, 'in_progress');
+    assert.equal(directStatusPatches[0]?.patch.assigneeAgentId, 'agent-1');
+    assert.deepEqual(directStatusPatches[0]?.patch.executionState, {
+      status: 'changes_requested',
+      currentStageId: 'review-stage',
+      currentStageIndex: 0,
+      currentStageType: 'review',
+      currentParticipant: { type: 'agent', agentId: 'agent-2', userId: null },
+      returnAssignee: { type: 'agent', agentId: 'agent-1', userId: null },
+      completedStageIds: [],
+      lastDecisionId: null,
+      lastDecisionOutcome: 'changes_requested'
+    });
+    assert.equal(wakeRequests.length, 1);
+    assert.equal(wakeRequests[0]?.agentId, 'agent-1');
+
+    const updatedIssue = await harness.ctx.issues.get(importedIssue.id, 'company-1') as Record<string, any> | null;
+    assert.equal(updatedIssue?.status, 'in_progress');
+    assert.equal(updatedIssue?.assigneeAgentId, 'agent-1');
+    assert.deepEqual(updatedIssue?.executionState, {
+      status: 'changes_requested',
+      currentStageId: 'review-stage',
+      currentStageIndex: 0,
+      currentStageType: 'review',
+      currentParticipant: { type: 'agent', agentId: 'agent-2', userId: null },
+      returnAssignee: { type: 'agent', agentId: 'agent-1', userId: null },
+      completedStageIds: [],
+      lastDecisionId: null,
+      lastDecisionOutcome: 'changes_requested'
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('worker moves reopened imported issues with no linked pull requests from done back to todo', async () => {
   const harness = createTestHarness({
     manifest,
@@ -13434,8 +15299,6 @@ test('worker moves reopened imported issues with no linked pull requests from do
   });
 
   const originalUpdate = harness.ctx.issues.update;
-  const originalCreateComment = harness.ctx.issues.createComment;
-
   const importedIssue = await harness.ctx.issues.create({
     companyId: 'company-1',
     projectId: 'project-1',
@@ -13463,13 +15326,6 @@ test('worker moves reopened imported issues with no linked pull requests from do
       }
     ]
   );
-
-  const transitionComments: Array<{ issueId: string; body: string }> = [];
-  harness.ctx.issues.createComment = async (issueId, body, companyId) => {
-    transitionComments.push({ issueId, body });
-    return originalCreateComment(issueId, body, companyId);
-  };
-
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input, init) => {
     const rawUrl = getRequestUrl(input);
@@ -13536,13 +15392,6 @@ test('worker moves reopened imported issues with no linked pull requests from do
 
     assert.equal(sync.syncState.status, 'success');
     assert.equal((await harness.ctx.issues.get(importedIssue.id, 'company-1'))?.status, 'todo');
-    assert.equal(transitionComments.length, 1);
-    assert.equal(transitionComments[0]?.issueId, importedIssue.id);
-    assert.match(transitionComments[0]?.body ?? '', /from `done` to `todo`/);
-    assert.match(
-      transitionComments[0]?.body ?? '',
-      /the GitHub issue is open with no linked pull requests/
-    );
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
## Summary
- align GitHub issue status sync with Paperclip execution policy, including executor/reviewer/approver handoffs and reopened issue routing
- add configurable assignee fallbacks for imported issues and sync-driven transitions, with support for either agents or the connected board user (`Me`)
- wake agent assignees explicitly on sync-driven handoffs, tighten dropdown UX/copy, and extend docs and tests around the new routing behavior

## Why
GitHub Sync was treating these transitions as largely status-only changes with agent-only fallback assignment. That could strand issues on the wrong assignee, skip execution-policy reviewer/approver semantics, and fail to hand work back to an actionable executor when GitHub activity reopened or pushed work backward.

## Impact
Operators can now choose who should receive executor, reviewer, and approver handoffs at the company level, including the connected board user, while still letting Paperclip execution policy win whenever the issue already exposes the right participant.

## Validation
- `pnpm test`
- `pnpm build`

## Model Used
- Model: `gpt-5` via Codex Desktop (the runtime did not expose a more specific model/build identifier in this session)
- Context window: not exposed by the runtime
- Capabilities: tool-assisted reasoning, local code editing, git/gh workflow, and test/build verification
