### PR TITLE
[codex] Handle non-mergeable linked PR sync states

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If a company already has a Paperclip project bound to a GitHub repository worksp
 
 ### Status sync with delivery context
 
-The plugin does more than mirror issue text. It looks at linked pull requests, CI, review threads, and trusted new GitHub comments so imported Paperclip issues can reflect where the work actually is. When GitHub links an issue to a pull request in another repository, GitHub Sync now follows that pull request's actual repository for status checks, review-thread state, and deep links instead of assuming the issue repository. When sync closes an imported issue as `done` or `cancelled`, it also clears any pending Paperclip review or approval execution state so the host accepts the terminal transition cleanly.
+The plugin does more than mirror issue text. It looks at linked pull requests, mergeability, CI, review threads, and trusted new GitHub comments so imported Paperclip issues can reflect where the work actually is. When GitHub links an issue to a pull request in another repository, GitHub Sync now follows that pull request's actual repository for status checks, review-thread state, and deep links instead of assuming the issue repository. When sync closes an imported issue as `done` or `cancelled`, it also clears any pending Paperclip review or approval execution state so the host accepts the terminal transition cleanly.
 
 ### Project pull request command center
 
@@ -138,8 +138,8 @@ When the local Paperclip API is available, the plugin also syncs labels by name,
 | Open issue with no linked pull request, created by a repository maintainer | `todo` on first import |
 | Open issue with no linked pull request | Configured default status, which defaults to `backlog` |
 | Open issue with a linked pull request and unfinished CI | `in_progress` |
-| Open issue with failing CI or unresolved review threads | `todo`, or `in_progress` when GitHub Sync can hand the work back to an executor |
-| Open issue with green CI and all review threads resolved | `in_review` |
+| Open issue with failing CI, a non-mergeable linked pull request, or unresolved review threads | `todo`, or `in_progress` when GitHub Sync can hand the work back to an executor |
+| Open issue with green CI, a merge-ready linked pull request, and all review threads resolved | `in_review` |
 | Closed issue completed as finished work | `done` |
 | Closed issue closed as `not_planned` or `duplicate` | `cancelled` |
 
@@ -148,6 +148,7 @@ Additional behavior:
 - Open issues with no linked pull request that are created by a verified repository maintainer/admin bypass the default imported status and start in `todo`.
 - When Paperclip board access is connected for a company, the advanced assignee dropdowns list both company agents and `Me` for the connected board user.
 - Newly imported issues that finish sync in `todo` and are assigned to an agent enqueue an assignee wakeup so the agent can pick them up promptly.
+- For linked pull requests, GitHub Sync treats merge-conflict, behind-branch, blocked, draft, and unstable merge states as executor work, while merge-ready states such as `CLEAN` and `HAS_HOOKS` can move work into `in_review` when CI and review threads are also clear.
 - When sync moves work into `in_review`, GitHub Sync first follows the Paperclip issue execution policy's current reviewer or approver when that stage is visible on the issue. If Paperclip exposes an internal review or approval stage but not yet the participant, the plugin falls back to the configured reviewer or approver handoff assignee. If the transition is only a healthy linked-PR wait with no visible internal review or approval stage, GitHub Sync leaves the issue unassigned so it can wait on normal maintainer review without waking an internal owner.
 - When sync moves work back into active execution, GitHub Sync first follows the Paperclip issue execution policy `returnAssignee` when it is available. Otherwise it falls back to the configured executor handoff assignee and then to the default imported assignee.
 - Sync-driven handoffs to agent assignees best-effort enqueue an explicit wakeup so the next reviewer, approver, or executor can pick the issue up even when their agent is not running heartbeats.

--- a/SPEC.md
+++ b/SPEC.md
@@ -96,8 +96,9 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 - If a Paperclip issue that came from an open GitHub issue without a linked PR is later moved out of `backlog`, the sync flow SHOULD preserve that Paperclip status until another open-issue GitHub rule applies.
 - If that Paperclip issue is currently `done` or `cancelled` while the linked GitHub issue is open with no linked PR, the sync flow MUST move it to `todo` instead of `backlog` so it re-enters the active queue.
 - An open GitHub issue with a linked PR that still has unfinished CI jobs MUST map to Paperclip `in_progress`.
-- An open GitHub issue with a linked PR that has red CI jobs or unresolved review threads MUST map to Paperclip `todo`, unless the worker can route the issue back to an executor through execution-policy or configured handoff data, in which case it MUST map to `in_progress`.
-- An open GitHub issue with a linked PR that has green CI and all review threads resolved MUST map to Paperclip `in_review`.
+- An open GitHub issue with a linked PR that has red CI jobs, an action-required GitHub merge state such as `CONFLICTING`, `DIRTY`, `BEHIND`, `BLOCKED`, `DRAFT`, or `UNSTABLE`, or unresolved review threads MUST map to Paperclip `todo`, unless the worker can route the issue back to an executor through execution-policy or configured handoff data, in which case it MUST map to `in_progress`.
+- An open GitHub issue with a linked PR that has green CI, a review-ready GitHub merge state such as `CLEAN` or `HAS_HOOKS`, and all review threads resolved MUST map to Paperclip `in_review`.
+- An open GitHub issue with a linked PR in GitHub merge state `UNKNOWN` MUST NOT be treated as review-ready; when no failing CI or unresolved review-thread rule applies, the worker SHOULD keep the issue in active execution until GitHub resolves mergeability.
 - Linked pull requests MAY live in a different GitHub repository than the linked issue, and the worker MUST evaluate CI, review-thread state, stored link metadata, and rendered GitHub deep links against each pull request's actual repository instead of assuming the issue repository.
 - A closed GitHub issue completed as finished work MUST map to Paperclip `done`.
 - A closed GitHub issue closed as not planned or duplicate MUST map to Paperclip `cancelled`.

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -12380,7 +12380,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
                     />
                     <p className="ghsync__hint">
                       The assignee that resumes work when GitHub Sync sends an issue back to active execution, such as failing CI,
-                      unresolved review threads, or a trusted new GitHub comment.
+                      non-mergeable linked pull requests, unresolved review threads, or a trusted new GitHub comment.
                     </p>
                   </div>
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1534,6 +1534,7 @@ const GITHUB_PROJECT_PULL_REQUEST_SUMMARY_FIELDS =
 const GITHUB_PROJECT_PULL_REQUEST_METRICS_FIELDS = `
           number
           mergeable
+          mergeStateStatus
           baseRefName
           reviews(first: 100) {
             pageInfo {
@@ -6792,7 +6793,7 @@ function describeGitHubStatusTransitionReason(params: {
   )];
   const hasUnfinishedCi = snapshot.linkedPullRequests.some((pullRequest) => pullRequest.ciState === 'unfinished');
   const hasUnknownMergeability = snapshot.linkedPullRequests.some(
-    (pullRequest) => pullRequest.mergeStateStatus === 'unknown' && pullRequest.mergeability !== 'mergeable'
+    (pullRequest) => pullRequest.mergeStateStatus === 'unknown'
   );
 
   if (blockingConditions.length > 0) {
@@ -7131,8 +7132,7 @@ function isGitHubPullRequestReviewReadyForSync(
     return false;
   }
 
-  return REVIEW_READY_GITHUB_PULL_REQUEST_MERGE_STATE_STATUSES.has(pullRequest.mergeStateStatus)
-    || (pullRequest.mergeStateStatus === 'unknown' && pullRequest.mergeability === 'mergeable');
+  return REVIEW_READY_GITHUB_PULL_REQUEST_MERGE_STATE_STATUSES.has(pullRequest.mergeStateStatus);
 }
 
 function listGitHubPullRequestSyncBlockingConditions(

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -631,6 +631,16 @@ type GitHubApiIssueLabelRecord =
 
 type GitHubIssueStateReason = 'completed' | 'not_planned' | 'duplicate';
 type GitHubPullRequestCiState = 'green' | 'red' | 'unfinished';
+type GitHubPullRequestMergeability = 'mergeable' | 'conflicting' | 'unknown';
+type GitHubPullRequestMergeStateStatus =
+  | 'behind'
+  | 'blocked'
+  | 'clean'
+  | 'dirty'
+  | 'draft'
+  | 'has_hooks'
+  | 'unknown'
+  | 'unstable';
 
 interface GitHubPullRequestReference {
   number: number;
@@ -644,6 +654,8 @@ interface GitHubLinkedPullRequestRecord extends GitHubPullRequestReference {
 interface GitHubPullRequestStatusSnapshot extends GitHubPullRequestReference {
   hasUnresolvedReviewThreads: boolean;
   ciState: GitHubPullRequestCiState;
+  mergeability: GitHubPullRequestMergeability;
+  mergeStateStatus: GitHubPullRequestMergeStateStatus;
 }
 
 interface GitHubIssueStatusSnapshot {
@@ -701,6 +713,8 @@ interface GitHubPullRequestReviewThreadsQueryResult {
 interface GitHubPullRequestCiContextsQueryResult {
   repository?: {
     pullRequest?: {
+      mergeable?: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN' | null;
+      mergeStateStatus?: string | null;
       statusCheckRollup?: {
         contexts?: {
           pageInfo?: GitHubPageInfo | null;
@@ -752,6 +766,8 @@ interface GitHubRepositoryOpenPullRequestStatusesQueryResult {
       pageInfo?: GitHubPageInfo | null;
       nodes?: Array<{
         number?: number | null;
+        mergeable?: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN' | null;
+        mergeStateStatus?: string | null;
         reviewThreads?: {
           pageInfo?: GitHubPageInfo | null;
           nodes?: Array<{
@@ -1163,6 +1179,7 @@ interface GitHubProjectPullRequestMetricsQueryResult {
       nodes?: Array<{
         number?: number | null;
         mergeable?: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN' | null;
+        mergeStateStatus?: string | null;
         baseRefName?: string | null;
         reviews?: {
           pageInfo?: GitHubPageInfo | null;
@@ -1253,6 +1270,17 @@ const PENDING_STATUS_CONTEXT_STATES = new Set(['EXPECTED', 'PENDING']);
 const GITHUB_REPOSITORY_MAINTAINER_WARMUP_CONCURRENCY = 4;
 const GITHUB_REPOSITORY_MAINTAINER_ROLE_NAMES = new Set(['admin', 'maintain']);
 const GITHUB_REPOSITORY_TRUSTED_AUTHOR_ASSOCIATIONS = new Set(['collaborator', 'member', 'owner']);
+const ACTION_REQUIRED_GITHUB_PULL_REQUEST_MERGE_STATE_STATUSES = new Set<GitHubPullRequestMergeStateStatus>([
+  'behind',
+  'blocked',
+  'dirty',
+  'draft',
+  'unstable'
+]);
+const REVIEW_READY_GITHUB_PULL_REQUEST_MERGE_STATE_STATUSES = new Set<GitHubPullRequestMergeStateStatus>([
+  'clean',
+  'has_hooks'
+]);
 
 const GITHUB_ISSUE_STATUS_SNAPSHOT_QUERY = `
   query GitHubIssueStatusSnapshot($owner: String!, $repo: String!, $issueNumber: Int!, $after: String) {
@@ -1307,6 +1335,8 @@ const GITHUB_PULL_REQUEST_CI_CONTEXTS_QUERY = `
   query GitHubPullRequestCiContexts($owner: String!, $repo: String!, $pullRequestNumber: Int!, $after: String) {
     repository(owner: $owner, name: $repo) {
       pullRequest(number: $pullRequestNumber) {
+        mergeable
+        mergeStateStatus
         statusCheckRollup {
           contexts(first: 100, after: $after) {
             pageInfo {
@@ -1372,6 +1402,8 @@ const GITHUB_REPOSITORY_OPEN_PULL_REQUEST_STATUSES_QUERY = `
         }
         nodes {
           number
+          mergeable
+          mergeStateStatus
           reviewThreads(first: 100) {
             pageInfo {
               hasNextPage
@@ -6136,15 +6168,20 @@ function resolvePaperclipStatusFromLinkedPullRequests(
     preferInProgress?: boolean;
   }
 ): PaperclipIssueStatus {
-  if (linkedPullRequests.some((pullRequest) => pullRequest.hasUnresolvedReviewThreads || pullRequest.ciState === 'red')) {
+  if (
+    linkedPullRequests.some(
+      (pullRequest) =>
+        pullRequest.hasUnresolvedReviewThreads
+        || pullRequest.ciState === 'red'
+        || isGitHubPullRequestActionRequiredForSync(pullRequest)
+    )
+  ) {
     return options?.preferInProgress ? 'in_progress' : 'todo';
   }
 
   if (
     linkedPullRequests.length > 0 &&
-    linkedPullRequests.every(
-      (pullRequest) => pullRequest.ciState === 'green' && pullRequest.hasUnresolvedReviewThreads === false
-    )
+    linkedPullRequests.every((pullRequest) => isGitHubPullRequestReviewReadyForSync(pullRequest))
   ) {
     return 'in_review';
   }
@@ -6750,24 +6787,24 @@ function describeGitHubStatusTransitionReason(params: {
 
   const linkedPullRequestSubject = snapshot.linkedPullRequests.length === 1 ? 'the linked pull request' : 'linked pull requests';
   const linkedPullRequestVerb = snapshot.linkedPullRequests.length === 1 ? 'has' : 'have';
-  const hasRedCi = snapshot.linkedPullRequests.some((pullRequest) => pullRequest.ciState === 'red');
-  const hasUnresolvedReviewThreads = snapshot.linkedPullRequests.some((pullRequest) => pullRequest.hasUnresolvedReviewThreads);
+  const blockingConditions = [...new Set(
+    snapshot.linkedPullRequests.flatMap((pullRequest) => listGitHubPullRequestSyncBlockingConditions(pullRequest))
+  )];
   const hasUnfinishedCi = snapshot.linkedPullRequests.some((pullRequest) => pullRequest.ciState === 'unfinished');
+  const hasUnknownMergeability = snapshot.linkedPullRequests.some(
+    (pullRequest) => pullRequest.mergeStateStatus === 'unknown' && pullRequest.mergeability !== 'mergeable'
+  );
 
-  if (hasRedCi && hasUnresolvedReviewThreads) {
-    return `${linkedPullRequestSubject} ${linkedPullRequestVerb} failing CI with unresolved review threads`;
-  }
-
-  if (hasRedCi) {
-    return `${linkedPullRequestSubject} ${linkedPullRequestVerb} failing CI`;
-  }
-
-  if (hasUnresolvedReviewThreads) {
-    return `${linkedPullRequestSubject} ${linkedPullRequestVerb} unresolved review threads`;
+  if (blockingConditions.length > 0) {
+    return `${linkedPullRequestSubject} ${linkedPullRequestVerb} ${formatPlainTextList(blockingConditions)}`;
   }
 
   if (hasUnfinishedCi) {
     return `${linkedPullRequestSubject} still ${linkedPullRequestVerb} unfinished CI jobs`;
+  }
+
+  if (hasUnknownMergeability) {
+    return `${linkedPullRequestSubject} ${linkedPullRequestVerb} unknown mergeability`;
   }
 
   return `${linkedPullRequestSubject} ${linkedPullRequestVerb} green CI with all review threads resolved`;
@@ -7047,8 +7084,98 @@ function extractGitHubCiContextRecords(
   return contexts;
 }
 
+function normalizeGitHubPullRequestMergeability(value: unknown): GitHubPullRequestMergeability {
+  if (value === 'MERGEABLE') {
+    return 'mergeable';
+  }
+
+  if (value === 'CONFLICTING') {
+    return 'conflicting';
+  }
+
+  return 'unknown';
+}
+
+function normalizeGitHubPullRequestMergeStateStatus(value: unknown): GitHubPullRequestMergeStateStatus {
+  switch (typeof value === 'string' ? value.trim().toLowerCase() : '') {
+    case 'behind':
+      return 'behind';
+    case 'blocked':
+      return 'blocked';
+    case 'clean':
+      return 'clean';
+    case 'dirty':
+      return 'dirty';
+    case 'draft':
+      return 'draft';
+    case 'has_hooks':
+      return 'has_hooks';
+    case 'unstable':
+      return 'unstable';
+    default:
+      return 'unknown';
+  }
+}
+
+function isGitHubPullRequestActionRequiredForSync(
+  pullRequest: Pick<GitHubPullRequestStatusSnapshot, 'mergeability' | 'mergeStateStatus'>
+): boolean {
+  return pullRequest.mergeability === 'conflicting'
+    || ACTION_REQUIRED_GITHUB_PULL_REQUEST_MERGE_STATE_STATUSES.has(pullRequest.mergeStateStatus);
+}
+
+function isGitHubPullRequestReviewReadyForSync(
+  pullRequest: Pick<GitHubPullRequestStatusSnapshot, 'ciState' | 'hasUnresolvedReviewThreads' | 'mergeability' | 'mergeStateStatus'>
+): boolean {
+  if (pullRequest.ciState !== 'green' || pullRequest.hasUnresolvedReviewThreads) {
+    return false;
+  }
+
+  return REVIEW_READY_GITHUB_PULL_REQUEST_MERGE_STATE_STATUSES.has(pullRequest.mergeStateStatus)
+    || (pullRequest.mergeStateStatus === 'unknown' && pullRequest.mergeability === 'mergeable');
+}
+
+function listGitHubPullRequestSyncBlockingConditions(
+  pullRequest: Pick<GitHubPullRequestStatusSnapshot, 'ciState' | 'hasUnresolvedReviewThreads' | 'mergeability' | 'mergeStateStatus'>
+): string[] {
+  const conditions: string[] = [];
+
+  if (pullRequest.ciState === 'red') {
+    conditions.push('failing CI');
+  }
+
+  if (pullRequest.mergeability === 'conflicting' || pullRequest.mergeStateStatus === 'dirty') {
+    conditions.push('merge conflicts');
+  } else {
+    switch (pullRequest.mergeStateStatus) {
+      case 'behind':
+        conditions.push('out-of-date branch state');
+        break;
+      case 'blocked':
+        conditions.push('blocked merge requirements');
+        break;
+      case 'draft':
+        conditions.push('draft status');
+        break;
+      case 'unstable':
+        conditions.push('unstable merge requirements');
+        break;
+      default:
+        break;
+    }
+  }
+
+  if (pullRequest.hasUnresolvedReviewThreads) {
+    conditions.push('unresolved review threads');
+  }
+
+  return conditions;
+}
+
 function tryBuildGitHubPullRequestStatusSnapshotFromBatchNode(node: {
   number?: number | null;
+  mergeable?: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN' | null;
+  mergeStateStatus?: string | null;
   reviewThreads?: {
     pageInfo?: GitHubPageInfo | null;
     nodes?: Array<{
@@ -7089,7 +7216,9 @@ function tryBuildGitHubPullRequestStatusSnapshotFromBatchNode(node: {
     number: node.number,
     repositoryUrl: repository.url,
     hasUnresolvedReviewThreads: reviewThreadSummary.unresolvedReviewThreads > 0,
-    ciState
+    ciState,
+    mergeability: normalizeGitHubPullRequestMergeability(node.mergeable),
+    mergeStateStatus: normalizeGitHubPullRequestMergeStateStatus(node.mergeStateStatus)
   };
 }
 
@@ -7178,7 +7307,21 @@ async function getGitHubPullRequestCiState(
   repository: ParsedRepositoryReference,
   pullRequestNumber: number
 ): Promise<GitHubPullRequestCiState> {
+  return (await getGitHubPullRequestCiSnapshot(octokit, repository, pullRequestNumber)).ciState;
+}
+
+async function getGitHubPullRequestCiSnapshot(
+  octokit: Octokit,
+  repository: ParsedRepositoryReference,
+  pullRequestNumber: number
+): Promise<{
+  ciState: GitHubPullRequestCiState;
+  mergeability: GitHubPullRequestMergeability;
+  mergeStateStatus: GitHubPullRequestMergeStateStatus;
+}> {
   const contexts: GitHubCiContextRecord[] = [];
+  let mergeability: GitHubPullRequestMergeability = 'unknown';
+  let mergeStateStatus: GitHubPullRequestMergeStateStatus = 'unknown';
   let after: string | undefined;
 
   do {
@@ -7188,6 +7331,9 @@ async function getGitHubPullRequestCiState(
       pullRequestNumber,
       after
     });
+
+    mergeability = normalizeGitHubPullRequestMergeability(response.repository?.pullRequest?.mergeable);
+    mergeStateStatus = normalizeGitHubPullRequestMergeStateStatus(response.repository?.pullRequest?.mergeStateStatus);
 
     const connection = response.repository?.pullRequest?.statusCheckRollup?.contexts;
     const nodes = connection?.nodes ?? [];
@@ -7216,7 +7362,11 @@ async function getGitHubPullRequestCiState(
     after = getPageCursor(connection?.pageInfo);
   } while (after);
 
-  return classifyGitHubPullRequestCiState(contexts);
+  return {
+    ciState: classifyGitHubPullRequestCiState(contexts),
+    mergeability,
+    mergeStateStatus
+  };
 }
 
 async function getGitHubPullRequestStatusSnapshot(
@@ -7227,6 +7377,8 @@ async function getGitHubPullRequestStatusSnapshot(
   options?: {
     reviewThreadSummary?: GitHubProjectPullRequestReviewThreadSummary | null;
     ciState?: GitHubPullRequestCiState | null;
+    mergeability?: GitHubPullRequestMergeability;
+    mergeStateStatus?: GitHubPullRequestMergeStateStatus;
   }
 ): Promise<GitHubPullRequestStatusSnapshot> {
   const cached = getCachedGitHubPullRequestStatusSnapshot(pullRequestStatusCache, repository, pullRequestNumber);
@@ -7241,12 +7393,19 @@ async function getGitHubPullRequestStatusSnapshot(
     return cachedSnapshot;
   }
 
-  if (options?.reviewThreadSummary && options.ciState) {
+  if (
+    options?.reviewThreadSummary
+    && options.ciState
+    && options.mergeability !== undefined
+    && options.mergeStateStatus !== undefined
+  ) {
     const snapshot = cacheGitHubPullRequestStatusSnapshot(repository, {
       number: pullRequestNumber,
       repositoryUrl: repository.url,
       hasUnresolvedReviewThreads: options.reviewThreadSummary.unresolvedReviewThreads > 0,
-      ciState: options.ciState
+      ciState: options.ciState,
+      mergeability: options.mergeability,
+      mergeStateStatus: options.mergeStateStatus
     });
     setCachedGitHubPullRequestStatusSnapshot(pullRequestStatusCache, snapshot);
     return snapshot;
@@ -7260,17 +7419,25 @@ async function getGitHubPullRequestStatusSnapshot(
   }
 
   const loadSnapshotPromise = (async () => {
-    const [reviewThreadSummary, ciState] = await Promise.all([
+    const [reviewThreadSummary, ciSnapshot] = await Promise.all([
       options?.reviewThreadSummary
         ?? getOrLoadCachedGitHubPullRequestReviewThreadSummary(octokit, repository, pullRequestNumber),
-      options?.ciState ?? getGitHubPullRequestCiState(octokit, repository, pullRequestNumber)
+      options?.ciState && options.mergeability !== undefined && options.mergeStateStatus !== undefined
+        ? {
+            ciState: options.ciState,
+            mergeability: options.mergeability,
+            mergeStateStatus: options.mergeStateStatus
+          }
+        : getGitHubPullRequestCiSnapshot(octokit, repository, pullRequestNumber)
     ]);
 
     return cacheGitHubPullRequestStatusSnapshot(repository, {
       number: pullRequestNumber,
       repositoryUrl: repository.url,
       hasUnresolvedReviewThreads: reviewThreadSummary.unresolvedReviewThreads > 0,
-      ciState
+      ciState: ciSnapshot.ciState,
+      mergeability: ciSnapshot.mergeability,
+      mergeStateStatus: ciSnapshot.mergeStateStatus
     });
   })();
   activeGitHubPullRequestStatusSnapshotPromiseCache.set(cacheKey, loadSnapshotPromise);
@@ -7717,6 +7884,22 @@ function formatMarkdownLinkList(links: string[]): string {
   }
 
   return `${links.slice(0, -1).join(', ')}, and ${links.at(-1)}`;
+}
+
+function formatPlainTextList(items: string[]): string {
+  if (items.length === 0) {
+    return '';
+  }
+
+  if (items.length === 1) {
+    return items[0];
+  }
+
+  if (items.length === 2) {
+    return `${items[0]} and ${items[1]}`;
+  }
+
+  return `${items.slice(0, -1).join(', ')}, and ${items.at(-1)}`;
 }
 
 function formatGitHubPullRequestReferences(
@@ -12527,6 +12710,8 @@ async function buildProjectPullRequestSummaryRecord(
   const inlineCiState = tryBuildGitHubPullRequestCiStateFromBatchNode({
     statusCheckRollup: node.statusCheckRollup
   });
+  const inlineMergeability = normalizeGitHubPullRequestMergeability(node.mergeable);
+  const inlineMergeStateStatus = normalizeGitHubPullRequestMergeStateStatus(node.mergeStateStatus);
   const [reviewThreadSummary, reviewSummary, statusSnapshot, behindBy] = await Promise.all([
     getOrLoadCachedGitHubPullRequestReviewThreadSummary(
       octokit,
@@ -12542,7 +12727,9 @@ async function buildProjectPullRequestSummaryRecord(
     ),
     getGitHubPullRequestStatusSnapshot(octokit, repository, node.number, pullRequestStatusCache, {
       reviewThreadSummary: inlineReviewThreadSummary,
-      ciState: inlineCiState
+      ciState: inlineCiState,
+      mergeability: inlineMergeability,
+      mergeStateStatus: inlineMergeStateStatus
     }),
     getGitHubPullRequestBehindCount(octokit, repository, {
       baseBranch: node.baseRefName,
@@ -12730,6 +12917,8 @@ async function buildProjectPullRequestMetricCounts(
   const inlineCiState = tryBuildGitHubPullRequestCiStateFromBatchNode({
     statusCheckRollup: node.statusCheckRollup
   });
+  const inlineMergeability = normalizeGitHubPullRequestMergeability(node.mergeable);
+  const inlineMergeStateStatus = normalizeGitHubPullRequestMergeStateStatus(node.mergeStateStatus);
   const [reviewThreadSummary, reviewSummary, statusSnapshot] = await Promise.all([
     getOrLoadCachedGitHubPullRequestReviewThreadSummary(
       octokit,
@@ -12745,7 +12934,9 @@ async function buildProjectPullRequestMetricCounts(
     ),
     getGitHubPullRequestStatusSnapshot(octokit, repository, node.number, pullRequestStatusCache, {
       reviewThreadSummary: inlineReviewThreadSummary,
-      ciState: inlineCiState
+      ciState: inlineCiState,
+      mergeability: inlineMergeability,
+      mergeStateStatus: inlineMergeStateStatus
     })
   ]);
   const checksStatus =

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -13638,7 +13638,7 @@ test('worker maps GitHub issue and linked PR state onto Paperclip statuses while
   }
 });
 
-test('worker treats action-required GitHub merge state statuses as executor work', async () => {
+test('worker routes non-review-ready GitHub merge state statuses back to active execution', async () => {
   const harness = createTestHarness({
     manifest,
     config: {
@@ -13728,6 +13728,15 @@ test('worker treats action-required GitHub merge state statuses as executor work
       pullRequestNumber: 450,
       title: 'Unknown mergeability',
       mergeable: 'UNKNOWN' as const,
+      mergeStateStatus: 'UNKNOWN',
+      expectedReason: /unknown mergeability/
+    },
+    {
+      githubIssueId: 4601,
+      githubIssueNumber: 46,
+      pullRequestNumber: 460,
+      title: 'Merge state still resolving',
+      mergeable: 'MERGEABLE' as const,
       mergeStateStatus: 'UNKNOWN',
       expectedReason: /unknown mergeability/
     }

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -13111,6 +13111,7 @@ test('worker maps GitHub issue and linked PR state onto Paperclip statuses while
   const pendingCiIssue = await makePaperclipIssue('Pending CI', 'backlog');
   const redCiIssue = await makePaperclipIssue('Red CI', 'backlog');
   const unresolvedThreadIssue = await makePaperclipIssue('Unresolved review thread', 'backlog');
+  const conflictingPullRequestIssue = await makePaperclipIssue('Merge conflict', 'in_review');
   const greenReviewIssue = await makePaperclipIssue('Green review', 'todo');
   const completedIssue = await makePaperclipIssue('Completed', 'backlog');
   const notPlannedIssue = await makePaperclipIssue('Not planned', 'backlog');
@@ -13175,6 +13176,14 @@ test('worker maps GitHub issue and linked PR state onto Paperclip statuses while
         githubIssueId: 3007,
         githubIssueNumber: 35,
         paperclipIssueId: greenReviewIssue.id,
+        importedAt: '2026-04-09T09:00:00.000Z',
+        lastSeenCommentCount: 0
+      },
+      {
+        mappingId: 'mapping-a',
+        githubIssueId: 3011,
+        githubIssueNumber: 40,
+        paperclipIssueId: conflictingPullRequestIssue.id,
         importedAt: '2026-04-09T09:00:00.000Z',
         lastSeenCommentCount: 0
       },
@@ -13276,6 +13285,15 @@ test('worker maps GitHub issue and linked PR state onto Paperclip statuses while
       comments: 0
     },
     {
+      id: 3011,
+      number: 40,
+      title: 'Merge conflict',
+      body: null,
+      html_url: 'https://github.com/paperclipai/example-repo/issues/40',
+      state: 'open',
+      comments: 0
+    },
+    {
       id: 3008,
       number: 36,
       title: 'Completed',
@@ -13315,6 +13333,7 @@ test('worker maps GitHub issue and linked PR state onto Paperclip statuses while
     [33, { state: 'OPEN', stateReason: null, comments: 0, linkedPullRequests: [330] }],
     [34, { state: 'OPEN', stateReason: null, comments: 0, linkedPullRequests: [340] }],
     [35, { state: 'OPEN', stateReason: null, comments: 0, linkedPullRequests: [350] }],
+    [40, { state: 'OPEN', stateReason: null, comments: 0, linkedPullRequests: [400] }],
     [36, { state: 'CLOSED', stateReason: 'COMPLETED', comments: 0, linkedPullRequests: [] }],
     [37, { state: 'CLOSED', stateReason: 'NOT_PLANNED', comments: 0, linkedPullRequests: [] }],
     [38, { state: 'CLOSED', stateReason: 'DUPLICATE', comments: 0, linkedPullRequests: [] }]
@@ -13324,7 +13343,8 @@ test('worker maps GitHub issue and linked PR state onto Paperclip statuses while
     [320, false],
     [330, false],
     [340, true],
-    [350, false]
+    [350, false],
+    [400, false]
   ]);
 
   const ciContexts = new Map<number, Array<Record<string, string | null>>>([
@@ -13366,7 +13386,30 @@ test('worker maps GitHub issue and linked PR state onto Paperclip statuses while
           state: 'SUCCESS'
         }
       ]
+    ],
+    [
+      400,
+      [
+        {
+          __typename: 'StatusContext',
+          state: 'SUCCESS'
+        }
+      ]
     ]
+  ]);
+  const pullRequestMergeability = new Map<number, 'MERGEABLE' | 'CONFLICTING'>([
+    [320, 'MERGEABLE'],
+    [330, 'MERGEABLE'],
+    [340, 'MERGEABLE'],
+    [350, 'MERGEABLE'],
+    [400, 'CONFLICTING']
+  ]);
+  const pullRequestMergeStateStatus = new Map<number, string>([
+    [320, 'CLEAN'],
+    [330, 'CLEAN'],
+    [340, 'CLEAN'],
+    [350, 'CLEAN'],
+    [400, 'DIRTY']
   ]);
 
   const originalFetch = globalThis.fetch;
@@ -13485,6 +13528,8 @@ test('worker maps GitHub issue and linked PR state onto Paperclip statuses while
         return graphqlResponse({
           repository: {
             pullRequest: {
+              mergeable: pullRequestMergeability.get(pullRequestNumber) ?? 'MERGEABLE',
+              mergeStateStatus: pullRequestMergeStateStatus.get(pullRequestNumber) ?? 'CLEAN',
               statusCheckRollup: {
                 contexts: {
                   pageInfo: {
@@ -13510,8 +13555,8 @@ test('worker maps GitHub issue and linked PR state onto Paperclip statuses while
 
     assert.equal(sync.syncState.status, 'success');
     assert.equal(sync.syncState.createdIssuesCount, 0);
-    assert.equal(sync.syncState.skippedIssuesCount, 7);
-    assert.equal(sync.syncState.syncedIssuesCount, 10);
+    assert.equal(sync.syncState.skippedIssuesCount, 8);
+    assert.equal(sync.syncState.syncedIssuesCount, 11);
 
     const issues = await harness.ctx.issues.list({
       companyId: 'company-1'
@@ -13523,11 +13568,12 @@ test('worker maps GitHub issue and linked PR state onto Paperclip statuses while
     assert.equal(issues.find((issue) => issue.title === 'Pending CI')?.status, 'backlog');
     assert.equal(issues.find((issue) => issue.title === 'Red CI')?.status, 'backlog');
     assert.equal(issues.find((issue) => issue.title === 'Unresolved review thread')?.status, 'backlog');
+    assert.equal(issues.find((issue) => issue.title === 'Merge conflict')?.status, 'todo');
     assert.equal(issues.find((issue) => issue.title === 'Green review')?.status, 'in_review');
     assert.equal(issues.find((issue) => issue.title === 'Completed')?.status, 'done');
     assert.equal(issues.find((issue) => issue.title === 'Not planned')?.status, 'cancelled');
     assert.equal(issues.find((issue) => issue.title === 'Duplicate')?.status, 'cancelled');
-    assert.equal(statusTransitionComments.length, 5);
+    assert.equal(statusTransitionComments.length, 6);
     assert.equal(statusTransitionComments.some((comment) => comment.issueId === preservedIssue.id), false);
     assert.equal(statusTransitionComments.some((comment) => comment.issueId === backlogCommentedIssue.id), false);
     assert.equal(statusTransitionComments.some((comment) => comment.issueId === pendingCiIssue.id), false);
@@ -13544,6 +13590,14 @@ test('worker maps GitHub issue and linked PR state onto Paperclip statuses while
     assert.doesNotMatch(
       statusTransitionComments.find((comment) => comment.issueId === commentedIssue.id)?.body ?? '',
       /paperclipai\/example-repo#31/
+    );
+    assert.match(
+      statusTransitionComments.find((comment) => comment.issueId === conflictingPullRequestIssue.id)?.body ?? '',
+      /from `in review` to `todo`/
+    );
+    assert.match(
+      statusTransitionComments.find((comment) => comment.issueId === conflictingPullRequestIssue.id)?.body ?? '',
+      /merge conflicts/
     );
     assert.match(
       statusTransitionComments.find((comment) => comment.issueId === greenReviewIssue.id)?.body ?? '',
@@ -13579,6 +13633,275 @@ test('worker maps GitHub issue and linked PR state onto Paperclip statuses while
     assert.equal(importRegistry.find((entry) => entry.githubIssueId === 3003)?.lastSeenCommentCount, 2);
     assert.equal(importRegistry.find((entry) => entry.githubIssueId === 3010)?.githubIssueNumber, 38);
     assert.equal(backlogCommentIssueCommentRequests, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('worker treats action-required GitHub merge state statuses as executor work', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubTokenRef: 'github-secret-ref'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+  harness.seed({
+    agents: [
+      createAgentFixture({
+        id: 'agent-1',
+        companyId: 'company-1',
+        name: 'Elliot',
+        title: 'Executor'
+      })
+    ]
+  });
+
+  await harness.performAction('settings.saveRegistration', {
+    companyId: 'company-1',
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    advancedSettings: {
+      executorAssigneeAgentId: 'agent-1',
+      defaultStatus: 'backlog',
+      ignoredIssueAuthorUsernames: ['renovate']
+    },
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  const statusTransitionComments: Array<{ issueId: string; body: string }> = [];
+  const originalCreateComment = harness.ctx.issues.createComment;
+  harness.ctx.issues.createComment = async (issueId, body, companyId) => {
+    statusTransitionComments.push({ issueId, body });
+    return originalCreateComment(issueId, body, companyId);
+  };
+
+  const scenarios = [
+    {
+      githubIssueId: 4101,
+      githubIssueNumber: 41,
+      pullRequestNumber: 410,
+      title: 'Behind branch',
+      mergeable: 'MERGEABLE' as const,
+      mergeStateStatus: 'BEHIND',
+      expectedReason: /out-of-date branch state/
+    },
+    {
+      githubIssueId: 4201,
+      githubIssueNumber: 42,
+      pullRequestNumber: 420,
+      title: 'Blocked merge',
+      mergeable: 'UNKNOWN' as const,
+      mergeStateStatus: 'BLOCKED',
+      expectedReason: /blocked merge requirements/
+    },
+    {
+      githubIssueId: 4301,
+      githubIssueNumber: 43,
+      pullRequestNumber: 430,
+      title: 'Draft pull request',
+      mergeable: 'UNKNOWN' as const,
+      mergeStateStatus: 'DRAFT',
+      expectedReason: /draft status/
+    },
+    {
+      githubIssueId: 4401,
+      githubIssueNumber: 44,
+      pullRequestNumber: 440,
+      title: 'Unstable merge requirements',
+      mergeable: 'UNKNOWN' as const,
+      mergeStateStatus: 'UNSTABLE',
+      expectedReason: /unstable merge requirements/
+    },
+    {
+      githubIssueId: 4501,
+      githubIssueNumber: 45,
+      pullRequestNumber: 450,
+      title: 'Unknown mergeability',
+      mergeable: 'UNKNOWN' as const,
+      mergeStateStatus: 'UNKNOWN',
+      expectedReason: /unknown mergeability/
+    }
+  ];
+
+  const importedIssues = await Promise.all(
+    scenarios.map(async (scenario) => {
+      const created = await harness.ctx.issues.create({
+        companyId: 'company-1',
+        projectId: 'project-1',
+        title: scenario.title
+      });
+
+      return created.status === 'in_review'
+        ? created
+        : harness.ctx.issues.update(created.id, { status: 'in_review' }, 'company-1');
+    })
+  );
+
+  await harness.ctx.state.set(
+    {
+      scopeKind: 'instance',
+      stateKey: 'paperclip-github-plugin-import-registry'
+    },
+    importedIssues.map((issue, index) => ({
+      mappingId: 'mapping-a',
+      githubIssueId: scenarios[index]?.githubIssueId ?? 0,
+      githubIssueNumber: scenarios[index]?.githubIssueNumber ?? 0,
+      paperclipIssueId: issue.id,
+      importedAt: '2026-04-09T09:00:00.000Z',
+      lastSeenCommentCount: 0
+    }))
+  );
+
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(getRequestUrl(input));
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues' && ['all', 'open'].includes(url.searchParams.get('state') ?? '')) {
+      return jsonResponse(
+        scenarios.map((scenario) => ({
+          id: scenario.githubIssueId,
+          number: scenario.githubIssueNumber,
+          title: scenario.title,
+          body: null,
+          html_url: `https://github.com/paperclipai/example-repo/issues/${scenario.githubIssueNumber}`,
+          state: 'open',
+          comments: 0
+        }))
+      );
+    }
+
+    if (url.pathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      const issueNumber = typeof variables.issueNumber === 'number' ? variables.issueNumber : undefined;
+      const pullRequestNumber =
+        typeof variables.pullRequestNumber === 'number' ? variables.pullRequestNumber : undefined;
+
+      if (query.includes('query GitHubIssueParentRelationships')) {
+        return graphqlIssueParentRelationshipsResponse(
+          scenarios.map((scenario) => ({
+            issueNumber: scenario.githubIssueNumber
+          }))
+        );
+      }
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && issueNumber !== undefined) {
+        const scenario = scenarios.find((entry) => entry.githubIssueNumber === issueNumber);
+        if (!scenario) {
+          throw new Error(`Missing merge-state scenario for issue #${issueNumber}.`);
+        }
+
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: scenario.githubIssueNumber,
+              state: 'OPEN',
+              stateReason: null,
+              comments: {
+                totalCount: 0
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: [
+                  {
+                    number: scenario.pullRequestNumber,
+                    state: 'OPEN'
+                  }
+                ]
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubPullRequestReviewThreads') && pullRequestNumber !== undefined) {
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: [{ isResolved: true }]
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubPullRequestCiContexts') && pullRequestNumber !== undefined) {
+        const scenario = scenarios.find((entry) => entry.pullRequestNumber === pullRequestNumber);
+        if (!scenario) {
+          throw new Error(`Missing merge-state scenario for pull request #${pullRequestNumber}.`);
+        }
+
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              mergeable: scenario.mergeable,
+              mergeStateStatus: scenario.mergeStateStatus,
+              statusCheckRollup: {
+                contexts: {
+                  pageInfo: {
+                    hasNextPage: false,
+                    endCursor: null
+                  },
+                  nodes: [
+                    {
+                      __typename: 'StatusContext',
+                      state: 'SUCCESS'
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    const sync = await harness.performAction('sync.runNow', {}) as {
+      syncState: { status: string; syncedIssuesCount?: number };
+    };
+
+    assert.equal(sync.syncState.status, 'success');
+    assert.equal(sync.syncState.syncedIssuesCount, scenarios.length);
+
+    const issues = await harness.ctx.issues.list({
+      companyId: 'company-1'
+    });
+
+    for (const scenario of scenarios) {
+      const issue = issues.find((entry) => entry.title === scenario.title);
+      assert.equal(issue?.status, 'in_progress');
+      assert.equal(issue?.assigneeAgentId, 'agent-1');
+      assert.match(
+        statusTransitionComments.find((comment) => comment.issueId === issue?.id)?.body ?? '',
+        /from `in review` to `in progress`/
+      );
+      assert.match(
+        statusTransitionComments.find((comment) => comment.issueId === issue?.id)?.body ?? '',
+        scenario.expectedReason
+      );
+    }
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -13957,7 +14280,7 @@ test('worker routes sync-driven review handoffs to execution-policy assignees an
                   hasNextPage: false,
                   endCursor: null
                 },
-                nodes: [{ isResolved: false }]
+                nodes: [{ isResolved: true }]
               }
             }
           }
@@ -13968,6 +14291,8 @@ test('worker routes sync-driven review handoffs to execution-policy assignees an
         return graphqlResponse({
           repository: {
             pullRequest: {
+              mergeable: 'MERGEABLE',
+              mergeStateStatus: 'CLEAN',
               statusCheckRollup: {
                 contexts: {
                   pageInfo: {
@@ -13991,6 +14316,8 @@ test('worker routes sync-driven review handoffs to execution-policy assignees an
         return graphqlResponse({
           repository: {
             pullRequest: {
+              mergeable: 'MERGEABLE',
+              mergeStateStatus: 'BEHIND',
               statusCheckRollup: {
                 contexts: {
                   pageInfo: {
@@ -14001,7 +14328,7 @@ test('worker routes sync-driven review handoffs to execution-policy assignees an
                     {
                       __typename: 'CheckRun',
                       status: 'COMPLETED',
-                      conclusion: 'FAILURE'
+                      conclusion: 'SUCCESS'
                     }
                   ]
                 }
@@ -14479,6 +14806,8 @@ test('worker routes execution-policy review handoffs to saved reviewers, executo
         return graphqlResponse({
           repository: {
             pullRequest: {
+              mergeable: 'MERGEABLE',
+              mergeStateStatus: 'CLEAN',
               statusCheckRollup: {
                 contexts: {
                   pageInfo: {
@@ -14502,6 +14831,8 @@ test('worker routes execution-policy review handoffs to saved reviewers, executo
         return graphqlResponse({
           repository: {
             pullRequest: {
+              mergeable: 'MERGEABLE',
+              mergeStateStatus: 'CLEAN',
               statusCheckRollup: {
                 contexts: {
                   pageInfo: {
@@ -14775,6 +15106,8 @@ test('worker handles linked pull requests from other repositories', async () => 
         return graphqlResponse({
           repository: {
             pullRequest: {
+              mergeable: 'MERGEABLE',
+              mergeStateStatus: 'CLEAN',
               statusCheckRollup: {
                 contexts: {
                   pageInfo: {
@@ -15890,6 +16223,8 @@ test('worker preserves execution-policy pending review state when the local Pape
               nodes: [
                 {
                   number: 430,
+                  mergeable: 'MERGEABLE',
+                  mergeStateStatus: 'CLEAN',
                   reviewThreads: {
                     pageInfo: {
                       hasNextPage: false,
@@ -15965,6 +16300,8 @@ test('worker preserves execution-policy pending review state when the local Pape
         return graphqlResponse({
           repository: {
             pullRequest: {
+              mergeable: 'MERGEABLE',
+              mergeStateStatus: 'CLEAN',
               statusCheckRollup: {
                 contexts: {
                   pageInfo: {


### PR DESCRIPTION
## Summary
- add detailed GitHub PR mergeability tracking to sync, including `mergeStateStatus`
- treat non-mergeable linked PR states like executor work, similar to failing CI
- keep merge-ready linked PRs eligible for `in_review` only when CI and review threads are also clear
- extend regression coverage for mergeability-driven status routing and fallback paths
- update docs and UI copy to describe non-mergeable linked PR handling

## Why
Sync previously keyed mostly off CI and review-thread state, which meant PRs that were behind, blocked, draft, unstable, or otherwise not actually merge-ready could still look healthy enough to advance incorrectly. This change brings GitHub mergeability into the status mapping so executors are prompted to act when a linked PR is not ready to merge.

## Impact
- imported Paperclip issues move back into active execution when linked PRs are non-mergeable
- merge-ready PRs can still advance into review when their other gates are clear
- transition comments now describe the specific blocking condition, such as merge conflicts or an out-of-date branch
- tests now cover the added mergeability states and the HTML sign-in fallback case on the new code path

## Validation
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Model Used
- Originator: Codex Desktop
- Model ID/version: unavailable from the Codex runtime in this environment
- Context window size: unavailable from the Codex runtime in this environment
- Capability details: tool-assisted coding session with terminal, git, GitHub CLI, repository tests, and thread automation support
