### PR TITLE
Speed up issue page GitHub sync

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -423,6 +423,8 @@ interface ResolvedSyncTarget {
   githubIssueId?: number;
   githubIssueNumber?: number;
   githubIssueUrl?: string;
+  githubPullRequestNumber?: number;
+  githubPullRequestUrl?: string;
   displayLabel: string;
 }
 
@@ -3426,6 +3428,26 @@ async function resolvePaperclipIssueGitHubLink(
   return await hydrateRecoveredPaperclipIssueGitHubLink(ctx, issueId, fallbackLink) ?? fallbackLink;
 }
 
+async function resolvePaperclipIssueGitHubPullRequestLink(
+  ctx: PluginSetupContext,
+  issueId: string,
+  companyId: string
+): Promise<GitHubPullRequestLinkRecord | null> {
+  const links = await listGitHubPullRequestLinkRecords(ctx, {
+    paperclipIssueId: issueId
+  });
+
+  return links
+    .filter((record) => !record.data.companyId || record.data.companyId === companyId)
+    .sort((left, right) => {
+      const rightTimestamp = Date.parse(right.updatedAt ?? right.createdAt ?? '');
+      const leftTimestamp = Date.parse(left.updatedAt ?? left.createdAt ?? '');
+      const safeRightTimestamp = Number.isFinite(rightTimestamp) ? rightTimestamp : 0;
+      const safeLeftTimestamp = Number.isFinite(leftTimestamp) ? leftTimestamp : 0;
+      return safeRightTimestamp - safeLeftTimestamp;
+    })[0] ?? null;
+}
+
 async function hydrateRecoveredPaperclipIssueGitHubLink(
   ctx: PluginSetupContext,
   issueId: string,
@@ -3519,22 +3541,35 @@ async function resolveManualSyncTarget(
 
     const link = await resolvePaperclipIssueGitHubLink(ctx, input.issueId, companyId);
     if (!link) {
-      throw new Error('This Paperclip issue is not linked to a GitHub issue yet. Run a broader sync first.');
-    }
+      const pullRequestLink = await resolvePaperclipIssueGitHubPullRequestLink(ctx, input.issueId, companyId);
+      if (!pullRequestLink) {
+        throw new Error('This Paperclip issue is not linked to a GitHub issue or pull request yet. Run a broader sync first.');
+      }
 
-    const candidateMappings = getSyncableMappingsForTarget(settings.mappings, {
-      kind: 'issue',
-      companyId,
-      projectId: link.paperclipProjectId,
-      repositoryUrl: link.repositoryUrl,
-      issueId: input.issueId,
-      githubIssueId: link.githubIssueId,
-      githubIssueNumber: link.githubIssueNumber,
-      githubIssueUrl: link.githubIssueUrl,
-      displayLabel: `issue #${link.githubIssueNumber}`
-    });
-    if (candidateMappings.length === 0) {
-      throw new Error('No saved GitHub repository mapping matches this Paperclip issue.');
+      const candidateMappings = getSyncableMappingsForTarget(settings.mappings, {
+        kind: 'issue',
+        companyId,
+        projectId: pullRequestLink.data.paperclipProjectId,
+        repositoryUrl: pullRequestLink.data.repositoryUrl,
+        issueId: input.issueId,
+        githubPullRequestNumber: pullRequestLink.data.githubPullRequestNumber,
+        githubPullRequestUrl: pullRequestLink.data.githubPullRequestUrl,
+        displayLabel: `pull request #${pullRequestLink.data.githubPullRequestNumber}`
+      });
+      if (candidateMappings.length === 0) {
+        throw new Error('No saved GitHub repository mapping matches this Paperclip issue.');
+      }
+
+      return {
+        kind: 'issue',
+        companyId,
+        projectId: pullRequestLink.data.paperclipProjectId,
+        issueId: input.issueId,
+        repositoryUrl: pullRequestLink.data.repositoryUrl,
+        githubPullRequestNumber: pullRequestLink.data.githubPullRequestNumber,
+        githubPullRequestUrl: pullRequestLink.data.githubPullRequestUrl,
+        displayLabel: `pull request #${pullRequestLink.data.githubPullRequestNumber}`
+      };
     }
 
     return {
@@ -3702,17 +3737,42 @@ async function buildToolbarSyncState(
 
   if (entityType === 'issue' && entityId && companyId) {
     const link = await resolvePaperclipIssueGitHubLink(ctx, entityId, companyId);
-    const mappings = link
+    if (link) {
+      const mappings = getSyncableMappingsForTarget(settings.mappings, {
+        kind: 'issue',
+        companyId,
+        projectId: link.paperclipProjectId,
+        issueId: entityId,
+        repositoryUrl: link.repositoryUrl,
+        githubIssueId: link.githubIssueId,
+        githubIssueNumber: link.githubIssueNumber,
+        githubIssueUrl: link.githubIssueUrl,
+        displayLabel: `issue #${link.githubIssueNumber}`
+      });
+
+      return {
+        kind: 'issue',
+        visible: false,
+        canRun: githubTokenConfigured && mappings.length > 0,
+        label: `Sync #${link.githubIssueNumber}`,
+        message: `Sync ${link.repositoryUrl.replace(/^https:\/\/github\.com\//, '')} issue #${link.githubIssueNumber}.`,
+        syncState: settings.syncState,
+        githubTokenConfigured,
+        savedMappingCount
+      };
+    }
+
+    const pullRequestLink = await resolvePaperclipIssueGitHubPullRequestLink(ctx, entityId, companyId);
+    const mappings = pullRequestLink
       ? getSyncableMappingsForTarget(settings.mappings, {
           kind: 'issue',
           companyId,
-          projectId: link.paperclipProjectId,
+          projectId: pullRequestLink.data.paperclipProjectId,
           issueId: entityId,
-          repositoryUrl: link.repositoryUrl,
-          githubIssueId: link.githubIssueId,
-          githubIssueNumber: link.githubIssueNumber,
-          githubIssueUrl: link.githubIssueUrl,
-          displayLabel: `issue #${link.githubIssueNumber}`
+          repositoryUrl: pullRequestLink.data.repositoryUrl,
+          githubPullRequestNumber: pullRequestLink.data.githubPullRequestNumber,
+          githubPullRequestUrl: pullRequestLink.data.githubPullRequestUrl,
+          displayLabel: `pull request #${pullRequestLink.data.githubPullRequestNumber}`
         })
       : [];
 
@@ -3720,9 +3780,11 @@ async function buildToolbarSyncState(
       kind: 'issue',
       visible: false,
       canRun: githubTokenConfigured && mappings.length > 0,
-      label: link?.githubIssueNumber ? `Sync #${link.githubIssueNumber}` : 'Sync issue',
-      message: link
-        ? `Sync ${link.repositoryUrl.replace(/^https:\/\/github\.com\//, '')} issue #${link.githubIssueNumber}.`
+      label: pullRequestLink?.data.githubPullRequestNumber
+        ? `Sync PR #${pullRequestLink.data.githubPullRequestNumber}`
+        : 'Sync issue',
+      message: pullRequestLink
+        ? `Sync ${pullRequestLink.data.repositoryUrl.replace(/^https:\/\/github\.com\//, '')} pull request #${pullRequestLink.data.githubPullRequestNumber}.`
         : 'This Paperclip issue is not linked to GitHub yet.',
       syncState: settings.syncState,
       githubTokenConfigured,
@@ -11763,6 +11825,56 @@ async function listRepositoryIssues(
   return normalizedIssues;
 }
 
+async function listRepositoryIssuesForSyncTarget(
+  octokit: Octokit,
+  repository: ParsedRepositoryReference,
+  state: 'open' | 'all',
+  target: ResolvedSyncTarget | undefined,
+  options: {
+    onProgress?: (progress: {
+      loadedIssueCount: number;
+    }) => Promise<void>;
+  } = {}
+): Promise<GitHubIssueRecord[]> {
+  if (target?.kind !== 'issue') {
+    return listRepositoryIssues(octokit, repository, state, options);
+  }
+
+  if (target.githubIssueNumber === undefined) {
+    if (options.onProgress) {
+      await options.onProgress({
+        loadedIssueCount: 0
+      });
+    }
+
+    return [];
+  }
+
+  const response = await octokit.rest.issues.get({
+    owner: repository.owner,
+    repo: repository.repo,
+    issue_number: target.githubIssueNumber,
+    headers: {
+      accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': GITHUB_API_VERSION
+    }
+  });
+  const issue = response.data as GitHubApiIssueRecord;
+  if ('pull_request' in issue) {
+    return [];
+  }
+
+  const normalizedIssue = normalizeGitHubIssueRecord(issue);
+  const issues = state === 'open' && normalizedIssue.state !== 'open' ? [] : [normalizedIssue];
+  if (options.onProgress) {
+    await options.onProgress({
+      loadedIssueCount: issues.length
+    });
+  }
+
+  return issues;
+}
+
 async function listRepositoryIssuesForImport(
   allIssues: GitHubIssueRecord[]
 ): Promise<GitHubIssueRecord[]> {
@@ -17572,10 +17684,11 @@ async function performSync(
         updateSyncFailureContext(failureContext, {
           phase: 'listing_github_issues'
         });
-        const allIssues = await listRepositoryIssues(
+        const allIssues = await listRepositoryIssuesForSyncTarget(
           octokit,
           repository,
           shouldLoadClosedIssues ? 'all' : 'open',
+          options.target,
           {
             onProgress: async (progress) => {
               currentProgress = {
@@ -17714,7 +17827,10 @@ async function performSync(
         await persistRunningProgress(true);
 
         try {
-          const warmedLinkedPullRequests = await loadLinkedPullRequestsForOpenIssues(octokit, repository);
+          const warmedLinkedPullRequests =
+            options.target?.kind === 'issue'
+              ? new Map<number, GitHubLinkedPullRequestRecord[]>()
+              : await loadLinkedPullRequestsForOpenIssues(octokit, repository);
           for (const [issueNumber, linkedPullRequests] of warmedLinkedPullRequests.entries()) {
             linkedPullRequestsByIssueNumber.set(issueNumber, linkedPullRequests);
           }

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -7983,6 +7983,276 @@ test('worker exposes toolbar sync state for global, project, and issue surfaces'
   assert.equal(issueState.label, 'Sync #77');
 });
 
+test('worker issue toolbar sync state supports Paperclip issues linked directly to GitHub pull requests', async () => {
+  const harness = await createProjectPullRequestsHarness();
+  const issue = await harness.ctx.issues.create({
+    companyId: 'company-1',
+    projectId: 'project-1',
+    title: 'Manual PR-linked issue',
+    description: 'This Paperclip issue is linked directly to a GitHub PR.'
+  });
+
+  await harness.ctx.entities.upsert({
+    entityType: 'paperclip-github-plugin.pull-request-link',
+    scopeKind: 'issue',
+    scopeId: issue.id,
+    externalId: 'https://github.com/paperclipai/example-repo/pull/89',
+    title: 'GitHub pull request #89',
+    status: 'open',
+    data: {
+      companyId: 'company-1',
+      paperclipProjectId: 'project-1',
+      repositoryUrl: 'https://github.com/paperclipai/example-repo',
+      githubPullRequestNumber: 89,
+      githubPullRequestUrl: 'https://github.com/paperclipai/example-repo/pull/89',
+      githubPullRequestState: 'open',
+      title: 'GitHub PR linked later',
+      syncedAt: '2026-04-27T09:30:00.000Z'
+    }
+  });
+
+  const toolbarState = await harness.getData<{
+    kind: string;
+    visible: boolean;
+    canRun: boolean;
+    label: string;
+    message?: string;
+  }>('sync.toolbarState', {
+    companyId: 'company-1',
+    entityType: 'issue',
+    entityId: issue.id
+  });
+
+  assert.equal(toolbarState.kind, 'issue');
+  assert.equal(toolbarState.visible, false);
+  assert.equal(toolbarState.canRun, true);
+  assert.equal(toolbarState.label, 'Sync PR #89');
+  assert.equal(toolbarState.message, 'Sync paperclipai/example-repo pull request #89.');
+});
+
+test('sync.runNow can target a Paperclip issue linked to a GitHub issue without listing the whole repository', async () => {
+  const harness = await createProjectPullRequestsHarness();
+  const originalFetch = globalThis.fetch;
+  const issue = await harness.ctx.issues.create({
+    companyId: 'company-1',
+    projectId: 'project-1',
+    title: 'Targeted manual issue link sync',
+    description: 'This Paperclip issue is linked directly to a GitHub issue.'
+  });
+
+  globalThis.fetch = async (input, init) => {
+    const requestUrl = getRequestUrl(input);
+    const requestPathname = getDecodedRequestPathname(input);
+
+    if (requestPathname === '/repos/paperclipai/example-repo/issues/88') {
+      return jsonResponse({
+        id: 8800,
+        number: 88,
+        title: 'GitHub issue linked later',
+        body: 'GitHub owns the delivery state.',
+        html_url: 'https://github.com/paperclipai/example-repo/issues/88',
+        state: 'open',
+        state_reason: null,
+        comments: 2,
+        user: {
+          login: 'octocat',
+          html_url: 'https://github.com/octocat',
+          avatar_url: 'https://avatars.githubusercontent.com/u/583231?v=4'
+        },
+        labels: []
+      });
+    }
+
+    if (requestPathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      if (query.includes('query GitHubRepositoryOpenIssueLinkedPullRequests')) {
+        throw new Error('Issue-targeted sync should not load linked pull requests for the whole repository.');
+      }
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && variables.issueNumber === 88) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: []
+              },
+              comments: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: []
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected fetch during targeted manual GitHub issue sync test: ${requestUrl}`);
+  };
+
+  try {
+    await harness.performAction('issue.linkGitHubItem', {
+      companyId: 'company-1',
+      issueId: issue.id,
+      kind: 'issue',
+      reference: '88'
+    });
+
+    const sync = await harness.performAction('sync.runNow', {
+      companyId: 'company-1',
+      issueId: issue.id,
+      waitForCompletion: true
+    }) as {
+      syncState: { status: string; syncedIssuesCount?: number };
+    };
+
+    assert.equal(sync.syncState.status, 'success');
+    assert.equal(sync.syncState.syncedIssuesCount, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('sync.runNow can target a Paperclip issue linked directly to a GitHub pull request', async () => {
+  const harness = await createProjectPullRequestsHarness();
+  const originalFetch = globalThis.fetch;
+  const originalCreateComment = harness.ctx.issues.createComment;
+  const statusTransitionComments: Array<{ issueId: string; body: string }> = [];
+  const issue = await harness.ctx.issues.create({
+    companyId: 'company-1',
+    projectId: 'project-1',
+    title: 'Targeted manual PR link sync',
+    description: 'This Paperclip issue is linked directly to a GitHub PR.'
+  });
+
+  harness.ctx.issues.createComment = async (issueId, body, companyId) => {
+    statusTransitionComments.push({ issueId, body });
+    return originalCreateComment(issueId, body, companyId);
+  };
+
+  await harness.ctx.entities.upsert({
+    entityType: 'paperclip-github-plugin.pull-request-link',
+    scopeKind: 'issue',
+    scopeId: issue.id,
+    externalId: 'https://github.com/paperclipai/example-repo/pull/89',
+    title: 'GitHub pull request #89',
+    status: 'open',
+    data: {
+      companyId: 'company-1',
+      paperclipProjectId: 'project-1',
+      repositoryUrl: 'https://github.com/paperclipai/example-repo',
+      githubPullRequestNumber: 89,
+      githubPullRequestUrl: 'https://github.com/paperclipai/example-repo/pull/89',
+      githubPullRequestState: 'open',
+      title: 'GitHub PR linked later',
+      syncedAt: '2026-04-27T09:30:00.000Z'
+    }
+  });
+  await harness.ctx.issues.update(issue.id, { status: 'in_review' }, 'company-1');
+
+  globalThis.fetch = async (input, init) => {
+    const requestUrl = getRequestUrl(input);
+    const requestPathname = getDecodedRequestPathname(input);
+
+    if (requestPathname === '/repos/paperclipai/example-repo/issues') {
+      throw new Error('PR-targeted sync should not list GitHub issues for the whole repository.');
+    }
+
+    if (requestPathname === '/repos/paperclipai/example-repo/pulls/89') {
+      return jsonResponse({
+        number: 89,
+        title: 'GitHub PR linked later',
+        body: 'GitHub owns PR readiness.',
+        html_url: 'https://github.com/paperclipai/example-repo/pull/89',
+        state: 'open',
+        merged: false
+      });
+    }
+
+    if (requestPathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      const pullRequestNumber =
+        typeof variables.pullRequestNumber === 'number' ? variables.pullRequestNumber : undefined;
+
+      if (query.includes('query GitHubRepositoryOpenIssueLinkedPullRequests')) {
+        throw new Error('PR-targeted sync should not load linked pull requests for the whole repository.');
+      }
+
+      if (query.includes('query GitHubPullRequestReviewThreads') && pullRequestNumber === 89) {
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: []
+              }
+            }
+          }
+        });
+      }
+
+      if (query.includes('query GitHubPullRequestCiContexts') && pullRequestNumber === 89) {
+        return graphqlResponse({
+          repository: {
+            pullRequest: {
+              mergeable: 'CONFLICTING',
+              mergeStateStatus: 'DIRTY',
+              statusCheckRollup: {
+                contexts: {
+                  pageInfo: {
+                    hasNextPage: false,
+                    endCursor: null
+                  },
+                  nodes: [
+                    {
+                      __typename: 'CheckRun',
+                      status: 'COMPLETED',
+                      conclusion: 'FAILURE'
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected fetch during targeted manual PR link sync test: ${requestUrl}`);
+  };
+
+  try {
+    const sync = await harness.performAction('sync.runNow', {
+      companyId: 'company-1',
+      issueId: issue.id,
+      waitForCompletion: true
+    }) as {
+      syncState: { status: string; syncedIssuesCount?: number };
+    };
+
+    assert.equal(sync.syncState.status, 'success');
+    assert.equal(sync.syncState.syncedIssuesCount, 1);
+
+    const updatedIssue = await harness.ctx.issues.get(issue.id, 'company-1');
+    assert.equal(updatedIssue?.status, 'todo');
+    assert.equal(statusTransitionComments.length, 1);
+    assert.match(statusTransitionComments[0]?.body ?? '', /from `in review` to `todo`/);
+    assert.match(statusTransitionComments[0]?.body ?? '', /failing CI/);
+  } finally {
+    harness.ctx.issues.createComment = originalCreateComment;
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('worker scopes global toolbar sync state to the requested company', async () => {
   const harness = createTestHarness({
     manifest,


### PR DESCRIPTION
## Summary
- Enable issue-page Sync for Paperclip issues linked directly to GitHub PRs.
- Teach issue-scoped manual sync to resolve PR-only links and sync only that target.
- Avoid repository-wide GitHub issue listing and bulk linked-PR warmup for issue-page sync.

## Validation
- pnpm exec tsx --test tests/plugin.spec.ts --test-name-pattern "without listing the whole repository|linked directly to a GitHub pull request"
- pnpm typecheck
- pnpm test
- pnpm build
- git diff --check

## Model Used
- OpenAI Codex coding agent, model id: gpt-5. The exact backend revision and context-window size were not exposed by the local Codex runtime. Tool use included local shell, git, and GitHub CLI.