### PR TITLE
Keep healthy PR waits out of internal review routing

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -7384,11 +7384,16 @@ function resolvePaperclipIssueExecutorAssignee(
 }
 
 function resolveSyncTransitionAssignee(params: {
+  currentStatus: PaperclipIssueStatus;
   nextStatus: PaperclipIssueStatus;
   syncContext: PaperclipIssueSyncContext;
   advancedSettings: GitHubSyncAdvancedSettings;
 }): SyncTransitionAssigneeResolution | null {
-  const { nextStatus, syncContext, advancedSettings } = params;
+  const { currentStatus, nextStatus, syncContext, advancedSettings } = params;
+
+  if (isHealthyMaintainerWaitTransition({ currentStatus, nextStatus, syncContext })) {
+    return null;
+  }
 
   if (nextStatus === 'in_review') {
     return resolvePaperclipIssueReviewAssignee(syncContext, advancedSettings);
@@ -7399,6 +7404,19 @@ function resolveSyncTransitionAssignee(params: {
   }
 
   return null;
+}
+
+function isHealthyMaintainerWaitTransition(params: {
+  currentStatus: PaperclipIssueStatus;
+  nextStatus: PaperclipIssueStatus;
+  syncContext: PaperclipIssueSyncContext;
+}): boolean {
+  const { currentStatus, nextStatus, syncContext } = params;
+
+  return nextStatus === 'in_review'
+    && (currentStatus === 'done' || currentStatus === 'in_review')
+    && syncContext.executionState === null
+    && syncContext.executionPolicy !== null;
 }
 
 function doesPaperclipIssueAssigneeMatch(
@@ -11158,6 +11176,7 @@ async function updatePaperclipIssueState(
     nextStatus: PaperclipIssueStatus;
     nextAssignee?: PaperclipIssueAssigneePrincipal | null;
     clearAssignee?: boolean;
+    clearExecutionPolicy?: boolean;
     transitionComment: string;
     transitionCommentAnnotation?: StoredStatusTransitionCommentAnnotation;
     paperclipApiBaseUrl?: string;
@@ -11171,6 +11190,7 @@ async function updatePaperclipIssueState(
     nextStatus,
     nextAssignee,
     clearAssignee,
+    clearExecutionPolicy,
     transitionComment,
     transitionCommentAnnotation,
     paperclipApiBaseUrl
@@ -11185,7 +11205,8 @@ async function updatePaperclipIssueState(
   });
   const issuePatch: Record<string, unknown> = {
     status: nextStatus,
-    ...(syncExecutionStatePatch === null ? { executionState: null } : {})
+    ...(syncExecutionStatePatch === null ? { executionState: null } : {}),
+    ...(clearExecutionPolicy ? { executionPolicy: null, executionState: null } : {})
   };
 
   if (nextAssignee) {
@@ -11868,14 +11889,20 @@ async function synchronizePaperclipIssueStatuses(
         maintainerAuthoredImportedIssue,
         hasExecutorHandoffTarget: Boolean(executorTransitionAssignee)
       });
+      const shouldPreserveMaintainerWaitRouting = isHealthyMaintainerWaitTransition({
+        currentStatus: paperclipIssue.status,
+        nextStatus,
+        syncContext: paperclipIssueSyncContext
+      });
       const nextTransitionAssignee = resolveSyncTransitionAssignee({
+        currentStatus: paperclipIssue.status,
         nextStatus,
         syncContext: paperclipIssueSyncContext,
         advancedSettings
       });
       const shouldClearTransitionAssignee =
         nextStatus === 'in_review'
-        && nextTransitionAssignee === null
+        && (nextTransitionAssignee === null || shouldPreserveMaintainerWaitRouting)
         && paperclipIssueSyncContext.assignee !== null;
       const nextAssigneeChanged = nextTransitionAssignee
         ? !doesPaperclipIssueAssigneeMatch(paperclipIssueSyncContext.assignee, nextTransitionAssignee.principal)
@@ -11910,6 +11937,7 @@ async function synchronizePaperclipIssueStatuses(
             syncContext: paperclipIssueSyncContext,
             nextStatus,
             clearAssignee: true,
+            ...(shouldPreserveMaintainerWaitRouting ? { clearExecutionPolicy: true } : {}),
             transitionComment: '',
             paperclipApiBaseUrl
           });
@@ -11948,6 +11976,7 @@ async function synchronizePaperclipIssueStatuses(
         nextStatus,
         ...(nextTransitionAssignee ? { nextAssignee: nextTransitionAssignee.principal } : {}),
         ...(shouldClearTransitionAssignee ? { clearAssignee: true } : {}),
+        ...(shouldPreserveMaintainerWaitRouting ? { clearExecutionPolicy: true } : {}),
         transitionComment: transitionComment.body,
         transitionCommentAnnotation: transitionComment.annotation,
         paperclipApiBaseUrl
@@ -12119,14 +12148,20 @@ async function synchronizePaperclipPullRequestIssueStatuses(
         pullRequest,
         hasExecutorHandoffTarget: Boolean(executorTransitionAssignee)
       });
+      const shouldPreserveMaintainerWaitRouting = isHealthyMaintainerWaitTransition({
+        currentStatus: paperclipIssue.status,
+        nextStatus,
+        syncContext: paperclipIssueSyncContext
+      });
       const nextTransitionAssignee = resolveSyncTransitionAssignee({
+        currentStatus: paperclipIssue.status,
         nextStatus,
         syncContext: paperclipIssueSyncContext,
         advancedSettings
       });
       const shouldClearTransitionAssignee =
         nextStatus === 'in_review'
-        && nextTransitionAssignee === null
+        && (nextTransitionAssignee === null || shouldPreserveMaintainerWaitRouting)
         && paperclipIssueSyncContext.assignee !== null;
       const nextAssigneeChanged = nextTransitionAssignee
         ? !doesPaperclipIssueAssigneeMatch(paperclipIssueSyncContext.assignee, nextTransitionAssignee.principal)
@@ -12151,6 +12186,7 @@ async function synchronizePaperclipPullRequestIssueStatuses(
             syncContext: paperclipIssueSyncContext,
             nextStatus,
             clearAssignee: true,
+            ...(shouldPreserveMaintainerWaitRouting ? { clearExecutionPolicy: true } : {}),
             transitionComment: '',
             paperclipApiBaseUrl
           });
@@ -12177,6 +12213,7 @@ async function synchronizePaperclipPullRequestIssueStatuses(
         nextStatus,
         ...(nextTransitionAssignee ? { nextAssignee: nextTransitionAssignee.principal } : {}),
         ...(shouldClearTransitionAssignee ? { clearAssignee: true } : {}),
+        ...(shouldPreserveMaintainerWaitRouting ? { clearExecutionPolicy: true } : {}),
         transitionComment,
         paperclipApiBaseUrl
       });
@@ -18554,6 +18591,12 @@ export function shouldStartWorkerHost(moduleUrl: string, entry = process.argv[1]
     return resolve(entry) === resolve(modulePath);
   }
 }
+
+export const __testing = {
+  buildSyncFallbackExecutionStatePatch,
+  isHealthyMaintainerWaitTransition,
+  resolveSyncTransitionAssignee
+};
 
 const plugin = definePlugin({
   async setup(ctx) {

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -50,6 +50,87 @@ test.beforeEach(async () => {
   plugin = await importFreshWorker();
 });
 
+test('sync keeps completed healthy PR waits unassigned instead of restarting internal review', async () => {
+  const workerModule = await importFreshWorkerModule();
+  const syncContext = {
+    assignee: { kind: 'agent', id: 'engineer-agent' },
+    executionPolicy: {
+      stages: [
+        {
+          id: 'architect-review',
+          type: 'review',
+          participants: [{ kind: 'agent', id: 'architect-agent' }]
+        }
+      ]
+    },
+    executionState: null
+  };
+  const advancedSettings = {
+    defaultStatus: 'backlog',
+    ignoredIssueAuthorUsernames: []
+  };
+
+  assert.equal(
+    workerModule.__testing.isHealthyMaintainerWaitTransition({
+      currentStatus: 'done',
+      nextStatus: 'in_review',
+      syncContext
+    }),
+    true
+  );
+  assert.equal(
+    workerModule.__testing.resolveSyncTransitionAssignee({
+      currentStatus: 'done',
+      nextStatus: 'in_review',
+      syncContext,
+      advancedSettings
+    }),
+    null
+  );
+});
+
+test('sync still starts internal review for active implementation handoffs', async () => {
+  const workerModule = await importFreshWorkerModule();
+  const syncContext = {
+    assignee: { kind: 'agent', id: 'engineer-agent' },
+    executionPolicy: {
+      stages: [
+        {
+          id: 'architect-review',
+          type: 'review',
+          participants: [{ kind: 'agent', id: 'architect-agent' }]
+        }
+      ]
+    },
+    executionState: null
+  };
+  const advancedSettings = {
+    defaultStatus: 'backlog',
+    ignoredIssueAuthorUsernames: []
+  };
+
+  assert.equal(
+    workerModule.__testing.isHealthyMaintainerWaitTransition({
+      currentStatus: 'in_progress',
+      nextStatus: 'in_review',
+      syncContext
+    }),
+    false
+  );
+  assert.deepEqual(
+    workerModule.__testing.resolveSyncTransitionAssignee({
+      currentStatus: 'in_progress',
+      nextStatus: 'in_review',
+      syncContext,
+      advancedSettings
+    }),
+    {
+      principal: { kind: 'agent', id: 'architect-agent' },
+      role: 'reviewer'
+    }
+  );
+});
+
 async function importManifestWithPluginVersion(pluginVersion?: string): Promise<typeof manifest> {
   const previousPluginVersion = process.env.PLUGIN_VERSION;
   const manifestModuleUrl = new URL(


### PR DESCRIPTION
## Summary
- keep completed healthy PR waits from selecting an internal reviewer again during sync
- clear stale execution policy/state when the synced PR is already in maintainer-wait state
- add focused tests that preserve implementation-to-review handoffs while preventing completed maintainer waits from restarting internal review

## Verification
- `env -u PAPERCLIP_API_URL -u PAPERCLIP_API_KEY -u PAPERCLIP_AGENT_ID -u PAPERCLIP_COMPANY_ID -u PAPERCLIP_RUN_ID npm test -- --test-name-pattern='healthy PR|active implementation'`
- `npm run typecheck`
- `git diff --check`
- Full plugin test suite also passed with the Paperclip heartbeat environment variables cleared.

## Approval
Authorized by Paperclip board approval `28bbb965-b0de-426c-9b70-27cb4d87fdc2` on `DEV-139`.

---
###### ✨ This message was AI-generated using gpt-5.5
