### PR TITLE
Adapt GitHub Sync to Paperclip 2026.428.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The plugin adds a full in-host workflow instead of a one-off import script:
 2. Connect one or more GitHub repositories to Paperclip projects.
 3. Run a sync manually or let the scheduled job keep things up to date.
 
-During sync, the plugin imports one top-level Paperclip issue per GitHub issue, stamps it with a namespaced GitHub Sync plugin origin, updates already imported issues instead of recreating them, maps GitHub labels into Paperclip labels, and keeps GitHub-specific metadata in dedicated Paperclip surfaces rather than stuffing everything into the issue description.
+During sync, the plugin imports one top-level Paperclip issue per GitHub issue, stamps it with a namespaced GitHub Sync plugin origin, updates already imported issues instead of recreating them, maps GitHub labels into Paperclip labels, and keeps GitHub-specific metadata in dedicated Paperclip surfaces rather than stuffing everything into the issue description. On Paperclip `2026.428.0` and newer, the detail surfaces can also recover GitHub issue and pull request links from Paperclip's own `originKind` / `originId` fields when the plugin registry or legacy hidden marker is missing.
 
 When the host exposes plugin issue creation, imported GitHub issues are created through the Paperclip plugin SDK path so they are not attributed to the connected board user. The worker still uses direct local Paperclip REST calls for label sync and for description, assignee, or status repair paths when those routes are available.
 
@@ -95,7 +95,7 @@ Paperclip agents can search GitHub for duplicates, read and update issues, post 
 ## Requirements
 
 - Node.js 20+
-- a Paperclip host with plugin installation enabled. GitHub Sync is built and tested against Paperclip `2026.427.0`; the manifest relies on explicit capabilities instead of a strict host-version gate because current latest/development hosts can report `0.0.0` during plugin upgrade.
+- a Paperclip host with plugin installation enabled. GitHub Sync is built and tested against Paperclip `2026.428.0`; the manifest relies on explicit capabilities instead of a strict host-version gate because current latest/development hosts can report `0.0.0` during plugin upgrade.
 - a GitHub token with API access to the repositories you want to sync
 
 ## Install from npm
@@ -283,10 +283,12 @@ Useful scripts:
 
 - `pnpm dev` watches the manifest, worker, and UI bundles and rebuilds them into `dist/`
 - `pnpm dev:ui` starts a local Paperclip plugin UI dev server from `dist/ui` on port `4177`
-- `pnpm test:e2e` builds the plugin, boots an isolated Paperclip instance, installs the plugin, and verifies the hosted settings page renders
-- `pnpm verify:manual` builds the plugin, boots a local-trusted Paperclip instance for manual inspection, seeds a `Dummy Company` with a mapped review project and a `CEO` agent on the Codex local adapter using model `gpt-5.4`, installs the plugin, and opens the company dashboard without seeding KPI history.
+- `pnpm test:e2e` builds the plugin, boots an isolated Paperclip `2026.428.0` instance, installs the plugin, and verifies the hosted settings page renders
+- `pnpm verify:manual` builds the plugin, boots a local-trusted Paperclip `2026.428.0` instance for manual inspection, seeds a `Dummy Company` with a mapped review project and a `CEO` agent on the Codex local adapter using model `gpt-5.4`, installs the plugin, and opens the company dashboard without seeding KPI history.
 
 For fast hosted UI iteration, run `pnpm dev` in one terminal and `pnpm dev:ui` in another.
+
+Set `PAPERCLIP_E2E_PAPERCLIPAI_VERSION` to run e2e or manual verification against a different Paperclip release.
 
 If you want the seeded `CEO` agent used in manual verification to opt into Codex's bypass flag, set `PAPERCLIP_E2E_CEO_BYPASS_APPROVALS_AND_SANDBOX=true`.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -74,6 +74,7 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 - The sync flow MUST create one top-level Paperclip issue per imported GitHub issue when the target mapping has a resolved Paperclip project identifier.
 - When the Paperclip runtime exposes plugin issue creation, the sync flow SHOULD prefer `ctx.issues.create(...)` for imported issue creation and reserve direct Paperclip REST issue calls for repair or update paths so imported issues are not attributed to the connected board user.
 - Imported GitHub issues MUST be created with a GitHub Sync namespaced plugin origin and the canonical GitHub issue URL as `originId`.
+- When a Paperclip issue has a GitHub Sync GitHub-issue or pull-request `originKind` and a parseable GitHub URL in `originId`, issue-scoped GitHub detail reads MUST use that origin metadata as a durable fallback when plugin-owned link entities, import-registry entries, or hidden description markers are missing.
 - When the mapping company has a configured default assignee, the sync flow MUST assign newly created imported Paperclip issues to that Paperclip assignee, whether the saved principal is a Paperclip agent or the connected board user.
 - Imported Paperclip issues MUST keep the original GitHub issue title without adding a `[GitHub]` prefix.
 - Imported issue descriptions SHOULD contain the normalized GitHub body when present and MUST normalize the GitHub raw HTML constructs that Paperclip cannot render in multiline descriptions.
@@ -131,7 +132,8 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 ## Host integration requirements
 
 - The plugin MUST register successfully in Paperclip.
-- The plugin manifest MUST NOT declare a strict `minimumHostVersion` or `minimumPaperclipVersion` gate while current latest/development Paperclip hosts may report `0.0.0` during plugin upgrade. Required host surfaces MUST remain represented by manifest capabilities and guarded by worker fallbacks where possible, and the docs MUST still state the intended Paperclip `2026.427.0` support baseline.
+- The plugin manifest MUST NOT declare a strict `minimumHostVersion` or `minimumPaperclipVersion` gate while current latest/development Paperclip hosts may report `0.0.0` during plugin upgrade. Required host surfaces MUST remain represented by manifest capabilities and guarded by worker fallbacks where possible, and the docs MUST still state the intended Paperclip `2026.428.0` support baseline.
+- Disposable e2e and manual host verification MUST pin the Paperclip CLI to `2026.428.0` by default, while retaining an explicit environment override for forward and backward compatibility checks.
 - The plugin MUST expose a dashboard widget contribution for sync readiness and setup.
 - The plugin MUST expose a separate dashboard KPI widget contribution.
 - The plugin MUST expose a settings page contribution.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "paperclip-github-plugin",
-  "version": "0.6.1",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paperclip-github-plugin",
-      "version": "0.6.1",
+      "version": "0.7.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@octokit/rest": "^22.0.1",
-        "@paperclipai/plugin-sdk": "^2026.427.0",
+        "@paperclipai/plugin-sdk": "^2026.428.0",
         "react": "^19.2.5",
         "react-markdown": "^10.1.0",
         "rehype-raw": "^7.0.0",
@@ -627,12 +627,12 @@
       }
     },
     "node_modules/@paperclipai/plugin-sdk": {
-      "version": "2026.427.0",
-      "resolved": "https://registry.npmjs.org/@paperclipai/plugin-sdk/-/plugin-sdk-2026.427.0.tgz",
-      "integrity": "sha512-nmEg133QbVHWsqchyKAk7muiXy6m/PTSKlEHcpgnnQuI3A+OKROJf3RaENDN1bpgSsQJiiLfF90/hm3zH7N5vw==",
+      "version": "2026.428.0",
+      "resolved": "https://registry.npmjs.org/@paperclipai/plugin-sdk/-/plugin-sdk-2026.428.0.tgz",
+      "integrity": "sha512-FcpV5zmSCz6Kkp+JfSmHNtcmN6NJyMxCv3ILwj1/yesRa4xP+mEmJrMnkXC9PLeVeIoEub7BlmVJ9UWzig2JKA==",
       "license": "MIT",
       "dependencies": {
-        "@paperclipai/shared": "2026.427.0",
+        "@paperclipai/shared": "2026.428.0",
         "zod": "^3.24.2"
       },
       "bin": {
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/@paperclipai/shared": {
-      "version": "2026.427.0",
-      "resolved": "https://registry.npmjs.org/@paperclipai/shared/-/shared-2026.427.0.tgz",
-      "integrity": "sha512-NX3/xd5isVfrRIGaPWZNVSYhPAka9Xo96Vb54wwzdrAIGl3vQf9QMAREv0CiXnPbCXSBCjwjNn0ldFb6j/byhA==",
+      "version": "2026.428.0",
+      "resolved": "https://registry.npmjs.org/@paperclipai/shared/-/shared-2026.428.0.tgz",
+      "integrity": "sha512-b4irrk/b+aGafkDgURVZJ/uGkyL1ryXy85RUv6cr1X+hg4581CejIiZ4QDMNxCGtRzfyKKXIecSDaq8Yqx4gKw==",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.24.2"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@octokit/rest": "^22.0.1",
-    "@paperclipai/plugin-sdk": "^2026.427.0",
+    "@paperclipai/plugin-sdk": "^2026.428.0",
     "react": "^19.2.5",
     "react-markdown": "^10.1.0",
     "rehype-raw": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@paperclipai/plugin-sdk':
-        specifier: ^2026.427.0
-        version: 2026.427.0(react@19.2.5)
+        specifier: ^2026.428.0
+        version: 2026.428.0(react@19.2.5)
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -415,8 +415,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@paperclipai/plugin-sdk@2026.427.0':
-    resolution: {integrity: sha512-nmEg133QbVHWsqchyKAk7muiXy6m/PTSKlEHcpgnnQuI3A+OKROJf3RaENDN1bpgSsQJiiLfF90/hm3zH7N5vw==}
+  '@paperclipai/plugin-sdk@2026.428.0':
+    resolution: {integrity: sha512-FcpV5zmSCz6Kkp+JfSmHNtcmN6NJyMxCv3ILwj1/yesRa4xP+mEmJrMnkXC9PLeVeIoEub7BlmVJ9UWzig2JKA==}
     hasBin: true
     peerDependencies:
       react: '>=18'
@@ -424,8 +424,8 @@ packages:
       react:
         optional: true
 
-  '@paperclipai/shared@2026.427.0':
-    resolution: {integrity: sha512-NX3/xd5isVfrRIGaPWZNVSYhPAka9Xo96Vb54wwzdrAIGl3vQf9QMAREv0CiXnPbCXSBCjwjNn0ldFb6j/byhA==}
+  '@paperclipai/shared@2026.428.0':
+    resolution: {integrity: sha512-b4irrk/b+aGafkDgURVZJ/uGkyL1ryXy85RUv6cr1X+hg4581CejIiZ4QDMNxCGtRzfyKKXIecSDaq8Yqx4gKw==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
@@ -1077,14 +1077,14 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@paperclipai/plugin-sdk@2026.427.0(react@19.2.5)':
+  '@paperclipai/plugin-sdk@2026.428.0(react@19.2.5)':
     dependencies:
-      '@paperclipai/shared': 2026.427.0
+      '@paperclipai/shared': 2026.428.0
       zod: 3.25.76
     optionalDependencies:
       react: 19.2.5
 
-  '@paperclipai/shared@2026.427.0':
+  '@paperclipai/shared@2026.428.0':
     dependencies:
       zod: 3.25.76
 

--- a/scripts/e2e/manual-paperclip-verify.mjs
+++ b/scripts/e2e/manual-paperclip-verify.mjs
@@ -22,6 +22,12 @@ const seededMappingId = 'manual-review-seeded-mapping';
 const seededAgentName = 'CEO';
 const seededAgentModel = 'gpt-5.4';
 const seededAgentHireDecisionNote = 'Approved automatically for GitHub Sync manual verification seeding.';
+const seededCompanyAttachmentMaxBytes = 10 * 1024 * 1024;
+const defaultPaperclipaiVersion = '2026.428.0';
+const paperclipaiVersion = process.env.PAPERCLIP_E2E_PAPERCLIPAI_VERSION?.trim() || defaultPaperclipaiVersion;
+const paperclipaiPackageSpec = paperclipaiVersion.startsWith('paperclipai@')
+  ? paperclipaiVersion
+  : `paperclipai@${paperclipaiVersion}`;
 const githubSyncPluginKey = 'paperclip-github-plugin';
 const seedAgentBypassApprovalsAndSandbox = process.env.PAPERCLIP_E2E_CEO_BYPASS_APPROVALS_AND_SANDBOX === 'true';
 const requestedPort = process.env.PAPERCLIP_E2E_PORT ? Number(process.env.PAPERCLIP_E2E_PORT) : 3100;
@@ -65,7 +71,7 @@ function log(message) {
 }
 
 function getPaperclipCommandArgs(args) {
-  return ['-p', 'node@20', '-p', 'paperclipai', 'paperclipai', ...args];
+  return ['-p', 'node@20', '-p', paperclipaiPackageSpec, 'paperclipai', ...args];
 }
 
 function runCommand(command, args, options = {}) {
@@ -135,6 +141,18 @@ function tryListen(port) {
       });
     });
   });
+}
+
+async function assertPaperclipReleaseUnderTest() {
+  const { stdout, stderr } = await runCommand('npx', getPaperclipCommandArgs(['--version']), { quiet: true });
+  const versionOutput = `${stdout}\n${stderr}`.trim();
+  if (!versionOutput.includes(paperclipaiVersion)) {
+    throw new Error(
+      `Expected disposable Paperclip CLI ${paperclipaiVersion}, but received version output: ${versionOutput || '<empty>'}`
+    );
+  }
+
+  log(`Using ${paperclipaiPackageSpec} for manual Paperclip verification.`);
 }
 
 async function findAvailablePort(startPort) {
@@ -312,7 +330,8 @@ async function ensureCompanySeeded() {
     method: 'POST',
     body: JSON.stringify({
       name: seededCompanyName,
-      description: 'Seed company for GitHub Sync manual review.'
+      description: 'Seed company for GitHub Sync manual review.',
+      attachmentMaxBytes: seededCompanyAttachmentMaxBytes
     })
   });
 
@@ -685,6 +704,7 @@ async function main() {
   embeddedDbPort = await findAvailablePort(requestedDbPort);
   const configPath = join(paperclipHome, 'instances', instanceId, 'config.json');
   env.PAPERCLIP_CONFIG_PATH = configPath;
+  await assertPaperclipReleaseUnderTest();
   await ensureConfigFile(configPath);
   baseUrl = await readConfiguredBaseUrl(configPath);
 

--- a/scripts/e2e/run-paperclip-smoke.mjs
+++ b/scripts/e2e/run-paperclip-smoke.mjs
@@ -22,6 +22,12 @@ const seededGitHubIssueUrl = 'https://github.com/paperclipai/example-repo/issues
 const seededGitHubPullRequestUrl = 'https://github.com/paperclipai/example-repo/pull/1000';
 const manualGitHubIssueLinkTitle = 'Manual GitHub Issue Link Smoke';
 const manualGitHubPullRequestLinkTitle = 'Manual GitHub PR Link Smoke';
+const seededCompanyAttachmentMaxBytes = 10 * 1024 * 1024;
+const defaultPaperclipaiVersion = '2026.428.0';
+const paperclipaiVersion = process.env.PAPERCLIP_E2E_PAPERCLIPAI_VERSION?.trim() || defaultPaperclipaiVersion;
+const paperclipaiPackageSpec = paperclipaiVersion.startsWith('paperclipai@')
+  ? paperclipaiVersion
+  : `paperclipai@${paperclipaiVersion}`;
 const requestedPort = process.env.PAPERCLIP_E2E_PORT ? Number(process.env.PAPERCLIP_E2E_PORT) : 3100;
 const requestedDbPort = process.env.PAPERCLIP_E2E_DB_PORT ? Number(process.env.PAPERCLIP_E2E_DB_PORT) : 54329;
 const defaultTimeoutMs = 30000;
@@ -48,7 +54,7 @@ function log(message) {
 }
 
 function getPaperclipCommandArgs(args) {
-  return ['-p', 'node@20', '-p', 'paperclipai', 'paperclipai', ...args];
+  return ['-p', 'node@20', '-p', paperclipaiPackageSpec, 'paperclipai', ...args];
 }
 
 function runCommand(command, args, options = {}) {
@@ -117,6 +123,18 @@ function captureCommand(command, args, options = {}) {
       rejectPromise(new Error(`${command} ${args.join(' ')} exited with code ${code}\n${stderr}`));
     });
   });
+}
+
+async function assertPaperclipReleaseUnderTest() {
+  const { stdout, stderr } = await captureCommand('npx', getPaperclipCommandArgs(['--version']));
+  const versionOutput = `${stdout}\n${stderr}`.trim();
+  if (!versionOutput.includes(paperclipaiVersion)) {
+    throw new Error(
+      `Expected disposable Paperclip CLI ${paperclipaiVersion}, but received version output: ${versionOutput || '<empty>'}`
+    );
+  }
+
+  log(`Using ${paperclipaiPackageSpec} for disposable Paperclip verification.`);
 }
 
 function tryListen(port) {
@@ -421,7 +439,8 @@ async function ensureCompanySeeded() {
     method: 'POST',
     body: JSON.stringify({
       name: 'Dummy Company',
-      description: 'Seed company for paperclip-github-plugin e2e verification.'
+      description: 'Seed company for paperclip-github-plugin e2e verification.',
+      attachmentMaxBytes: seededCompanyAttachmentMaxBytes
     })
   });
 
@@ -680,6 +699,7 @@ async function main() {
   embeddedDbPort = await findAvailablePort(requestedDbPort);
   const configPath = join(paperclipHome, 'instances', instanceId, 'config.json');
   env.PAPERCLIP_CONFIG_PATH = configPath;
+  await assertPaperclipReleaseUnderTest();
   await ensureConfigFile(configPath);
   const githubToken = await ensureWorkerGitHubTokenConfig();
   const manualLinkFixtures = await resolveManualLinkFixtures(githubToken);

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -326,7 +326,7 @@ interface SyncToolbarStateData {
 interface GitHubIssueDetailsData {
   paperclipIssueId: string;
   kind?: 'issue' | 'pull_request';
-  source: 'entity' | 'import_registry' | 'description' | 'pull_request_entity';
+  source: 'entity' | 'import_registry' | 'description' | 'issue_origin' | 'pull_request_entity';
   githubIssueNumber?: number;
   githubIssueUrl?: string;
   githubPullRequestNumber?: number;
@@ -14656,6 +14656,8 @@ function GitHubSyncIssueDetailTabContent(props: {
       ? 'Closed'
       : 'Open'
     : formatGitHubIssueState(issueDetails?.githubIssueState, issueDetails?.githubIssueStateReason);
+  const showRecoveredLinkNote = issueDetails?.source === 'issue_origin'
+    || (issueDetails?.kind !== 'pull_request' && issueDetails?.source !== 'entity');
 
   function closeManualLinkModal(): void {
     if (manualLinkPending) {
@@ -14858,9 +14860,11 @@ function GitHubSyncIssueDetailTabContent(props: {
             </div>
           ) : null}
 
-          {issueDetails.kind !== 'pull_request' && issueDetails.source !== 'entity' ? (
+          {showRecoveredLinkNote ? (
             <div className="ghsync-extension-note">
-              GitHub Sync recovered this link from older sync metadata. Run sync once to refresh the creator, GitHub state, labels, and linked PRs in this panel.
+              {issueDetails.source === 'issue_origin'
+                ? 'GitHub Sync recovered this link from the Paperclip issue origin. Run sync once to refresh richer GitHub metadata in this panel.'
+                : 'GitHub Sync recovered this link from older sync metadata. Run sync once to refresh the creator, GitHub state, labels, and linked PRs in this panel.'}
             </div>
           ) : null}
         </>

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -376,7 +376,7 @@ interface GitHubIssueLinkTarget {
 }
 
 interface ResolvedPaperclipIssueGitHubLink {
-  source: 'entity' | 'import_registry' | 'description';
+  source: 'entity' | 'import_registry' | 'description' | 'issue_origin';
   companyId?: string;
   paperclipProjectId?: string;
   repositoryUrl: string;
@@ -386,6 +386,13 @@ interface ResolvedPaperclipIssueGitHubLink {
   linkedPullRequestNumbers: number[];
   linkedPullRequests: GitHubPullRequestReference[];
   entityRecord?: GitHubIssueLinkRecord;
+}
+
+interface ResolvedPaperclipPullRequestOriginLink {
+  source: 'issue_origin';
+  repositoryUrl: string;
+  githubPullRequestNumber: number;
+  githubPullRequestUrl: string;
 }
 
 interface StoredStatusTransitionCommentAnnotation {
@@ -3350,6 +3357,51 @@ function doesImportedIssueMatchTarget(
     (target.githubIssueNumber !== undefined && issue.githubIssueNumber === target.githubIssueNumber);
 }
 
+function resolvePaperclipIssueOriginGitHubIssueLink(
+  issue: Issue | null | undefined,
+  companyId: string
+): ResolvedPaperclipIssueGitHubLink | null {
+  if (issue?.originKind !== GITHUB_ISSUE_ORIGIN_KIND || typeof issue.originId !== 'string') {
+    return null;
+  }
+
+  const reference = parseGitHubIssueHtmlUrl(issue.originId);
+  if (!reference) {
+    return null;
+  }
+
+  return {
+    source: 'issue_origin',
+    companyId,
+    paperclipProjectId: issue.projectId ?? undefined,
+    repositoryUrl: reference.repositoryUrl,
+    githubIssueNumber: reference.issueNumber,
+    githubIssueUrl: reference.issueUrl,
+    linkedPullRequestNumbers: [],
+    linkedPullRequests: []
+  };
+}
+
+function resolvePaperclipIssueOriginGitHubPullRequestLink(
+  issue: Issue | null | undefined
+): ResolvedPaperclipPullRequestOriginLink | null {
+  if (issue?.originKind !== GITHUB_PULL_REQUEST_ORIGIN_KIND || typeof issue.originId !== 'string') {
+    return null;
+  }
+
+  const reference = parseGitHubPullRequestHtmlUrl(issue.originId);
+  if (!reference) {
+    return null;
+  }
+
+  return {
+    source: 'issue_origin',
+    repositoryUrl: reference.repositoryUrl,
+    githubPullRequestNumber: reference.pullRequestNumber,
+    githubPullRequestUrl: reference.pullRequestUrl
+  };
+}
+
 async function resolvePaperclipIssueGitHubLink(
   ctx: PluginSetupContext,
   issueId: string,
@@ -3408,6 +3460,11 @@ async function resolvePaperclipIssueGitHubLink(
   }
 
   const issue = options.paperclipIssue ?? await ctx.issues.get(issueId, companyId);
+  const issueOriginLink = resolvePaperclipIssueOriginGitHubIssueLink(issue, companyId);
+  if (issueOriginLink) {
+    return await hydrateRecoveredPaperclipIssueGitHubLink(ctx, issueId, issueOriginLink) ?? issueOriginLink;
+  }
+
   const githubIssueUrl = extractImportedGitHubIssueUrlFromDescription(issue?.description);
   const githubIssueReference = githubIssueUrl ? parseGitHubIssueHtmlUrl(githubIssueUrl) : null;
   if (!githubIssueReference) {
@@ -4074,27 +4131,47 @@ async function buildIssueGitHubDetails(
       const safeLeftTimestamp = Number.isFinite(leftTimestamp) ? leftTimestamp : 0;
       return safeRightTimestamp - safeLeftTimestamp;
     })[0];
-  if (!pullRequestLink) {
+  if (pullRequestLink) {
+    return {
+      paperclipIssueId: issueId,
+      kind: 'pull_request',
+      source: 'pull_request_entity',
+      repositoryUrl: pullRequestLink.data.repositoryUrl,
+      githubPullRequestNumber: pullRequestLink.data.githubPullRequestNumber,
+      githubPullRequestUrl: pullRequestLink.data.githubPullRequestUrl,
+      githubPullRequestState: pullRequestLink.data.githubPullRequestState,
+      title: pullRequestLink.data.title,
+      linkedPullRequestNumbers: [pullRequestLink.data.githubPullRequestNumber],
+      linkedPullRequests: [
+        {
+          number: pullRequestLink.data.githubPullRequestNumber,
+          repositoryUrl: pullRequestLink.data.repositoryUrl
+        }
+      ],
+      syncedAt: pullRequestLink.data.syncedAt
+    };
+  }
+
+  const paperclipIssue = await ctx.issues.get(issueId, companyId);
+  const pullRequestOriginLink = resolvePaperclipIssueOriginGitHubPullRequestLink(paperclipIssue);
+  if (!pullRequestOriginLink) {
     return null;
   }
 
   return {
     paperclipIssueId: issueId,
     kind: 'pull_request',
-    source: 'pull_request_entity',
-    repositoryUrl: pullRequestLink.data.repositoryUrl,
-    githubPullRequestNumber: pullRequestLink.data.githubPullRequestNumber,
-    githubPullRequestUrl: pullRequestLink.data.githubPullRequestUrl,
-    githubPullRequestState: pullRequestLink.data.githubPullRequestState,
-    title: pullRequestLink.data.title,
-    linkedPullRequestNumbers: [pullRequestLink.data.githubPullRequestNumber],
+    source: pullRequestOriginLink.source,
+    repositoryUrl: pullRequestOriginLink.repositoryUrl,
+    githubPullRequestNumber: pullRequestOriginLink.githubPullRequestNumber,
+    githubPullRequestUrl: pullRequestOriginLink.githubPullRequestUrl,
+    linkedPullRequestNumbers: [pullRequestOriginLink.githubPullRequestNumber],
     linkedPullRequests: [
       {
-        number: pullRequestLink.data.githubPullRequestNumber,
-        repositoryUrl: pullRequestLink.data.repositoryUrl
+        number: pullRequestOriginLink.githubPullRequestNumber,
+        repositoryUrl: pullRequestOriginLink.repositoryUrl
       }
-    ],
-    syncedAt: pullRequestLink.data.syncedAt
+    ]
   };
 }
 

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -8538,6 +8538,99 @@ test('worker issue.githubDetails returns issue-scoped GitHub detail payloads', a
   });
 });
 
+test('worker issue.githubDetails recovers GitHub issue links from Paperclip origin fields', async () => {
+  const harness = createTestHarness({ manifest });
+  await plugin.definition.setup(harness.ctx);
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    const url = getRequestUrl(input);
+    if (url === 'https://api.github.com/repos/paperclipai/example-repo/issues/303') {
+      return jsonResponse({ message: 'Not Found' }, 404);
+    }
+
+    return originalFetch(input, init);
+  };
+
+  try {
+    const issue = await harness.ctx.issues.create({
+      companyId: 'company-1',
+      projectId: 'project-1',
+      title: 'Origin-only imported issue',
+      description: 'No hidden import marker here.',
+      originKind: 'plugin:paperclip-github-plugin:github-issue',
+      originId: 'https://github.com/paperclipai/example-repo/issues/303'
+    });
+
+    const details = await harness.getData<{
+      paperclipIssueId: string;
+      kind: 'issue';
+      source: string;
+      repositoryUrl: string;
+      githubIssueNumber: number;
+      githubIssueUrl: string;
+      linkedPullRequestNumbers: number[];
+    } | null>('issue.githubDetails', {
+      companyId: 'company-1',
+      issueId: issue.id
+    });
+
+    assert.equal(details?.paperclipIssueId, issue.id);
+    assert.equal(details?.kind, 'issue');
+    assert.equal(details?.source, 'issue_origin');
+    assert.equal(details?.repositoryUrl, 'https://github.com/paperclipai/example-repo');
+    assert.equal(details?.githubIssueNumber, 303);
+    assert.equal(details?.githubIssueUrl, 'https://github.com/paperclipai/example-repo/issues/303');
+    assert.deepEqual(details?.linkedPullRequestNumbers, []);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('worker issue.githubDetails recovers GitHub pull request links from Paperclip origin fields', async () => {
+  const harness = createTestHarness({ manifest });
+  await plugin.definition.setup(harness.ctx);
+
+  const issue = await harness.ctx.issues.create({
+    companyId: 'company-1',
+    projectId: 'project-1',
+    title: 'Origin-only pull request issue',
+    description: 'Created from a pull request before the link entity was written.',
+    originKind: 'plugin:paperclip-github-plugin:github-pull-request',
+    originId: 'https://github.com/paperclipai/example-repo/pull/404'
+  });
+
+  const details = await harness.getData<{
+    paperclipIssueId: string;
+    kind: 'pull_request';
+    source: string;
+    repositoryUrl: string;
+    githubPullRequestNumber: number;
+    githubPullRequestUrl: string;
+    linkedPullRequestNumbers: number[];
+    linkedPullRequests: Array<{
+      number: number;
+      repositoryUrl: string;
+    }>;
+  } | null>('issue.githubDetails', {
+    companyId: 'company-1',
+    issueId: issue.id
+  });
+
+  assert.equal(details?.paperclipIssueId, issue.id);
+  assert.equal(details?.kind, 'pull_request');
+  assert.equal(details?.source, 'issue_origin');
+  assert.equal(details?.repositoryUrl, 'https://github.com/paperclipai/example-repo');
+  assert.equal(details?.githubPullRequestNumber, 404);
+  assert.equal(details?.githubPullRequestUrl, 'https://github.com/paperclipai/example-repo/pull/404');
+  assert.deepEqual(details?.linkedPullRequestNumbers, [404]);
+  assert.deepEqual(details?.linkedPullRequests, [
+    {
+      number: 404,
+      repositoryUrl: 'https://github.com/paperclipai/example-repo'
+    }
+  ]);
+});
+
 test('worker filters issue-scoped GitHub link records even when entities.list ignores scopeId', async () => {
   const harness = createTestHarness({
     manifest,


### PR DESCRIPTION
## Summary

Adapts GitHub Sync to the Paperclip `2026.428.0` release.

- Bumps `@paperclipai/plugin-sdk` and lockfiles to `2026.428.0`.
- Recovers issue-scoped GitHub issue and pull request links from Paperclip `originKind` / `originId` metadata when plugin entities, import registries, or hidden description markers are missing.
- Updates hosted issue UI copy so origin-recovered links render as valid partial metadata with refresh guidance.
- Updates disposable e2e/manual host harnesses for the new company `attachmentMaxBytes` contract and pins them to `paperclipai@2026.428.0` by default, with `PAPERCLIP_E2E_PAPERCLIPAI_VERSION` available for cross-version checks.
- Documents the new support baseline and adds regression coverage for origin-only issue and pull request recovery.

## Why

Paperclip `2026.428.0` adds company attachment caps, issue-list offset support, new company creation defaults, and preserves issue origin fields through the plugin SDK. GitHub Sync already stamps imported issues and PR-created issues with GitHub Sync origins; using those fields as a first-party fallback makes issue detail surfaces more durable after state loss or older metadata drift.

## Validation

- `pnpm typecheck`
- `pnpm test` — 204 plugin tests plus build-script test passed
- `pnpm build`
- `pnpm test:e2e` — booted disposable `paperclipai@2026.428.0`, applied migrations `0071`-`0074`, installed the local plugin, and exercised hosted browser settings/dashboard/project/issue/manual-link flows

## Model Used

GPT-5 Codex in the Codex desktop app. Exact model snapshot identifier and context-window size are not exposed to this runtime; work used shell, GitHub CLI, web/source inspection, TypeScript tests, build tooling, and Playwright-backed e2e verification.
