### PR TITLE
Tolerate stale issue relation capability denials

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -7348,6 +7348,21 @@ function hasUnresolvedPaperclipIssueBlockerSummary(blockers: unknown): boolean {
   });
 }
 
+function isMissingIssueRelationsReadCapabilityError(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : '';
+
+  return (
+    /missing required capability/i.test(message)
+    && /issue\.relations\.read/.test(message)
+    && /issues\.relations\.get/.test(message)
+  );
+}
+
 async function hasUnresolvedPaperclipIssueBlocker(
   ctx: PluginSetupContext,
   issue: Issue,
@@ -7362,8 +7377,16 @@ async function hasUnresolvedPaperclipIssueBlocker(
     return false;
   }
 
-  const relations = await ctx.issues.relations.get(issue.id, companyId);
-  return hasUnresolvedPaperclipIssueBlockerSummary(relations.blockedBy);
+  try {
+    const relations = await ctx.issues.relations.get(issue.id, companyId);
+    return hasUnresolvedPaperclipIssueBlockerSummary(relations.blockedBy);
+  } catch (error) {
+    if (isMissingIssueRelationsReadCapabilityError(error)) {
+      return false;
+    }
+
+    throw error;
+  }
 }
 
 function isSamePaperclipIssueAssigneePrincipal(
@@ -20069,6 +20092,7 @@ export function shouldStartWorkerHost(moduleUrl: string, entry = process.argv[1]
 
 export const __testing = {
   buildSyncFallbackExecutionStatePatch,
+  hasUnresolvedPaperclipIssueBlocker,
   isHealthyMaintainerWaitTransition,
   resolveSyncTransitionAssignee
 };

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2121,7 +2121,18 @@ function formatGitHubIssueCountLabel(count: number): string {
 }
 
 function getErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (error && typeof error === 'object' && 'message' in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === 'string') {
+      return message;
+    }
+  }
+
+  return String(error);
 }
 
 function isPaperclipLabelSyncError(error: unknown): error is PaperclipLabelSyncError {
@@ -7349,17 +7360,12 @@ function hasUnresolvedPaperclipIssueBlockerSummary(blockers: unknown): boolean {
 }
 
 function isMissingIssueRelationsReadCapabilityError(error: unknown): boolean {
-  const message =
-    error instanceof Error
-      ? error.message
-      : typeof error === 'string'
-        ? error
-        : '';
+  const message = getErrorMessage(error);
 
   return (
     /missing required capability/i.test(message)
-    && /issue\.relations\.read/.test(message)
-    && /issues\.relations\.get/.test(message)
+    && /issue\.relations\.read/i.test(message)
+    && /issues\.relations\.get/i.test(message)
   );
 }
 

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -160,6 +160,55 @@ test('issue blocker relation checks tolerate stale host capability denials', asy
   );
 
   assert.equal(isBlocked, false);
+
+  const isBlockedFromObjectError = await testing.hasUnresolvedPaperclipIssueBlocker(
+    {
+      issues: {
+        relations: {
+          get: async () => {
+            throw {
+              message:
+                'Plugin "d5344f69-c969-457c-89c0-ed7608f3703b" is missing required capability "issue.relations.read" for method "issues.relations.get"'
+            };
+          }
+        }
+      }
+    },
+    { id: 'issue-12' },
+    'company-1'
+  );
+
+  assert.equal(isBlockedFromObjectError, false);
+});
+
+test('issue blocker relation checks propagate unrelated relation read failures', async () => {
+  const workerModule = await importFreshWorkerModule();
+  const testing = workerModule.__testing as typeof workerModule.__testing & {
+    hasUnresolvedPaperclipIssueBlocker?: (
+      ctx: unknown,
+      issue: { id: string; blockedBy?: unknown },
+      companyId: string
+    ) => Promise<boolean>;
+  };
+
+  assert.equal(typeof testing.hasUnresolvedPaperclipIssueBlocker, 'function');
+
+  await assert.rejects(
+    testing.hasUnresolvedPaperclipIssueBlocker(
+      {
+        issues: {
+          relations: {
+            get: async () => {
+              throw new Error('Paperclip relation storage is unavailable.');
+            }
+          }
+        }
+      },
+      { id: 'issue-12' },
+      'company-1'
+    ),
+    /relation storage is unavailable/
+  );
 });
 
 async function importManifestWithPluginVersion(pluginVersion?: string): Promise<typeof manifest> {

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -131,6 +131,37 @@ test('sync still starts internal review for active implementation handoffs', asy
   );
 });
 
+test('issue blocker relation checks tolerate stale host capability denials', async () => {
+  const workerModule = await importFreshWorkerModule();
+  const testing = workerModule.__testing as typeof workerModule.__testing & {
+    hasUnresolvedPaperclipIssueBlocker?: (
+      ctx: unknown,
+      issue: { id: string; blockedBy?: unknown },
+      companyId: string
+    ) => Promise<boolean>;
+  };
+
+  assert.equal(typeof testing.hasUnresolvedPaperclipIssueBlocker, 'function');
+
+  const isBlocked = await testing.hasUnresolvedPaperclipIssueBlocker(
+    {
+      issues: {
+        relations: {
+          get: async () => {
+            throw new Error(
+              'Plugin "d5344f69-c969-457c-89c0-ed7608f3703b" is missing required capability "issue.relations.read" for method "issues.relations.get"'
+            );
+          }
+        }
+      }
+    },
+    { id: 'issue-12' },
+    'company-1'
+  );
+
+  assert.equal(isBlocked, false);
+});
+
 async function importManifestWithPluginVersion(pluginVersion?: string): Promise<typeof manifest> {
   const previousPluginVersion = process.env.PLUGIN_VERSION;
   const manifestModuleUrl = new URL(


### PR DESCRIPTION
## Summary

- Treat host-thrown `missing required capability` errors for `issues.relations.get` / `issue.relations.read` as an unavailable optional relation surface during blocker checks.
- Keep unrelated relation-read failures fatal so real integration problems are still visible.
- Add a regression test using the reported Paperclip capability-denial shape.

## Why

`src/manifest.ts` already declares `issue.relations.read`, but a live host can temporarily run worker code against stale installed manifest/capability metadata during plugin upgrades. In that state, syncing issue descriptions could fail when the worker checked Paperclip blocker relations. This keeps sync moving by falling back to existing issue snapshot data when the optional relation read is rejected for that exact capability gate.

## Validation

- `pnpm exec tsx --test --test-name-pattern "issue blocker relation checks" tests/plugin.spec.ts`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `git diff --check`
- Confirmed built `dist/manifest.js` includes `issue.relations.read`

## Known Limitations

- If relation reads are unavailable, blocker preservation can only use blocker data already present on the issue object.
- Existing installations should still upgrade/reinstall the plugin so the host manifest snapshot includes `issue.relations.read`; this patch prevents that stale snapshot from failing the sync path.

## Model Used

- Model ID/version: GPT-5 Codex, as exposed to this Codex desktop session.
- Context window size: not disclosed by the Codex desktop runtime in this session.
- Capabilities used: local shell commands, `apply_patch`, TypeScript test/build tooling, and GitHub CLI for PR creation.
