### PR TITLE
Route Octokit request logs through plugin logger

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -146,6 +146,14 @@ interface PaperclipApiJsonReadResult<T> {
   failure?: PaperclipApiOperationFailure;
 }
 
+interface GitHubOctokitLogContext {
+  companyId?: string;
+  operation?: string;
+  repositoryUrl?: string;
+  syncTrigger?: 'manual' | 'schedule' | 'retry';
+  toolName?: string;
+}
+
 interface PaperclipLabelCreationAttempt {
   label: PaperclipIssueLabel | null;
   failure?: PaperclipApiOperationFailure;
@@ -2186,6 +2194,105 @@ function getErrorResponseDataMessage(error: unknown): string | undefined {
 
   const message = (data as { message?: unknown }).message;
   return typeof message === 'string' && message.trim() ? message.trim() : undefined;
+}
+
+function getGitHubRequestId(error: unknown): string | undefined {
+  const requestId = getErrorResponseHeaders(error)['x-github-request-id']?.trim();
+  return requestId || undefined;
+}
+
+function buildGitHubOctokitLogMetadata(context: GitHubOctokitLogContext): Record<string, unknown> {
+  const metadata: Record<string, unknown> = {};
+  const companyId = normalizeCompanyId(context.companyId);
+  const operation = normalizeOptionalString(context.operation);
+  const repositoryUrl = normalizeOptionalString(context.repositoryUrl);
+  const toolName = normalizeOptionalString(context.toolName);
+
+  if (companyId) {
+    metadata.companyId = companyId;
+  }
+
+  if (operation) {
+    metadata.operation = operation;
+  }
+
+  if (repositoryUrl) {
+    metadata.repositoryUrl = repositoryUrl;
+  }
+
+  if (context.syncTrigger) {
+    metadata.syncTrigger = context.syncTrigger;
+  }
+
+  if (toolName) {
+    metadata.toolName = toolName;
+  }
+
+  return metadata;
+}
+
+function getGitHubOctokitRequestPath(url: unknown, baseUrl: unknown): string | undefined {
+  if (typeof url !== 'string' || !url.trim()) {
+    return undefined;
+  }
+
+  const trimmedUrl = url.trim();
+  if (typeof baseUrl === 'string' && baseUrl.trim() && trimmedUrl.startsWith(baseUrl.trim())) {
+    return trimmedUrl.slice(baseUrl.trim().length) || '/';
+  }
+
+  try {
+    const parsed = new URL(trimmedUrl);
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return trimmedUrl;
+  }
+}
+
+function createGitHubOctokit(
+  ctx: Pick<PluginSetupContext, 'logger'>,
+  token: string,
+  context: GitHubOctokitLogContext = {}
+): Octokit {
+  const metadata = buildGitHubOctokitLogMetadata(context);
+  const octokit = new Octokit({
+    auth: token,
+    log: {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: (message) => {
+        ctx.logger.warn('GitHub Octokit warning.', {
+          ...metadata,
+          message
+        });
+      },
+      error: () => undefined
+    }
+  });
+
+  octokit.hook.wrap('request', async (request, options) => {
+    const start = Date.now();
+    const requestOptions = octokit.request.endpoint.parse(options);
+
+    try {
+      return await request(options);
+    } catch (error) {
+      const responseMessage = getErrorResponseDataMessage(error);
+      ctx.logger.warn('GitHub API request failed.', {
+        ...metadata,
+        method: requestOptions.method,
+        path: getGitHubOctokitRequestPath(requestOptions.url, options.baseUrl),
+        status: getErrorStatus(error) ?? null,
+        requestId: getGitHubRequestId(error) ?? null,
+        durationMs: Date.now() - start,
+        error: getErrorMessage(error),
+        ...(responseMessage ? { responseMessage } : {})
+      });
+      throw error;
+    }
+  });
+
+  return octokit;
 }
 
 function getErrorResponseDataErrors(error: unknown): unknown[] {
@@ -14167,7 +14274,10 @@ async function createGitHubToolOctokit(ctx: PluginSetupContext, companyId?: stri
     throw new Error(MISSING_GITHUB_TOKEN_SYNC_MESSAGE);
   }
 
-  return new Octokit({ auth: token });
+  return createGitHubOctokit(ctx, token, {
+    companyId,
+    operation: 'github-api'
+  });
 }
 
 async function listGitHubRepositoryOpenPullRequestNumbers(
@@ -18146,8 +18256,10 @@ function mergeNamedValues(
   return [...values.values()];
 }
 
-async function validateGithubToken(token: string): Promise<TokenValidationResult> {
-  const octokit = new Octokit({ auth: token.trim() });
+async function validateGithubToken(ctx: PluginSetupContext, token: string): Promise<TokenValidationResult> {
+  const octokit = createGitHubOctokit(ctx, token.trim(), {
+    operation: 'settings.validateToken'
+  });
 
   try {
     const response = await octokit.rest.users.getAuthenticated();
@@ -18292,7 +18404,11 @@ async function performSync(
 
   activePaperclipApiAuthTokensByCompanyId = await resolvePaperclipApiAuthTokens(ctx, settings, config, mappings);
 
-  const octokit = new Octokit({ auth: token });
+  const octokit = createGitHubOctokit(ctx, token, {
+    companyId: targetCompanyId,
+    operation: 'sync.github-issues',
+    syncTrigger: trigger
+  });
   let syncedIssuesCount = 0;
   let createdIssuesCount = 0;
   let skippedIssuesCount = 0;
@@ -20116,6 +20232,7 @@ export function shouldStartWorkerHost(moduleUrl: string, entry = process.argv[1]
 
 export const __testing = {
   buildSyncFallbackExecutionStatePatch,
+  createGitHubToolOctokit,
   hasUnresolvedPaperclipIssueBlocker,
   isHealthyMaintainerWaitTransition,
   resolveSyncTransitionAssignee
@@ -20504,7 +20621,7 @@ const plugin = definePlugin({
         throw new Error('Enter a GitHub token.');
       }
 
-      return validateGithubToken(trimmedToken);
+      return validateGithubToken(ctx, trimmedToken);
     });
 
     ctx.actions.register('project.pullRequests.createIssue', async (input) => {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -148,6 +148,7 @@ interface PaperclipApiJsonReadResult<T> {
 
 interface GitHubOctokitLogContext {
   companyId?: string;
+  logFailures?: boolean;
   operation?: string;
   repositoryUrl?: string;
   syncTrigger?: 'manual' | 'schedule' | 'retry';
@@ -2254,7 +2255,6 @@ function createGitHubOctokit(
   token: string,
   context: GitHubOctokitLogContext = {}
 ): Octokit {
-  const metadata = buildGitHubOctokitLogMetadata(context);
   const octokit = new Octokit({
     auth: token,
     log: {
@@ -2262,13 +2262,17 @@ function createGitHubOctokit(
       info: () => undefined,
       warn: (message) => {
         ctx.logger.warn('GitHub Octokit warning.', {
-          ...metadata,
+          ...buildGitHubOctokitLogMetadata(context),
           message
         });
       },
       error: () => undefined
     }
   });
+
+  if (context.logFailures === false) {
+    return octokit;
+  }
 
   octokit.hook.wrap('request', async (request, options) => {
     const start = Date.now();
@@ -2279,7 +2283,7 @@ function createGitHubOctokit(
     } catch (error) {
       const responseMessage = getErrorResponseDataMessage(error);
       ctx.logger.warn('GitHub API request failed.', {
-        ...metadata,
+        ...buildGitHubOctokitLogMetadata(context),
         method: requestOptions.method,
         path: getGitHubOctokitRequestPath(requestOptions.url, options.baseUrl),
         status: getErrorStatus(error) ?? null,
@@ -14268,7 +14272,11 @@ async function handleCompanyMetricApiRoute(
   };
 }
 
-async function createGitHubToolOctokit(ctx: PluginSetupContext, companyId?: string): Promise<Octokit> {
+async function createGitHubToolOctokit(
+  ctx: PluginSetupContext,
+  companyId?: string,
+  context: Pick<GitHubOctokitLogContext, 'repositoryUrl' | 'toolName'> = {}
+): Promise<Octokit> {
   const token = (await resolveGithubToken(ctx, { companyId })).trim();
   if (!token) {
     throw new Error(MISSING_GITHUB_TOKEN_SYNC_MESSAGE);
@@ -14276,7 +14284,8 @@ async function createGitHubToolOctokit(ctx: PluginSetupContext, companyId?: stri
 
   return createGitHubOctokit(ctx, token, {
     companyId,
-    operation: 'github-api'
+    operation: 'github-api',
+    ...context
   });
 }
 
@@ -18258,6 +18267,7 @@ function mergeNamedValues(
 
 async function validateGithubToken(ctx: PluginSetupContext, token: string): Promise<TokenValidationResult> {
   const octokit = createGitHubOctokit(ctx, token.trim(), {
+    logFailures: false,
     operation: 'settings.validateToken'
   });
 
@@ -18404,11 +18414,12 @@ async function performSync(
 
   activePaperclipApiAuthTokensByCompanyId = await resolvePaperclipApiAuthTokens(ctx, settings, config, mappings);
 
-  const octokit = createGitHubOctokit(ctx, token, {
+  const octokitLogContext: GitHubOctokitLogContext = {
     companyId: targetCompanyId,
     operation: 'sync.github-issues',
     syncTrigger: trigger
-  });
+  };
+  const octokit = createGitHubOctokit(ctx, token, octokitLogContext);
   let syncedIssuesCount = 0;
   let createdIssuesCount = 0;
   let skippedIssuesCount = 0;
@@ -18590,6 +18601,7 @@ async function performSync(
 
       try {
         const repository = requireRepositoryReference(mapping.repositoryUrl);
+        octokitLogContext.repositoryUrl = repository.url;
         const importedIssueRecords = nextRegistry
           .filter((entry) => doesImportedIssueRecordMatchMapping(entry, mapping))
           .filter((entry) => doesImportedIssueMatchTarget(entry, options.target));
@@ -18725,6 +18737,7 @@ async function performSync(
 
       try {
         const { mapping, advancedSettings, repository, repositoryIndex, allIssuesById, issues, pullRequestLinks } = plan;
+        octokitLogContext.repositoryUrl = repository.url;
         const companyId = mapping.companyId;
         let availableLabels = companyId ? companyLabelDirectoryCache.get(companyId) : undefined;
         if (!availableLabels) {
@@ -19242,13 +19255,24 @@ async function startSync(
 }
 
 function registerGitHubAgentTools(ctx: PluginSetupContext): void {
+  async function createAgentToolOctokit(
+    runCtx: ToolRunContext,
+    toolName: string,
+    repository?: ParsedRepositoryReference
+  ): Promise<Octokit> {
+    return createGitHubToolOctokit(ctx, runCtx.companyId, {
+      toolName,
+      ...(repository ? { repositoryUrl: repository.url } : {})
+    });
+  }
+
   ctx.tools.register(
     'search_repository_items',
     getGitHubAgentToolDeclaration('search_repository_items'),
     async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
-      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
       const repository = await resolveGitHubToolRepository(ctx, runCtx, input);
+      const octokit = await createAgentToolOctokit(runCtx, 'search_repository_items', repository);
       const rawQuery = normalizeOptionalToolString(input.query);
       if (!rawQuery) {
         throw new Error('query is required.');
@@ -19324,7 +19348,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
     async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const target = await resolveGitHubIssueToolTarget(ctx, runCtx, input);
-      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
+      const octokit = await createAgentToolOctokit(runCtx, 'get_issue', target.repository);
       const response = await octokit.rest.issues.get({
         owner: target.repository.owner,
         repo: target.repository.repo,
@@ -19377,7 +19401,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
     async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const target = await resolveGitHubIssueToolTarget(ctx, runCtx, input);
-      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
+      const octokit = await createAgentToolOctokit(runCtx, 'list_issue_comments', target.repository);
       const comments = await listAllGitHubIssueComments(octokit, target.repository, target.issueNumber);
 
       return buildToolSuccessResult(
@@ -19397,7 +19421,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
     async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const target = await resolveGitHubIssueToolTarget(ctx, runCtx, input);
-      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
+      const octokit = await createAgentToolOctokit(runCtx, 'update_issue', target.repository);
       const currentResponse = await octokit.rest.issues.get({
         owner: target.repository.owner,
         repo: target.repository.repo,
@@ -19500,7 +19524,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
     async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const target = await resolveGitHubIssueToolTarget(ctx, runCtx, input);
-      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
+      const octokit = await createAgentToolOctokit(runCtx, 'assign_to_current_user', target.repository);
       const [currentResponse, authenticatedUserResponse] = await Promise.all([
         octokit.rest.issues.get({
           owner: target.repository.owner,
@@ -19570,7 +19594,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
     async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const target = await resolveGitHubIssueToolTarget(ctx, runCtx, input);
-      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
+      const octokit = await createAgentToolOctokit(runCtx, 'add_issue_comment', target.repository);
       const body = appendAiAuthorshipFooter(String(input.body ?? ''), 'comment', normalizeOptionalToolString(input.llmModel));
       const response = await octokit.rest.issues.createComment({
         owner: target.repository.owner,
@@ -19627,7 +19651,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
             normalizeOptionalToolString(input.llmModel)
           )
         : undefined;
-      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
+      const octokit = await createAgentToolOctokit(runCtx, 'create_pull_request', repository);
       const response = await octokit.rest.pulls.create({
         owner: repository.owner,
         repo: repository.repo,
@@ -19710,7 +19734,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
     async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const target = await resolveGitHubPullRequestToolTarget(ctx, runCtx, input);
-      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
+      const octokit = await createAgentToolOctokit(runCtx, 'get_pull_request', target.repository);
       const response = await octokit.rest.pulls.get({
         owner: target.repository.owner,
         repo: target.repository.repo,
@@ -19760,7 +19784,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
     async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const target = await resolveGitHubPullRequestToolTarget(ctx, runCtx, input);
-      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
+      const octokit = await createAgentToolOctokit(runCtx, 'update_pull_request', target.repository);
       let currentResponse = await octokit.rest.pulls.get({
         owner: target.repository.owner,
         repo: target.repository.repo,
@@ -19835,7 +19859,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
     async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const target = await resolveGitHubPullRequestToolTarget(ctx, runCtx, input);
-      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
+      const octokit = await createAgentToolOctokit(runCtx, 'list_pull_request_files', target.repository);
       const files = await listAllPullRequestFiles(octokit, target.repository, target.pullRequestNumber);
 
       return buildToolSuccessResult(
@@ -19855,7 +19879,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
     async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const target = await resolveGitHubPullRequestToolTarget(ctx, runCtx, input);
-      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
+      const octokit = await createAgentToolOctokit(runCtx, 'get_pull_request_checks', target.repository);
       const pullRequestResponse = await octokit.rest.pulls.get({
         owner: target.repository.owner,
         repo: target.repository.repo,
@@ -19964,7 +19988,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
     async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const target = await resolveGitHubPullRequestToolTarget(ctx, runCtx, input);
-      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
+      const octokit = await createAgentToolOctokit(runCtx, 'list_pull_request_review_threads', target.repository);
       const threads = await listDetailedPullRequestReviewThreads(octokit, target.repository, target.pullRequestNumber);
 
       return buildToolSuccessResult(
@@ -19989,7 +20013,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
       }
 
       const body = appendAiAuthorshipFooter(String(input.body ?? ''), 'comment', normalizeOptionalToolString(input.llmModel));
-      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
+      const octokit = await createAgentToolOctokit(runCtx, 'reply_to_review_thread');
       const response = await octokit.graphql<GitHubAddPullRequestReviewThreadReplyMutationResult>(
         GITHUB_ADD_PULL_REQUEST_REVIEW_THREAD_REPLY_MUTATION,
         {
@@ -20027,7 +20051,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
         throw new Error('threadId is required.');
       }
 
-      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
+      const octokit = await createAgentToolOctokit(runCtx, 'resolve_review_thread');
       const response = await octokit.graphql<GitHubResolveReviewThreadMutationResult>(
         GITHUB_RESOLVE_REVIEW_THREAD_MUTATION,
         {
@@ -20061,7 +20085,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
         throw new Error('threadId is required.');
       }
 
-      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
+      const octokit = await createAgentToolOctokit(runCtx, 'unresolve_review_thread');
       const response = await octokit.graphql<GitHubUnresolveReviewThreadMutationResult>(
         GITHUB_UNRESOLVE_REVIEW_THREAD_MUTATION,
         {
@@ -20097,7 +20121,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
         throw new Error('Provide at least one user reviewer or team reviewer.');
       }
 
-      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
+      const octokit = await createAgentToolOctokit(runCtx, 'request_pull_request_reviewers', target.repository);
       const response = await octokit.rest.pulls.requestReviewers({
         owner: target.repository.owner,
         repo: target.repository.repo,
@@ -20131,7 +20155,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
         throw new Error('organization is required.');
       }
 
-      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
+      const octokit = await createAgentToolOctokit(runCtx, 'list_organization_projects');
       const projects = await listGitHubOrganizationProjects(octokit, organization, {
         includeClosed: input.includeClosed === true,
         query: normalizeOptionalToolString(input.query),
@@ -20154,7 +20178,7 @@ function registerGitHubAgentTools(ctx: PluginSetupContext): void {
     async (params, runCtx) => executeGitHubTool(async () => {
       const input = getToolInputRecord(params);
       const target = await resolveGitHubPullRequestToolTarget(ctx, runCtx, input);
-      const octokit = await createGitHubToolOctokit(ctx, runCtx.companyId);
+      const octokit = await createAgentToolOctokit(runCtx, 'add_pull_request_to_project', target.repository);
       const projectTarget = await resolveGitHubProjectToolTarget(octokit, input);
       const pullRequest = await getGitHubPullRequestProjectItems(
         octokit,

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -211,6 +211,75 @@ test('issue blocker relation checks propagate unrelated relation read failures',
   );
 });
 
+test('GitHub request failures are logged through the plugin logger instead of stderr', async () => {
+  const workerModule = await importFreshWorkerModule();
+  const testing = workerModule.__testing as typeof workerModule.__testing & {
+    createGitHubToolOctokit?: (ctx: unknown, companyId?: string) => Promise<{
+      graphql: (query: string, variables?: Record<string, unknown>) => Promise<unknown>;
+    }>;
+  };
+
+  assert.equal(typeof testing.createGitHubToolOctokit, 'function');
+
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      githubToken: TEST_GITHUB_TOKEN
+    }
+  });
+  const warnings: Array<{ message: string; metadata: Record<string, unknown> }> = [];
+  const stderrCalls: unknown[][] = [];
+  const originalFetch = globalThis.fetch;
+  const originalConsoleError = console.error;
+
+  harness.ctx.logger.warn = (message: string, metadata?: unknown) => {
+    warnings.push({
+      message,
+      metadata: metadata && typeof metadata === 'object' ? metadata as Record<string, unknown> : {}
+    });
+  };
+
+  console.error = (...args: unknown[]) => {
+    stderrCalls.push(args);
+  };
+
+  globalThis.fetch = async (input) => {
+    if (getRequestUrl(input) === 'https://api.github.com/graphql') {
+      return jsonResponse({ message: 'Bad credentials' }, 401);
+    }
+
+    throw new Error(`Unexpected request: ${getRequestUrl(input)}`);
+  };
+
+  try {
+    const octokit = await testing.createGitHubToolOctokit(harness.ctx, 'company-1');
+
+    await assert.rejects(
+      octokit.graphql('query { viewer { login } }'),
+      /Bad credentials/
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.error = originalConsoleError;
+  }
+
+  assert.deepEqual(stderrCalls, []);
+  assert.equal(warnings.length, 1);
+  assert.equal(warnings[0]?.message, 'GitHub API request failed.');
+  assert.deepEqual(warnings[0]?.metadata, {
+    companyId: 'company-1',
+    durationMs: warnings[0]?.metadata.durationMs,
+    error: 'Bad credentials',
+    method: 'POST',
+    operation: 'github-api',
+    path: '/graphql',
+    requestId: null,
+    responseMessage: 'Bad credentials',
+    status: 401
+  });
+  assert.equal(typeof warnings[0]?.metadata.durationMs, 'number');
+});
+
 async function importManifestWithPluginVersion(pluginVersion?: string): Promise<typeof manifest> {
   const previousPluginVersion = process.env.PLUGIN_VERSION;
   const manifestModuleUrl = new URL(
@@ -13099,6 +13168,31 @@ test('worker refreshes Paperclip labels before creating a missing label so newly
         ]);
       }
 
+      if (query.includes('query GitHubRepositoryOpenIssueLinkedPullRequests')) {
+        return graphqlResponse({
+          repository: {
+            issues: {
+              pageInfo: {
+                hasNextPage: false,
+                endCursor: null
+              },
+              nodes: [
+                {
+                  number: 22,
+                  closedByPullRequestsReferences: {
+                    pageInfo: {
+                      hasNextPage: false,
+                      endCursor: null
+                    },
+                    nodes: []
+                  }
+                }
+              ]
+            }
+          }
+        });
+      }
+
       if (query.includes('query GitHubIssueStatusSnapshot') && issueNumber === 22) {
         return graphqlResponse({
           repository: {
@@ -13258,6 +13352,31 @@ test('worker resolves duplicate label create races by refreshing labels without 
             issueNumber: 23
           }
         ]);
+      }
+
+      if (query.includes('query GitHubRepositoryOpenIssueLinkedPullRequests')) {
+        return graphqlResponse({
+          repository: {
+            issues: {
+              pageInfo: {
+                hasNextPage: false,
+                endCursor: null
+              },
+              nodes: [
+                {
+                  number: 23,
+                  closedByPullRequestsReferences: {
+                    pageInfo: {
+                      hasNextPage: false,
+                      endCursor: null
+                    },
+                    nodes: []
+                  }
+                }
+              ]
+            }
+          }
+        });
       }
 
       if (query.includes('query GitHubIssueStatusSnapshot') && issueNumber === 23) {

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -214,7 +214,11 @@ test('issue blocker relation checks propagate unrelated relation read failures',
 test('GitHub request failures are logged through the plugin logger instead of stderr', async () => {
   const workerModule = await importFreshWorkerModule();
   const testing = workerModule.__testing as typeof workerModule.__testing & {
-    createGitHubToolOctokit?: (ctx: unknown, companyId?: string) => Promise<{
+    createGitHubToolOctokit?: (
+      ctx: unknown,
+      companyId?: string,
+      context?: { repositoryUrl?: string; toolName?: string }
+    ) => Promise<{
       graphql: (query: string, variables?: Record<string, unknown>) => Promise<unknown>;
     }>;
   };
@@ -252,7 +256,10 @@ test('GitHub request failures are logged through the plugin logger instead of st
   };
 
   try {
-    const octokit = await testing.createGitHubToolOctokit(harness.ctx, 'company-1');
+    const octokit = await testing.createGitHubToolOctokit(harness.ctx, 'company-1', {
+      repositoryUrl: 'https://github.com/paperclipai/example-repo',
+      toolName: 'list_pull_request_review_threads'
+    });
 
     await assert.rejects(
       octokit.graphql('query { viewer { login } }'),
@@ -274,8 +281,10 @@ test('GitHub request failures are logged through the plugin logger instead of st
     operation: 'github-api',
     path: '/graphql',
     requestId: null,
+    repositoryUrl: 'https://github.com/paperclipai/example-repo',
     responseMessage: 'Bad credentials',
-    status: 401
+    status: 401,
+    toolName: 'list_pull_request_review_threads'
   });
   assert.equal(typeof warnings[0]?.metadata.durationMs, 'number');
 });
@@ -10517,6 +10526,42 @@ test('worker validates a GitHub token by reaching the GitHub API', async () => {
     assert.deepEqual(result, {
       login: 'octocat'
     });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('worker keeps expected GitHub token validation failures out of warning logs', async () => {
+  const harness = createTestHarness({ manifest });
+  await plugin.definition.setup(harness.ctx);
+
+  const warnings: Array<{ message: string; data: unknown }> = [];
+  harness.ctx.logger.warn = (message, data) => {
+    warnings.push({
+      message,
+      data
+    });
+  };
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    assert.equal(url, 'https://api.github.com/user');
+
+    return jsonResponse({
+      message: 'Bad credentials'
+    }, 401);
+  };
+
+  try {
+    await assert.rejects(
+      harness.performAction('settings.validateToken', {
+        token: 'ghp_rejected_token'
+      }),
+      /GitHub rejected this token/
+    );
+
+    assert.deepEqual(warnings, []);
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
## Summary
- Centralize GitHub Octokit construction so bundled request-log output no longer writes anonymous GraphQL failures to stderr.
- Re-emit failed GitHub requests through the Paperclip plugin logger with operation, company, endpoint, status, request id, duration, and error details.
- Add regression coverage that a failing GraphQL call stays off `console.error`, plus complete the affected GraphQL mocks used by label-race tests.

Fixes #94.

## Root Cause
`@octokit/rest` includes `@octokit/plugin-request-log`, whose default logger falls back to `console.error`. Paperclip captures plugin stderr, so local or unactionable GraphQL request failures were surfacing as noisy `POST /graphql - 500 with id UNKNOWN` lines before the worker could attach useful plugin context.

## Validation
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Known Limitations
- None.

## Model Used
- Model ID/version: GPT-5 Codex coding agent in Codex desktop.
- Context window size: not exposed by this runtime.
- Capabilities used: repository editing, shell verification, GitHub CLI, and Codex automation setup.
