### PR TITLE
[codex] Clear execution state on terminal sync close

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If a company already has a Paperclip project bound to a GitHub repository worksp
 
 ### Status sync with delivery context
 
-The plugin does more than mirror issue text. It looks at linked pull requests, CI, review threads, and trusted new GitHub comments so imported Paperclip issues can reflect where the work actually is.
+The plugin does more than mirror issue text. It looks at linked pull requests, CI, review threads, and trusted new GitHub comments so imported Paperclip issues can reflect where the work actually is. When sync closes an imported issue as `done` or `cancelled`, it also clears any pending Paperclip review or approval execution state so the host accepts the terminal transition cleanly.
 
 ### Project pull request command center
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -100,6 +100,7 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 - An open GitHub issue with a linked PR that has green CI and all review threads resolved MUST map to Paperclip `in_review`.
 - A closed GitHub issue completed as finished work MUST map to Paperclip `done`.
 - A closed GitHub issue closed as not planned or duplicate MUST map to Paperclip `cancelled`.
+- When sync moves an imported Paperclip issue into `done` or `cancelled`, it MUST clear any pending Paperclip review or approval execution state as part of that same transition so the host does not reject the terminal status update.
 - A new GitHub issue comment on an open imported issue MUST move the corresponding Paperclip issue back into active work only when at least one newly added comment since the last sync was written by the original GitHub issue author or by a repository maintainer/admin that the worker can verify through the GitHub API, and that active-work status MUST be `in_progress` when the worker can route the issue back to an executor through execution-policy or configured handoff data and `todo` otherwise.
 - A new GitHub issue comment from any other GitHub account MUST NOT move the corresponding Paperclip issue back into active work.
 - If that Paperclip issue is currently `backlog`, trusted GitHub comments MUST still leave it in `backlog`.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -6623,6 +6623,10 @@ function buildSyncFallbackExecutionStatePatch(params: {
     return previousState ? null : undefined;
   }
 
+  if (nextStatus === 'done' || nextStatus === 'cancelled') {
+    return previousState ? null : undefined;
+  }
+
   if (nextStatus === 'in_review' && syncContext.executionPolicy) {
     const nextStageMatch = findPaperclipIssueExecutionStageMatch(syncContext.executionPolicy, previousState);
     if (!nextStageMatch) {
@@ -9626,8 +9630,15 @@ async function updatePaperclipIssueState(
   } = params;
   const trimmedTransitionComment = transitionComment.trim();
   let issueUpdated = false;
+  const syncExecutionStatePatch = buildSyncFallbackExecutionStatePatch({
+    currentStatus,
+    nextStatus,
+    syncContext,
+    nextAssignee
+  });
   const issuePatch: Record<string, unknown> = {
-    status: nextStatus
+    status: nextStatus,
+    ...(syncExecutionStatePatch === null ? { executionState: null } : {})
   };
 
   if (nextAssignee) {
@@ -9688,16 +9699,10 @@ async function updatePaperclipIssueState(
   }
 
   if (!issueUpdated) {
-    const fallbackExecutionStatePatch = buildSyncFallbackExecutionStatePatch({
-      currentStatus,
-      nextStatus,
-      syncContext,
-      nextAssignee
-    });
     const preserveExistingUserAssigneeWithoutLocalApi = nextAssignee?.kind === 'user' && !paperclipApiBaseUrl;
     const sdkIssuePatch: Record<string, unknown> = {
       ...issuePatch,
-      ...(fallbackExecutionStatePatch !== undefined ? { executionState: fallbackExecutionStatePatch } : {})
+      ...(syncExecutionStatePatch !== undefined ? { executionState: syncExecutionStatePatch } : {})
     };
 
     if (preserveExistingUserAssigneeWithoutLocalApi) {

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -14383,6 +14383,196 @@ test('worker uses the local Paperclip issue PATCH API for status transitions whe
   }
 });
 
+test('worker clears pending review and approval execution state before closing an imported issue', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubTokenRef: 'github-secret-ref',
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+  harness.ctx.http.fetch = async () => {
+    throw new Error('Local Paperclip issue API calls should use direct worker fetch, not ctx.http.fetch.');
+  };
+
+  await harness.performAction('settings.saveRegistration', {
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    syncState: {
+      status: 'idle'
+    },
+    paperclipApiBaseUrl: 'http://127.0.0.1:63675'
+  });
+
+  const originalUpdate = harness.ctx.issues.update;
+  const importedIssue = await harness.ctx.issues.create({
+    companyId: 'company-1',
+    projectId: 'project-1',
+    title: 'Blocked review issue',
+    description: 'Body\n\n<!-- paperclip-github-plugin-imported-from: https://github.com/paperclipai/example-repo/issues/45 -->'
+  });
+  await originalUpdate(
+    importedIssue.id,
+    {
+      status: 'blocked',
+      assigneeAgentId: 'agent-3',
+      executionPolicy: {
+        mode: 'normal',
+        commentRequired: true,
+        stages: [
+          {
+            id: 'review-stage',
+            type: 'review',
+            participants: [{ type: 'agent', agentId: 'agent-2' }]
+          },
+          {
+            id: 'approval-stage',
+            type: 'approval',
+            participants: [{ type: 'agent', agentId: 'agent-3' }]
+          }
+        ]
+      },
+      executionState: {
+        status: 'pending',
+        currentStageId: 'approval-stage',
+        currentStageIndex: 1,
+        currentStageType: 'approval',
+        currentParticipant: { type: 'agent', agentId: 'agent-3' },
+        returnAssignee: { type: 'agent', agentId: 'agent-1' },
+        completedStageIds: ['review-stage']
+      }
+    } as never,
+    'company-1'
+  );
+
+  await harness.ctx.state.set(
+    {
+      scopeKind: 'instance',
+      stateKey: 'paperclip-github-plugin-import-registry'
+    },
+    [
+      {
+        mappingId: 'mapping-a',
+        githubIssueId: 4501,
+        githubIssueNumber: 45,
+        paperclipIssueId: importedIssue.id,
+        importedAt: '2026-04-09T09:00:00.000Z',
+        lastSeenCommentCount: 0,
+        repositoryUrl: 'https://github.com/paperclipai/example-repo',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ]
+  );
+
+  const directStatusUpdateCalls: Array<{ issueId: string; patch: Record<string, unknown> }> = [];
+  harness.ctx.issues.update = async (issueId, patch, companyId) => {
+    if (patch && typeof patch === 'object' && 'status' in patch) {
+      directStatusUpdateCalls.push({
+        issueId,
+        patch: (patch ?? {}) as Record<string, unknown>
+      });
+    }
+
+    return originalUpdate(issueId, patch, companyId);
+  };
+
+  const patchRequests: Array<{ issueId: string; body: Record<string, unknown> | null }> = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (input, init) => {
+    const rawUrl = getRequestUrl(input);
+    const url = new URL(rawUrl);
+
+    if (url.pathname === `/api/issues/${importedIssue.id}`) {
+      const method = typeof input === 'string' || input instanceof URL ? init?.method : input.method;
+      assert.equal(method, 'PATCH');
+
+      const body = getJsonRequestBody(init);
+      patchRequests.push({
+        issueId: importedIssue.id,
+        body
+      });
+
+      if (body?.status === 'done') {
+        if (!Object.prototype.hasOwnProperty.call(body, 'executionState') || body.executionState !== null) {
+          return jsonResponse({
+            error: 'Clear reviewers and approvers before closing the issue.'
+          }, 422);
+        }
+
+        await originalUpdate(importedIssue.id, {
+          status: 'done',
+          executionState: null
+        } as never, 'company-1');
+      }
+
+      const updated = await harness.ctx.issues.get(importedIssue.id, 'company-1');
+      return jsonResponse(updated ?? {});
+    }
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues' && ['all', 'open'].includes(url.searchParams.get('state') ?? '')) {
+      return jsonResponse([
+        {
+          id: 4501,
+          number: 45,
+          title: 'Blocked review issue',
+          body: 'Body',
+          html_url: 'https://github.com/paperclipai/example-repo/issues/45',
+          state: 'closed',
+          state_reason: 'completed',
+          comments: 0
+        }
+      ]);
+    }
+
+    if (url.pathname === '/graphql') {
+      const { query } = getGraphqlRequest(init);
+
+      if (query.includes('query GitHubIssueParentRelationships')) {
+        return graphqlIssueParentRelationshipsResponse([
+          {
+            issueNumber: 45
+          }
+        ]);
+      }
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    const sync = await harness.performAction('sync.runNow', {
+      waitForCompletion: true
+    }) as {
+      syncState: { status: string };
+    };
+
+    assert.equal(sync.syncState.status, 'success');
+    const statusPatchRequests = patchRequests.filter((request) => typeof request.body?.status === 'string');
+    assert.equal(statusPatchRequests.length, 1);
+    assert.equal(statusPatchRequests[0]?.issueId, importedIssue.id);
+    assert.equal(statusPatchRequests[0]?.body?.status, 'done');
+    assert.equal(Object.prototype.hasOwnProperty.call(statusPatchRequests[0]?.body ?? {}, 'executionState'), true);
+    assert.equal(statusPatchRequests[0]?.body?.executionState, null);
+    assert.equal(directStatusUpdateCalls.length, 0);
+
+    const updatedIssue = await harness.ctx.issues.get(importedIssue.id, 'company-1') as Record<string, any> | null;
+    assert.equal(updatedIssue?.status, 'done');
+    assert.equal(updatedIssue?.executionState ?? null, null);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('comment.annotation falls back to GitHub links found in plain issue comments', async () => {
   const harness = createTestHarness({
     manifest


### PR DESCRIPTION
## Summary
- clear stale execution state when sync closes imported issues as `done` or `cancelled`
- preserve the same clear in the SDK fallback path and cover it with a regression test
- document the terminal-transition requirement in the README and SPEC

## Root Cause
Paperclip rejects terminal status transitions when stale review or approval execution state is still attached to the issue. GitHub Sync was updating the status without explicitly clearing that pending execution state, so blocked issues closed from GitHub could be rejected when transitioning to `done`.

## Testing
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Model Used
- Model ID/version: unavailable in this Codex Desktop runtime (GPT-5-based coding agent)
- Context window size: unavailable in this runtime
- Capability details: medium reasoning, terminal tool use, patch application, and automation setup
