### PR TITLE
Require comments for sync status transitions

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -11794,6 +11794,8 @@ async function updatePaperclipIssueState(
     paperclipApiBaseUrl
   } = params;
   const trimmedTransitionComment = transitionComment.trim();
+  const statusWillChange = currentStatus !== nextStatus;
+  let createdTransitionComment: IssueComment | null = null;
   let issueUpdated = false;
   const syncExecutionStatePatch = buildSyncFallbackExecutionStatePatch({
     currentStatus,
@@ -11818,6 +11820,18 @@ async function updatePaperclipIssueState(
   } else if (clearAssignee) {
     issuePatch.assigneeAgentId = null;
     issuePatch.assigneeUserId = null;
+  }
+
+  if (statusWillChange) {
+    if (!trimmedTransitionComment) {
+      throw new Error('GitHub Sync refused to update a Paperclip issue status without an explanatory transition comment.');
+    }
+
+    if (typeof ctx.issues.createComment !== 'function') {
+      throw new Error('This Paperclip runtime does not expose issue comment creation, so GitHub Sync refused to update a Paperclip issue status without an explanatory comment.');
+    }
+
+    createdTransitionComment = await ctx.issues.createComment(issueId, trimmedTransitionComment, companyId);
   }
 
   if (paperclipApiBaseUrl) {
@@ -11887,7 +11901,19 @@ async function updatePaperclipIssueState(
 
     await ctx.issues.update(issueId, sdkIssuePatch as PaperclipIssueUpdatePatchWithLabels, companyId);
   }
-  if (trimmedTransitionComment && typeof ctx.issues.createComment === 'function') {
+  if (createdTransitionComment) {
+    if (transitionCommentAnnotation) {
+      await upsertStatusTransitionCommentAnnotation(ctx, {
+        issueId,
+        commentId: createdTransitionComment.id,
+        annotation: {
+          ...transitionCommentAnnotation,
+          companyId,
+          paperclipIssueId: issueId
+        }
+      });
+    }
+  } else if (trimmedTransitionComment && typeof ctx.issues.createComment === 'function') {
     const createdComment = await ctx.issues.createComment(issueId, trimmedTransitionComment, companyId);
     if (transitionCommentAnnotation) {
       await upsertStatusTransitionCommentAnnotation(ctx, {

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -17453,6 +17453,138 @@ test('worker uses the local Paperclip issue PATCH API for status transitions whe
   }
 });
 
+test('worker does not perform sync-driven status transitions when the explanatory comment cannot be created', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubTokenRef: 'github-secret-ref'
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+
+  await harness.performAction('settings.saveRegistration', {
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ],
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  const originalUpdate = harness.ctx.issues.update;
+  const originalCreateComment = harness.ctx.issues.createComment;
+  const importedIssue = await harness.ctx.issues.create({
+    companyId: 'company-1',
+    projectId: 'project-1',
+    title: 'Comment creation must gate status changes',
+    description: '* GitHub issue: [#47](https://github.com/paperclipai/example-repo/issues/47)\n\n---\n\nBody'
+  });
+  await originalUpdate(importedIssue.id, { status: 'in_progress' }, 'company-1');
+
+  await harness.ctx.state.set(
+    {
+      scopeKind: 'instance',
+      stateKey: 'paperclip-github-plugin-import-registry'
+    },
+    [
+      {
+        mappingId: 'mapping-a',
+        githubIssueId: 4701,
+        githubIssueNumber: 47,
+        paperclipIssueId: importedIssue.id,
+        importedAt: '2026-04-09T09:00:00.000Z',
+        lastSeenCommentCount: 0,
+        repositoryUrl: 'https://github.com/paperclipai/example-repo',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-1'
+      }
+    ]
+  );
+
+  harness.ctx.issues.createComment = async () => {
+    throw new Error('Comment bridge unavailable');
+  };
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    const rawUrl = getRequestUrl(input);
+    const url = new URL(rawUrl);
+
+    if (url.pathname === '/repos/paperclipai/example-repo/issues' && ['all', 'open'].includes(url.searchParams.get('state') ?? '')) {
+      return jsonResponse([
+        {
+          id: 4701,
+          number: 47,
+          title: 'Comment creation must gate status changes',
+          body: 'Body',
+          html_url: 'https://github.com/paperclipai/example-repo/issues/47',
+          state: 'closed',
+          state_reason: 'completed',
+          comments: 0
+        }
+      ]);
+    }
+
+    if (url.pathname === '/graphql') {
+      const { query, variables } = getGraphqlRequest(init);
+      const issueNumber = typeof variables.issueNumber === 'number' ? variables.issueNumber : undefined;
+
+      if (query.includes('query GitHubIssueParentRelationships')) {
+        return graphqlIssueParentRelationshipsResponse([
+          {
+            issueNumber: 47
+          }
+        ]);
+      }
+
+      if (query.includes('query GitHubIssueStatusSnapshot') && issueNumber === 47) {
+        return graphqlResponse({
+          repository: {
+            issue: {
+              number: 47,
+              state: 'CLOSED',
+              stateReason: 'COMPLETED',
+              comments: {
+                totalCount: 0
+              },
+              closedByPullRequestsReferences: {
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null
+                },
+                nodes: []
+              }
+            }
+          }
+        });
+      }
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url.toString()}`);
+  };
+
+  try {
+    const sync = await harness.performAction('sync.runNow', {
+      waitForCompletion: true
+    }) as {
+      syncState: { status: string; updatedStatusesCount?: number };
+    };
+
+    assert.equal(sync.syncState.status, 'error');
+    assert.equal(sync.syncState.updatedStatusesCount ?? 0, 0);
+    assert.equal((await harness.ctx.issues.get(importedIssue.id, 'company-1'))?.status, 'in_progress');
+  } finally {
+    harness.ctx.issues.createComment = originalCreateComment;
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('worker clears pending review and approval execution state before closing an imported issue', async () => {
   const harness = createTestHarness({
     manifest,


### PR DESCRIPTION
## Summary
- Create the sync status-transition comment before mutating Paperclip issue status.
- Fail the automated transition if the explanatory comment cannot be created, leaving the existing status untouched.
- Add a regression test for comment creation failure during GitHub Sync reconciliation.

## Validation
- `pnpm typecheck`
- `pnpm test` (207/207 passing)
- `pnpm build`
- `git diff --check`

## Model Used
- Model: OpenAI GPT-5 Codex coding agent.
- Context window: not exposed by the current Codex desktop runtime.
- Capabilities used: repository editing, shell execution, git/GitHub CLI operations, TypeScript typechecking, test execution, and build verification.

## Known Limitations
- None.