### PR TITLE
Remove strict host version gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Paperclip agents can search GitHub for duplicates, read and update issues, post 
 ## Requirements
 
 - Node.js 20+
-- a Paperclip host on `2026.427.0` or newer with plugin installation enabled
+- a Paperclip host with plugin installation enabled. GitHub Sync is built and tested against Paperclip `2026.427.0`; the manifest relies on explicit capabilities instead of a strict host-version gate because current latest/development hosts can report `0.0.0` during plugin upgrade.
 - a GitHub token with API access to the repositories you want to sync
 
 ## Install from npm
@@ -248,6 +248,7 @@ Because the KPI attribution endpoint is a native plugin JSON route rather than a
 
 ## Troubleshooting
 
+- If an older GitHub Sync build fails upgrade with `requires host version 2026.427.0 or newer, but this server is running 0.0.0`, upgrade to a build that removes the strict manifest host-version gate. The host is reporting a development-version sentinel, so the plugin now relies on declared capabilities and runtime fallbacks instead.
 - If setup is reported as incomplete, confirm that a GitHub token has been saved or that `${PAPERCLIP_HOME:-~/.paperclip}/plugins/github-sync/config.json` contains `githubToken`, and make sure at least one mapping has a created Paperclip project.
 - If Paperclip says board access is required, open plugin settings inside the affected company and complete the Paperclip board access flow before retrying sync.
 - If GitHub Sync agent tools fail with `403 {"error":"Board access required"}` on `/api/plugins/tools` or `/api/plugins/tools/execute`, the current Paperclip host rejected the request before the plugin worker ran. Re-run from a board-authenticated session or agent run that has board access to the target company.

--- a/SPEC.md
+++ b/SPEC.md
@@ -129,7 +129,7 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 ## Host integration requirements
 
 - The plugin MUST register successfully in Paperclip.
-- The plugin manifest MUST declare `minimumHostVersion: "2026.427.0"` because it relies on the host-owned `issues.wakeup` capability and plugin-origin issue metadata added in that Paperclip release.
+- The plugin manifest MUST NOT declare a strict `minimumHostVersion` or `minimumPaperclipVersion` gate while current latest/development Paperclip hosts may report `0.0.0` during plugin upgrade. Required host surfaces MUST remain represented by manifest capabilities and guarded by worker fallbacks where possible, and the docs MUST still state the intended Paperclip `2026.427.0` support baseline.
 - The plugin MUST expose a dashboard widget contribution for sync readiness and setup.
 - The plugin MUST expose a separate dashboard KPI widget contribution.
 - The plugin MUST expose a settings page contribution.

--- a/scripts/e2e/run-paperclip-smoke.mjs
+++ b/scripts/e2e/run-paperclip-smoke.mjs
@@ -507,6 +507,8 @@ async function main() {
   log('Installed local paperclip-github-plugin plugin.');
 
   const seededIssue = await ensureSeedIssueWithGitHubMetadata(company, seededProject);
+  const health = await fetchJson(new URL('/api/health', baseUrl).toString());
+  const isAuthenticatedDeployment = String(health?.deploymentMode ?? '').toLowerCase() === 'authenticated';
 
   const { chromium } = await import('playwright');
   const browser = await chromium.launch({ headless: true });
@@ -536,7 +538,12 @@ async function main() {
     await page.getByRole('heading', { name: 'GitHub Sync' }).waitFor({ timeout: 120000 });
     await page.getByText('GitHub Sync settings', { exact: true }).waitFor({ timeout: 120000 });
     await page.getByRole('heading', { name: 'GitHub access', exact: true }).waitFor({ timeout: 120000 });
-    await page.getByRole('heading', { name: 'Paperclip board access', exact: true }).waitFor({ timeout: 120000 });
+    const boardAccessHeading = page.getByRole('heading', { name: 'Paperclip board access', exact: true });
+    if (isAuthenticatedDeployment) {
+      await boardAccessHeading.waitFor({ timeout: 120000 });
+    } else if (await boardAccessHeading.count() > 0) {
+      throw new Error('Paperclip board access settings should stay hidden outside authenticated deployments.');
+    }
     await page.getByRole('heading', { name: 'Repositories', exact: true }).waitFor({ timeout: 120000 });
     await page.getByRole('heading', { name: 'Sync', exact: true }).waitFor({ timeout: 120000 });
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -21,7 +21,6 @@ export const manifest: PaperclipPluginManifestV1 = {
   id: GITHUB_SYNC_PLUGIN_ID,
   apiVersion: 1,
   version: MANIFEST_VERSION,
-  minimumHostVersion: '2026.427.0',
   displayName: 'GitHub Sync',
   description: 'Synchronize GitHub issues into Paperclip projects.',
   author: 'Álvaro Sánchez-Mariscal',

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -321,6 +321,11 @@ test(
   }
 );
 
+test('manifest does not enforce a strict host version gate during upgrade', () => {
+  assert.equal('minimumHostVersion' in manifest, false);
+  assert.equal('minimumPaperclipVersion' in manifest, false);
+});
+
 test('shouldStartWorkerHost matches symlinked entrypoints to the real worker file', async () => {
   const workerModule = await importFreshWorkerModule();
   const tempDir = await mkdtemp(join(tmpdir(), 'paperclip-github-plugin-worker-path-'));
@@ -3359,7 +3364,7 @@ test('manifest exposes GitHub Sync page, sidebar, dashboard widgets, and setting
 
   assert.equal(manifest.id, GITHUB_SYNC_PLUGIN_ID);
   assert.equal(manifest.apiVersion, 1);
-  assert.equal(manifest.minimumHostVersion, '2026.427.0');
+  assert.equal('minimumHostVersion' in manifest, false);
   assert.equal(manifest.entrypoints.worker, './dist/worker.js');
   assert.equal(manifest.jobs?.[0]?.jobKey, 'sync.github-issues');
   assert.equal(manifest.jobs?.[0]?.schedule, '* * * * *');


### PR DESCRIPTION
## Summary
- Remove the manifest `minimumHostVersion` gate so latest/development Paperclip hosts that report `0.0.0` during plugin upgrade can install the plugin.
- Keep the intended Paperclip `2026.427.0` support baseline documented through README/SPEC language and manifest capability declarations.
- Update the e2e smoke to only expect the Paperclip board-access settings section on authenticated deployments.

## Validation
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm test:e2e`

## Model Used
- Model ID/version: GPT-5 Codex, as exposed in this Codex desktop session.
- Context window: not exposed by the local Codex runtime.
- Capabilities used: repository file editing, shell commands, git, GitHub CLI, Playwright-backed e2e verification, and Codex app automation setup.