### PR TITLE
[codex] Monitor PR-created issues during sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Each mapped project can expose a **Pull Requests** entry in the sidebar that ope
 
 Paperclip issue linkage on the queue prefers the GitHub issue that the pull request closes, so imported GitHub issues and delivery work stay connected in the same project view. If a pull request has no closing-issue-backed link yet, the queue falls back to the Paperclip issue created directly from that pull request and updates the table immediately when that create action returns.
 
+Those pull-request-created Paperclip issues also stay in the scheduled/manual sync loop even when the pull request does not close a GitHub issue. GitHub Sync checks their CI, merge state, and review threads so new failures or unresolved feedback move the Paperclip issue back into active work.
+
 The issue detail panel and sync-created comment annotations also preserve cross-repository linked pull requests, showing those PRs with their real repository path so operators land in the right place on GitHub.
 
 ### Agent workflows built in

--- a/SPEC.md
+++ b/SPEC.md
@@ -89,6 +89,7 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 - If the plugin-owned import registry is stale or missing, repeated sync runs MUST repair deduplication by reusing an existing imported Paperclip issue in the mapped project when durable GitHub link metadata or, for legacy issues, the description source link matches the GitHub issue URL.
 - The worker SHOULD persist pull request to Paperclip issue links in a plugin-owned entity so project-scoped queue and detail surfaces can reuse durable links without reparsing issue descriptions.
 - Repeated sync runs MUST continue reconciling imported Paperclip issue statuses against the latest GitHub state.
+- Repeated sync runs MUST also monitor open pull requests that were linked to Paperclip issues through the project Pull Requests page when those pull requests do not close a synced GitHub issue, and MUST reconcile those Paperclip issue statuses from the pull request CI, merge, and review-thread state.
 - When the local Paperclip host API is available, sync-driven Paperclip status transitions SHOULD go through the same issue-update path Paperclip UI uses so timeline activity is recorded for agents and humans.
 - Repeated sync runs MUST continue reconciling imported Paperclip issue labels against the latest mapped GitHub labels, including removing labels that were removed on GitHub.
 - An open GitHub issue without a linked PR that was created by a repository maintainer/admin MUST map to Paperclip `todo` when it is first imported.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -9666,10 +9666,6 @@ function doesGitHubPullRequestLinkRecordMatchMapping(
   record: GitHubPullRequestLinkRecord,
   mapping: RepositoryMapping
 ): boolean {
-  if (record.data.githubPullRequestState !== 'open') {
-    return false;
-  }
-
   if (record.data.repositoryUrl !== getNormalizedMappingRepositoryUrl(mapping)) {
     return false;
   }
@@ -9711,7 +9707,9 @@ async function listGitHubPullRequestIssueLinksForMapping(
   mapping: RepositoryMapping,
   target?: ResolvedSyncTarget
 ): Promise<GitHubPullRequestLinkRecord[]> {
-  const records = await listGitHubPullRequestLinkRecords(ctx);
+  const records = await listGitHubPullRequestLinkRecords(ctx, {
+    ...(target?.kind === 'issue' && target.issueId ? { paperclipIssueId: target.issueId } : {})
+  });
   const recordsByKey = new Map<string, GitHubPullRequestLinkRecord>();
 
   for (const record of records) {
@@ -11992,6 +11990,7 @@ async function synchronizePaperclipPullRequestIssueStatuses(
 }> {
   if (
     !mapping.companyId ||
+    !mapping.paperclipProjectId ||
     !ctx.issues ||
     typeof ctx.issues.get !== 'function' ||
     typeof ctx.issues.update !== 'function'
@@ -12003,6 +12002,8 @@ async function synchronizePaperclipPullRequestIssueStatuses(
 
   let updatedStatusesCount = 0;
   let completedIssueCount = 0;
+  const mappingCompanyId = mapping.companyId;
+  const mappingProjectId = mapping.paperclipProjectId;
   const totalIssueCount = pullRequestLinks.length;
   const queuedIssueWakeups: Array<{
     assigneeAgentId?: string | null;
@@ -12025,6 +12026,40 @@ async function synchronizePaperclipPullRequestIssueStatuses(
         repositoryUrl: pullRequestRepository.url,
         githubIssueNumber: undefined
       });
+      const pullRequestResponse = await octokit.rest.pulls.get({
+        owner: pullRequestRepository.owner,
+        repo: pullRequestRepository.repo,
+        pull_number: pullRequestLink.data.githubPullRequestNumber,
+        headers: {
+          'X-GitHub-Api-Version': GITHUB_API_VERSION
+        }
+      });
+      const livePullRequestState = getPullRequestApiState({
+        state: pullRequestResponse.data.state,
+        merged: pullRequestResponse.data.merged
+      }) === 'open'
+        ? 'open'
+        : 'closed';
+      if (
+        livePullRequestState !== pullRequestLink.data.githubPullRequestState
+        || pullRequestResponse.data.html_url !== pullRequestLink.data.githubPullRequestUrl
+        || pullRequestResponse.data.title !== pullRequestLink.data.title
+      ) {
+        await upsertGitHubPullRequestLinkRecord(ctx, {
+          companyId: pullRequestLink.data.companyId ?? mappingCompanyId,
+          projectId: pullRequestLink.data.paperclipProjectId ?? mappingProjectId,
+          issueId: pullRequestLink.paperclipIssueId,
+          repositoryUrl: pullRequestRepository.url,
+          pullRequestNumber: pullRequestLink.data.githubPullRequestNumber,
+          pullRequestUrl: pullRequestResponse.data.html_url ?? pullRequestLink.data.githubPullRequestUrl,
+          pullRequestTitle: pullRequestResponse.data.title || pullRequestLink.data.title || `Pull request #${pullRequestLink.data.githubPullRequestNumber}`,
+          pullRequestState: livePullRequestState
+        });
+      }
+      if (livePullRequestState !== 'open') {
+        continue;
+      }
+
       const pullRequest = await getGitHubPullRequestStatusSnapshot(
         octokit,
         pullRequestRepository,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -636,6 +636,7 @@ interface RepositorySyncPlan {
   allIssues: GitHubIssueRecord[];
   issues: GitHubIssueRecord[];
   allIssuesById: Map<number, GitHubIssueRecord>;
+  pullRequestLinks: GitHubPullRequestLinkRecord[];
   trackedIssueCount: number;
 }
 
@@ -6215,6 +6216,16 @@ function buildTrackedIssueProgressKey(mapping: RepositoryMapping, githubIssueId:
   return `${mapping.id}:${githubIssueId}`;
 }
 
+function buildTrackedPullRequestIssueProgressKey(
+  mapping: RepositoryMapping,
+  record: GitHubPullRequestLinkRecord
+): string {
+  return `${mapping.id}:pull-request:${record.paperclipIssueId}:${buildGitHubPullRequestReferenceKey({
+    number: record.data.githubPullRequestNumber,
+    repositoryUrl: record.data.repositoryUrl
+  })}`;
+}
+
 function buildImportedIssueRecord(
   mapping: RepositoryMapping,
   issue: GitHubIssueRecord,
@@ -7504,6 +7515,34 @@ function buildSyncFallbackExecutionStatePatch(params: {
   return undefined;
 }
 
+function describeGitHubLinkedPullRequestsStatusReason(
+  linkedPullRequests: GitHubPullRequestStatusSnapshot[]
+): string {
+  const linkedPullRequestSubject = linkedPullRequests.length === 1 ? 'the linked pull request' : 'linked pull requests';
+  const linkedPullRequestVerb = linkedPullRequests.length === 1 ? 'has' : 'have';
+  const blockingConditions = [...new Set(
+    linkedPullRequests.flatMap((pullRequest) => listGitHubPullRequestSyncBlockingConditions(pullRequest))
+  )];
+  const hasUnfinishedCi = linkedPullRequests.some((pullRequest) => pullRequest.ciState === 'unfinished');
+  const hasUnknownMergeability = linkedPullRequests.some(
+    (pullRequest) => pullRequest.mergeStateStatus === 'unknown'
+  );
+
+  if (blockingConditions.length > 0) {
+    return `${linkedPullRequestSubject} ${linkedPullRequestVerb} ${formatPlainTextList(blockingConditions)}`;
+  }
+
+  if (hasUnfinishedCi) {
+    return `${linkedPullRequestSubject} still ${linkedPullRequestVerb} unfinished CI jobs`;
+  }
+
+  if (hasUnknownMergeability) {
+    return `${linkedPullRequestSubject} ${linkedPullRequestVerb} unknown mergeability`;
+  }
+
+  return `${linkedPullRequestSubject} ${linkedPullRequestVerb} green CI with all review threads resolved`;
+}
+
 function describeGitHubStatusTransitionReason(params: {
   snapshot: GitHubIssueStatusSnapshot;
   hasTrustedNewComment?: boolean;
@@ -7534,29 +7573,7 @@ function describeGitHubStatusTransitionReason(params: {
     return 'the GitHub issue is open with no linked pull requests';
   }
 
-  const linkedPullRequestSubject = snapshot.linkedPullRequests.length === 1 ? 'the linked pull request' : 'linked pull requests';
-  const linkedPullRequestVerb = snapshot.linkedPullRequests.length === 1 ? 'has' : 'have';
-  const blockingConditions = [...new Set(
-    snapshot.linkedPullRequests.flatMap((pullRequest) => listGitHubPullRequestSyncBlockingConditions(pullRequest))
-  )];
-  const hasUnfinishedCi = snapshot.linkedPullRequests.some((pullRequest) => pullRequest.ciState === 'unfinished');
-  const hasUnknownMergeability = snapshot.linkedPullRequests.some(
-    (pullRequest) => pullRequest.mergeStateStatus === 'unknown'
-  );
-
-  if (blockingConditions.length > 0) {
-    return `${linkedPullRequestSubject} ${linkedPullRequestVerb} ${formatPlainTextList(blockingConditions)}`;
-  }
-
-  if (hasUnfinishedCi) {
-    return `${linkedPullRequestSubject} still ${linkedPullRequestVerb} unfinished CI jobs`;
-  }
-
-  if (hasUnknownMergeability) {
-    return `${linkedPullRequestSubject} ${linkedPullRequestVerb} unknown mergeability`;
-  }
-
-  return `${linkedPullRequestSubject} ${linkedPullRequestVerb} green CI with all review threads resolved`;
+  return describeGitHubLinkedPullRequestsStatusReason(snapshot.linkedPullRequests);
 }
 
 function buildStatusTransitionCommentAnnotation(params: StatusTransitionCommentAnnotationInput): StoredStatusTransitionCommentAnnotation {
@@ -7614,6 +7631,15 @@ function buildPaperclipIssueStatusTransitionComment(params: {
   };
 }
 
+function buildPaperclipPullRequestIssueStatusTransitionComment(params: {
+  previousStatus: PaperclipIssueStatus;
+  nextStatus: PaperclipIssueStatus;
+  pullRequest: GitHubPullRequestStatusSnapshot;
+}): string {
+  const reason = describeGitHubLinkedPullRequestsStatusReason([params.pullRequest]);
+  return `GitHub Sync updated the status from \`${formatPaperclipIssueStatus(params.previousStatus)}\` to \`${formatPaperclipIssueStatus(params.nextStatus)}\` because ${reason}.`;
+}
+
 function resolvePaperclipIssueStatus(params: {
   currentStatus: PaperclipIssueStatus;
   snapshot: GitHubIssueStatusSnapshot;
@@ -7663,6 +7689,22 @@ function resolvePaperclipIssueStatus(params: {
   }
 
   return currentStatus;
+}
+
+function resolvePaperclipPullRequestIssueStatus(params: {
+  currentStatus: PaperclipIssueStatus;
+  pullRequest: GitHubPullRequestStatusSnapshot;
+  hasExecutorHandoffTarget?: boolean;
+}): PaperclipIssueStatus {
+  const { currentStatus, pullRequest, hasExecutorHandoffTarget } = params;
+
+  if (currentStatus === 'done' || currentStatus === 'cancelled') {
+    return currentStatus;
+  }
+
+  return resolvePaperclipStatusFromLinkedPullRequests([pullRequest], {
+    preferInProgress: hasExecutorHandoffTarget
+  });
 }
 
 async function listLinkedPullRequestsForIssue(
@@ -9618,6 +9660,78 @@ async function listGitHubPullRequestLinkRecords(
   }
 
   return records;
+}
+
+function doesGitHubPullRequestLinkRecordMatchMapping(
+  record: GitHubPullRequestLinkRecord,
+  mapping: RepositoryMapping
+): boolean {
+  if (record.data.githubPullRequestState !== 'open') {
+    return false;
+  }
+
+  if (record.data.repositoryUrl !== getNormalizedMappingRepositoryUrl(mapping)) {
+    return false;
+  }
+
+  if (record.data.companyId && record.data.companyId !== mapping.companyId) {
+    return false;
+  }
+
+  if (record.data.paperclipProjectId && record.data.paperclipProjectId !== mapping.paperclipProjectId) {
+    return false;
+  }
+
+  return Boolean(mapping.companyId && mapping.paperclipProjectId);
+}
+
+function doesGitHubPullRequestLinkRecordMatchTarget(
+  record: GitHubPullRequestLinkRecord,
+  target?: ResolvedSyncTarget
+): boolean {
+  if (!target) {
+    return true;
+  }
+
+  switch (target.kind) {
+    case 'company':
+      return !record.data.companyId || record.data.companyId === target.companyId;
+    case 'project':
+      return (!record.data.companyId || record.data.companyId === target.companyId)
+        && (!record.data.paperclipProjectId || record.data.paperclipProjectId === target.projectId);
+    case 'issue':
+      return Boolean(target.issueId && record.paperclipIssueId === target.issueId);
+    default:
+      return true;
+  }
+}
+
+async function listGitHubPullRequestIssueLinksForMapping(
+  ctx: PluginSetupContext,
+  mapping: RepositoryMapping,
+  target?: ResolvedSyncTarget
+): Promise<GitHubPullRequestLinkRecord[]> {
+  const records = await listGitHubPullRequestLinkRecords(ctx);
+  const recordsByKey = new Map<string, GitHubPullRequestLinkRecord>();
+
+  for (const record of records) {
+    if (
+      !doesGitHubPullRequestLinkRecordMatchMapping(record, mapping)
+      || !doesGitHubPullRequestLinkRecordMatchTarget(record, target)
+    ) {
+      continue;
+    }
+
+    recordsByKey.set(
+      `${record.paperclipIssueId}:${buildGitHubPullRequestReferenceKey({
+        number: record.data.githubPullRequestNumber,
+        repositoryUrl: record.data.repositoryUrl
+      })}`,
+      record
+    );
+  }
+
+  return [...recordsByKey.values()];
 }
 
 async function findStoredStatusTransitionCommentAnnotation(
@@ -11854,6 +11968,194 @@ async function synchronizePaperclipIssueStatuses(
     updatedStatusesCount,
     updatedLabelsCount,
     updatedDescriptionsCount
+  };
+}
+
+async function synchronizePaperclipPullRequestIssueStatuses(
+  ctx: PluginSetupContext,
+  octokit: Octokit,
+  mapping: RepositoryMapping,
+  advancedSettings: GitHubSyncAdvancedSettings,
+  pullRequestLinks: GitHubPullRequestLinkRecord[],
+  paperclipApiBaseUrl: string | undefined,
+  pullRequestStatusCache: GitHubPullRequestStatusSnapshotCache,
+  syncFailureContext: SyncFailureContext,
+  failures: SyncProcessingFailure[],
+  assertNotCancelled?: () => Promise<void>,
+  onProgress?: (progress: {
+    pullRequestLink: GitHubPullRequestLinkRecord;
+    completedIssueCount: number;
+    totalIssueCount: number;
+  }) => Promise<void>
+): Promise<{
+  updatedStatusesCount: number;
+}> {
+  if (
+    !mapping.companyId ||
+    !ctx.issues ||
+    typeof ctx.issues.get !== 'function' ||
+    typeof ctx.issues.update !== 'function'
+  ) {
+    return {
+      updatedStatusesCount: 0
+    };
+  }
+
+  let updatedStatusesCount = 0;
+  let completedIssueCount = 0;
+  const totalIssueCount = pullRequestLinks.length;
+  const queuedIssueWakeups: Array<{
+    assigneeAgentId?: string | null;
+    paperclipIssueId: string;
+    reason: string;
+    mutation: 'status_transition';
+    previousStatus?: PaperclipIssueStatus;
+    nextStatus?: PaperclipIssueStatus;
+  }> = [];
+
+  for (const pullRequestLink of pullRequestLinks) {
+    if (assertNotCancelled) {
+      await assertNotCancelled();
+    }
+
+    try {
+      const pullRequestRepository = requireRepositoryReference(pullRequestLink.data.repositoryUrl);
+      updateSyncFailureContext(syncFailureContext, {
+        phase: 'evaluating_github_status',
+        repositoryUrl: pullRequestRepository.url,
+        githubIssueNumber: undefined
+      });
+      const pullRequest = await getGitHubPullRequestStatusSnapshot(
+        octokit,
+        pullRequestRepository,
+        pullRequestLink.data.githubPullRequestNumber,
+        pullRequestStatusCache
+      );
+      const paperclipIssue = await ctx.issues.get(pullRequestLink.paperclipIssueId, mapping.companyId);
+      if (!paperclipIssue) {
+        continue;
+      }
+
+      const paperclipIssueSyncContext = getPaperclipIssueSyncContext(paperclipIssue);
+      const executorTransitionAssignee = resolvePaperclipIssueExecutorAssignee(
+        paperclipIssueSyncContext,
+        advancedSettings
+      );
+      const nextStatus = resolvePaperclipPullRequestIssueStatus({
+        currentStatus: paperclipIssue.status,
+        pullRequest,
+        hasExecutorHandoffTarget: Boolean(executorTransitionAssignee)
+      });
+      const nextTransitionAssignee = resolveSyncTransitionAssignee({
+        nextStatus,
+        syncContext: paperclipIssueSyncContext,
+        advancedSettings
+      });
+      const shouldClearTransitionAssignee =
+        nextStatus === 'in_review'
+        && nextTransitionAssignee === null
+        && paperclipIssueSyncContext.assignee !== null;
+      const nextAssigneeChanged = nextTransitionAssignee
+        ? !doesPaperclipIssueAssigneeMatch(paperclipIssueSyncContext.assignee, nextTransitionAssignee.principal)
+        : false;
+      const shouldWakeTransitionAssignee =
+        paperclipIssue.status !== nextStatus
+        && nextTransitionAssignee?.principal.kind === 'agent'
+        && isActionablePaperclipIssueStatus(nextStatus)
+        && (nextAssigneeChanged || paperclipIssue.status !== nextStatus);
+
+      if (paperclipIssue.status === nextStatus) {
+        if (shouldClearTransitionAssignee) {
+          updateSyncFailureContext(syncFailureContext, {
+            phase: 'updating_paperclip_status',
+            repositoryUrl: pullRequestRepository.url,
+            githubIssueNumber: undefined
+          });
+          await updatePaperclipIssueState(ctx, {
+            companyId: mapping.companyId,
+            issueId: pullRequestLink.paperclipIssueId,
+            currentStatus: paperclipIssue.status,
+            syncContext: paperclipIssueSyncContext,
+            nextStatus,
+            clearAssignee: true,
+            transitionComment: '',
+            paperclipApiBaseUrl
+          });
+        }
+
+        continue;
+      }
+
+      const transitionComment = buildPaperclipPullRequestIssueStatusTransitionComment({
+        previousStatus: paperclipIssue.status,
+        nextStatus,
+        pullRequest
+      });
+      updateSyncFailureContext(syncFailureContext, {
+        phase: 'updating_paperclip_status',
+        repositoryUrl: pullRequestRepository.url,
+        githubIssueNumber: undefined
+      });
+      await updatePaperclipIssueState(ctx, {
+        companyId: mapping.companyId,
+        issueId: pullRequestLink.paperclipIssueId,
+        currentStatus: paperclipIssue.status,
+        syncContext: paperclipIssueSyncContext,
+        nextStatus,
+        ...(nextTransitionAssignee ? { nextAssignee: nextTransitionAssignee.principal } : {}),
+        ...(shouldClearTransitionAssignee ? { clearAssignee: true } : {}),
+        transitionComment,
+        paperclipApiBaseUrl
+      });
+      updatedStatusesCount += 1;
+
+      if (shouldWakeTransitionAssignee && nextTransitionAssignee?.principal.kind === 'agent') {
+        queuedIssueWakeups.push({
+          assigneeAgentId: nextTransitionAssignee.principal.id,
+          paperclipIssueId: pullRequestLink.paperclipIssueId,
+          reason: STATUS_TRANSITION_WAKE_REASON,
+          mutation: 'status_transition',
+          previousStatus: paperclipIssue.status,
+          nextStatus
+        });
+      }
+    } catch (error) {
+      if (isGitHubRateLimitError(error)) {
+        throw error;
+      }
+
+      recordRecoverableSyncFailure(ctx, failures, error, syncFailureContext);
+      continue;
+    } finally {
+      completedIssueCount += 1;
+
+      if (onProgress) {
+        await onProgress({
+          pullRequestLink,
+          completedIssueCount,
+          totalIssueCount
+        });
+      }
+    }
+  }
+
+  await mapWithConcurrency(
+    queuedIssueWakeups,
+    IMPORTED_ISSUE_WAKEUP_CONCURRENCY,
+    async (queuedWakeup) => wakePaperclipIssueAssignee(ctx, {
+      assigneeAgentId: queuedWakeup.assigneeAgentId,
+      paperclipIssueId: queuedWakeup.paperclipIssueId,
+      companyId: mapping.companyId,
+      paperclipApiBaseUrl,
+      reason: queuedWakeup.reason,
+      mutation: queuedWakeup.mutation,
+      previousStatus: queuedWakeup.previousStatus,
+      nextStatus: queuedWakeup.nextStatus
+    })
+  );
+
+  return {
+    updatedStatusesCount
   };
 }
 
@@ -16748,6 +17050,19 @@ async function performSync(
     completedTrackedIssueCount += 1;
   }
 
+  function markTrackedPullRequestIssueProcessed(
+    mapping: RepositoryMapping,
+    record: GitHubPullRequestLinkRecord
+  ): void {
+    const key = buildTrackedPullRequestIssueProgressKey(mapping, record);
+    if (completedTrackedIssueKeys.has(key)) {
+      return;
+    }
+
+    completedTrackedIssueKeys.add(key);
+    completedTrackedIssueCount += 1;
+  }
+
   function recordCompanyBacklogSnapshotsFromPlans(repositoryPlans: RepositorySyncPlan[]): void {
     if (options.target?.kind === 'project' || options.target?.kind === 'issue') {
       return;
@@ -16875,12 +17190,15 @@ async function performSync(
         const importRegistryByIssueId = new Map(
           importedIssueRecords.map((entry) => [entry.githubIssueId, entry])
         );
+        const pullRequestLinks = await listGitHubPullRequestIssueLinksForMapping(ctx, mapping, options.target);
         const ensuredPaperclipIssueIds = new Map<number, string>();
         const trackedIssueIds = new Set<number>([
           ...issues.map((issue) => issue.id),
           ...importRegistryByIssueId.keys()
         ]);
-        const trackedIssueCount = [...trackedIssueIds].filter((issueId) => allIssuesById.has(issueId)).length;
+        const trackedIssueCount =
+          [...trackedIssueIds].filter((issueId) => allIssuesById.has(issueId)).length
+          + pullRequestLinks.length;
         totalTrackedIssueCount += trackedIssueCount;
         syncedIssuesCount = totalTrackedIssueCount;
         currentProgress = {
@@ -16900,6 +17218,7 @@ async function performSync(
           allIssues: eligibleIssues,
           issues,
           allIssuesById,
+          pullRequestLinks,
           trackedIssueCount
         });
       } catch (error) {
@@ -16940,7 +17259,7 @@ async function performSync(
       await throwIfSyncCancelled();
 
       try {
-        const { mapping, advancedSettings, repository, repositoryIndex, allIssuesById, issues } = plan;
+        const { mapping, advancedSettings, repository, repositoryIndex, allIssuesById, issues, pullRequestLinks } = plan;
         const companyId = mapping.companyId;
         let availableLabels = companyId ? companyLabelDirectoryCache.get(companyId) : undefined;
         if (!availableLabels) {
@@ -17004,6 +17323,15 @@ async function performSync(
                 openLinkedPullRequestNumbersByRepository.set(pullRequestRepository.url, entry);
               }
             }
+          }
+          for (const pullRequestLink of pullRequestLinks) {
+            const pullRequestRepository = requireRepositoryReference(pullRequestLink.data.repositoryUrl);
+            const entry = openLinkedPullRequestNumbersByRepository.get(pullRequestRepository.url) ?? {
+              repository: pullRequestRepository,
+              numbers: new Set<number>()
+            };
+            entry.numbers.add(pullRequestLink.data.githubPullRequestNumber);
+            openLinkedPullRequestNumbersByRepository.set(pullRequestRepository.url, entry);
           }
 
           for (const entry of openLinkedPullRequestNumbersByRepository.values()) {
@@ -17166,6 +17494,34 @@ async function performSync(
         updatedStatusesCount += synchronizationResult.updatedStatusesCount;
         updatedLabelsCount += synchronizationResult.updatedLabelsCount;
         updatedDescriptionsCount += synchronizationResult.updatedDescriptionsCount;
+
+        const pullRequestSynchronizationResult = await synchronizePaperclipPullRequestIssueStatuses(
+          ctx,
+          octokit,
+          mapping,
+          advancedSettings,
+          pullRequestLinks,
+          paperclipApiBaseUrl,
+          pullRequestStatusCache,
+          failureContext,
+          recoverableFailures,
+          throwIfSyncCancelled,
+          async (progress) => {
+            markTrackedPullRequestIssueProcessed(mapping, progress.pullRequestLink);
+            const pullRequestRepository = requireRepositoryReference(progress.pullRequestLink.data.repositoryUrl);
+            currentProgress = {
+              phase: 'syncing',
+              totalRepositoryCount: mappings.length,
+              currentRepositoryIndex: repositoryIndex,
+              currentRepositoryUrl: repository.url,
+              completedIssueCount: completedTrackedIssueCount,
+              totalIssueCount: totalTrackedIssueCount,
+              detailLabel: `Synced pull request #${progress.pullRequestLink.data.githubPullRequestNumber} in ${pullRequestRepository.owner}/${pullRequestRepository.repo}.`
+            };
+            await persistRunningProgress(progress.completedIssueCount === progress.totalIssueCount);
+          }
+        );
+        updatedStatusesCount += pullRequestSynchronizationResult.updatedStatusesCount;
       } catch (error) {
         if (error instanceof SyncCancellationError || isGitHubRateLimitError(error)) {
           throw error;

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -5397,6 +5397,24 @@ test('sync.runNow monitors Paperclip issues created from pull requests without c
       projectId: 'project-1',
       pullRequestNumber: 42
     });
+    await harness.ctx.entities.upsert({
+      entityType: 'paperclip-github-plugin.pull-request-link',
+      scopeKind: 'issue',
+      scopeId: created.paperclipIssueId,
+      externalId: 'https://github.com/paperclipai/example-repo/pull/42',
+      title: 'GitHub pull request #42',
+      status: 'closed',
+      data: {
+        companyId: 'company-1',
+        paperclipProjectId: 'project-1',
+        repositoryUrl: 'https://github.com/paperclipai/example-repo',
+        githubPullRequestNumber: 42,
+        githubPullRequestUrl: 'https://github.com/paperclipai/example-repo/pull/42',
+        githubPullRequestState: 'closed',
+        title: 'Fix orphan PR workflow',
+        syncedAt: '2026-04-27T09:30:00.000Z'
+      }
+    });
     await harness.ctx.issues.update(created.paperclipIssueId, { status: 'in_review' }, 'company-1');
 
     const sync = await harness.performAction('sync.runNow', {
@@ -5413,6 +5431,16 @@ test('sync.runNow monitors Paperclip issues created from pull requests without c
     assert.equal(statusTransitionComments.length, 1);
     assert.match(statusTransitionComments[0]?.body ?? '', /from `in review` to `todo`/);
     assert.match(statusTransitionComments[0]?.body ?? '', /unresolved review threads/);
+
+    const pullRequestLinks = await harness.ctx.entities.list({
+      entityType: 'paperclip-github-plugin.pull-request-link',
+      scopeKind: 'issue',
+      scopeId: created.paperclipIssueId
+    });
+    const refreshedLink = pullRequestLinks.find((entry) =>
+      entry.externalId === 'https://github.com/paperclipai/example-repo/pull/42'
+    );
+    assert.equal((refreshedLink?.data as { githubPullRequestState?: unknown } | undefined)?.githubPullRequestState, 'open');
   } finally {
     harness.ctx.issues.createComment = originalCreateComment;
     globalThis.fetch = originalFetch;

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -5278,6 +5278,147 @@ test('project.pullRequests.createIssue creates and then reuses the linked Paperc
   }
 });
 
+test('sync.runNow monitors Paperclip issues created from pull requests without closing GitHub issues', async () => {
+  const harness = await createProjectPullRequestsHarness();
+  const originalFetch = globalThis.fetch;
+  const originalCreateComment = harness.ctx.issues.createComment;
+  const statusTransitionComments: Array<{ issueId: string; body: string }> = [];
+
+  harness.ctx.issues.createComment = async (issueId, body, companyId) => {
+    statusTransitionComments.push({ issueId, body });
+    return originalCreateComment(issueId, body, companyId);
+  };
+
+  globalThis.fetch = async (input, init) => {
+    const requestUrl = getRequestUrl(input);
+    const requestPathname = getDecodedRequestPathname(input);
+
+    if (requestPathname === '/repos/paperclipai/example-repo/pulls/42') {
+      return jsonResponse({
+        number: 42,
+        title: 'Fix orphan PR workflow',
+        body: 'This PR was created before a GitHub issue existed.',
+        html_url: 'https://github.com/paperclipai/example-repo/pull/42',
+        state: 'open',
+        merged: false
+      });
+    }
+
+    if (requestPathname === '/repos/paperclipai/example-repo/issues') {
+      return jsonResponse([]);
+    }
+
+    if (requestPathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      const pullRequestNumber =
+        typeof variables.pullRequestNumber === 'number' ? variables.pullRequestNumber : undefined;
+
+      if (query.includes('query GitHubRepositoryOpenIssueLinkedPullRequests')) {
+        return graphqlResponse({
+          repository: {
+            issues: {
+              pageInfo: {
+                hasNextPage: false,
+                endCursor: null
+              },
+              nodes: []
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubPullRequestReviewThreads') && pullRequestNumber === 42) {
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: [
+                  {
+                    id: 'PRRT_orphan_42',
+                    isResolved: false,
+                    comments: {
+                      totalCount: 1,
+                      nodes: [
+                        {
+                          id: 'PRRC_orphan_42',
+                          body: 'Please address this before merging.',
+                          author: {
+                            login: 'reviewer'
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubPullRequestCiContexts') && pullRequestNumber === 42) {
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              mergeable: 'MERGEABLE',
+              mergeStateStatus: 'CLEAN',
+              statusCheckRollup: {
+                contexts: {
+                  pageInfo: {
+                    hasNextPage: false,
+                    endCursor: null
+                  },
+                  nodes: [
+                    {
+                      __typename: 'StatusContext',
+                      state: 'SUCCESS'
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected fetch during pull-request issue sync test: ${requestUrl}`);
+  };
+
+  try {
+    const created = await harness.performAction<{
+      paperclipIssueId: string;
+    }>('project.pullRequests.createIssue', {
+      companyId: 'company-1',
+      projectId: 'project-1',
+      pullRequestNumber: 42
+    });
+    await harness.ctx.issues.update(created.paperclipIssueId, { status: 'in_review' }, 'company-1');
+
+    const sync = await harness.performAction('sync.runNow', {
+      waitForCompletion: true
+    }) as {
+      syncState: { status: string; syncedIssuesCount?: number };
+    };
+
+    assert.equal(sync.syncState.status, 'success');
+    assert.equal(sync.syncState.syncedIssuesCount, 1);
+
+    const updatedIssue = await harness.ctx.issues.get(created.paperclipIssueId, 'company-1');
+    assert.equal(updatedIssue?.status, 'todo');
+    assert.equal(statusTransitionComments.length, 1);
+    assert.match(statusTransitionComments[0]?.body ?? '', /from `in review` to `todo`/);
+    assert.match(statusTransitionComments[0]?.body ?? '', /unresolved review threads/);
+  } finally {
+    harness.ctx.issues.createComment = originalCreateComment;
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('project.pullRequests.updateBranch requests a GitHub branch update for behind clean pull requests', async () => {
   const harness = await createProjectPullRequestsHarness();
   const originalFetch = globalThis.fetch;


### PR DESCRIPTION
## Summary

- Include pull-request-created Paperclip issue links in sync planning when the PR has no closing GitHub issue.
- Reconcile those Paperclip issue statuses from PR CI, merge state, and review-thread snapshots during manual and scheduled syncs.
- Add regression coverage and update the README/SPEC contract for the new monitoring behavior.

## Root Cause

Paperclip issues created from the project Pull Requests page were persisted as pull request link entities, but sync only built its monitored worklist from imported GitHub issue registry entries. A PR without a linked GitHub issue could therefore receive failing CI or unresolved review threads without ever moving its Paperclip issue back into active work.

## Validation

- `pnpm typecheck && pnpm test && pnpm build`
- `git diff --check`

## Model Used

- Model: GPT-5 Codex / Codex Desktop coding agent
- Context window: not exposed by the runtime in this session
- Capabilities used: local shell, git, GitHub CLI, repository tests/build, Codex automation tooling
