### PR TITLE
Handle disabled plugin secret refs during setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ The plugin is designed to avoid persisting raw credentials in plugin state.
 - The settings UI also keeps lightweight non-secret identity labels for those saved connections, so later visits can still show who each company GitHub token and board access are connected as.
 - On authenticated deployments, any selected propagation agents receive `GITHUB_TOKEN` as an agent env secret-ref binding that points at the same saved GitHub token secret instead of a copied raw token.
 - The worker resolves those secret references at runtime instead of storing raw tokens in plugin state.
+- When the current Paperclip host rejects plugin secret refs, GitHub Sync keeps company-scoped worker-local compatibility copies for GitHub tokens and Paperclip board-access tokens in `${PAPERCLIP_HOME:-~/.paperclip}/plugins/github-sync/config.json`. Reconnect board access once after upgrading if sync still cannot authenticate Paperclip label or issue REST calls.
 - On authenticated Paperclip deployments, sync is blocked until the relevant company has connected Paperclip board access.
 - KPI API route requests must include `Authorization: Bearer <PAPERCLIP_API_KEY>` from an agent run; the Paperclip host authenticates the token and supplies the agent company before the worker records any metric event.
 
@@ -208,6 +209,9 @@ If Paperclip-managed secrets are not available, the worker can read a local fall
   "githubToken": "ghp_your_token_here",
   "githubTokensByCompanyId": {
     "company-uuid": "ghp_company_specific_token_here"
+  },
+  "paperclipBoardApiTokensByCompanyId": {
+    "company-uuid": "paperclip_board_api_token_here"
   }
 }
 ```
@@ -217,6 +221,7 @@ Notes:
 - This file is read by the worker only.
 - The raw token is never persisted back into plugin state or plugin config.
 - A GitHub token secret saved through the settings UI is the primary source. If the current Paperclip host rejects plugin secret-ref resolution while company-scoped plugin config is unavailable, GitHub Sync stores the validated token in `githubTokensByCompanyId` as a worker-local compatibility fallback.
+- A Paperclip board access secret saved through the settings UI is also the primary source. If the host cannot resolve it for plugin workers, reconnecting board access stores the approved board token in `paperclipBoardApiTokensByCompanyId` as a worker-local compatibility fallback for direct Paperclip REST calls.
 - On authenticated deployments, selected agents receive `GITHUB_TOKEN` as a latest-version secret-ref env binding, and the settings UI patches agent adapter config with `replaceAdapterConfig: true` so newer Paperclip hosts persist the merged env map.
 
 ### Worker-facing Paperclip API URL

--- a/SPEC.md
+++ b/SPEC.md
@@ -36,8 +36,9 @@ The settings page MUST allow saving mappings and triggering a manual sync.
 
 - The raw GitHub token MUST NOT be persisted in plugin state.
 - Saving a token from the settings UI MUST create or reuse a company secret through the Paperclip host API.
-- The plugin MUST persist only the resulting secret UUID, keyed by company, in plugin instance config.
+- The plugin MUST persist only the resulting secret UUID, keyed by company, in plugin state and SHOULD mirror it into plugin instance config when the host allows plugin secret refs there.
 - The worker MUST resolve that secret UUID at runtime via `ctx.secrets.resolve(...)`.
+- UI-side plugin config writes MUST recover from the known plugin-secret-reference-disabled failure by retrying without plugin secret-ref maps, so saving non-secret settings cannot be blocked by stale secret-ref config.
 - If a Paperclip host rejects plugin secret-ref resolution with the known plugin-secret-reference-disabled failure while company-scoped plugin config is unavailable, the settings UI MAY ask the worker to persist the validated raw token in a worker-local company-scoped fallback map at `${PAPERCLIP_HOME:-~/.paperclip}/plugins/github-sync/config.json` so production sync can continue without writing the raw token to plugin state or plugin config.
 - The plugin MAY persist lightweight non-secret display metadata such as the validated GitHub login alongside the saved GitHub token secret ref so hosted UI can keep connected-state copy consistent across refreshes without resolving the secret.
 - When authenticated deployment settings select agents for GitHub token propagation, the hosted settings UI MUST patch those agents through the host API so `adapterConfig.env.GITHUB_TOKEN` points at that same secret UUID with a latest-version secret-ref binding instead of copying the raw token value.
@@ -45,9 +46,10 @@ The settings page MUST allow saving mappings and triggering a manual sync.
 - Agent token propagation updates MUST send `replaceAdapterConfig: true` when patching agent adapter config so newer Paperclip hosts persist the merged `env` map.
 - If `${PAPERCLIP_HOME:-~/.paperclip}/plugins/github-sync/config.json` exists and contains either a string `githubToken` or a `githubTokensByCompanyId` map, the worker MUST treat those values as worker-only fallback sources for the GitHub token without persisting or returning those raw tokens.
 - The raw Paperclip board API token MUST NOT be persisted in plugin state.
-- Connecting Paperclip board access from the settings UI MUST create or reuse a company secret through the Paperclip host API and MUST persist only the resulting secret UUID, keyed by company in plugin state and mirrored into plugin instance config so the worker can resolve it.
+- Connecting Paperclip board access from the settings UI MUST create or reuse a company secret through the Paperclip host API and MUST persist only the resulting secret UUID, keyed by company in plugin state and mirrored into plugin instance config when the host allows plugin secret refs there.
+- If the host cannot resolve saved board-access secret refs for plugin workers, the settings UI MAY pass the approved raw board token to a worker action that persists a company-scoped worker-local fallback in `${PAPERCLIP_HOME:-~/.paperclip}/plugins/github-sync/config.json` so direct Paperclip REST sync calls can continue without storing the raw board token in plugin state or plugin config.
 - The plugin MAY persist lightweight company-scoped non-secret display metadata such as the connected board identity label alongside the saved board token secret ref so hosted UI can keep connected-state copy consistent across refreshes without resolving the secret.
-- The worker MUST resolve the saved Paperclip board token secret at runtime via `ctx.secrets.resolve(...)` before making direct Paperclip REST calls for that company, and MUST treat plugin config as the worker-readable source of truth for those secret refs.
+- The worker MUST resolve the saved Paperclip board token secret at runtime via `ctx.secrets.resolve(...)` before making direct Paperclip REST calls for that company, falling back to the company-scoped worker-local board token only when host secret-ref resolution is unavailable.
 
 ## Synchronization behavior
 
@@ -92,7 +94,7 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 - The worker MUST NOT rely on a Paperclip process environment variable named `PAPERCLIP_API_URL`; release-target e2e verification uses an explicit Worker Paperclip API URL because plugin worker runtime environments do not guarantee that process variable.
 - Direct Paperclip REST fetch failures MUST preserve method, URL, primary error, nested cause message, and cause code in diagnostics when available so TLS and routing problems remain actionable.
 - Before a manual or scheduled sync touches any mapping whose company is missing board access, the worker MUST probe `/api/health` on the resolved Paperclip API origin and fail fast with configuration guidance when that deployment reports `deploymentMode: "authenticated"`.
-- When a company has connected Paperclip board access, the worker MUST attach `Authorization: Bearer <board-token>` to direct Paperclip REST issue and label calls for that company.
+- When a company has connected Paperclip board access, the worker MUST attach `Authorization: Bearer <board-token>` to direct Paperclip REST issue and label calls for that company, using the saved secret ref when resolvable and the company-scoped worker-local board-token fallback when plugin secret refs are disabled.
 - When the Paperclip runtime exposes existing issue labels for the target company, the sync flow MUST map GitHub labels onto matching Paperclip labels by name and SHOULD prefer an exact color match when multiple Paperclip labels share the same name.
 - When no matching Paperclip label exists and the local Paperclip label API is reachable, the sync flow MUST create the missing Paperclip label using the GitHub label color when available before attaching it to the imported issue.
 - When a local Paperclip REST call returns an unexpected non-JSON success payload, such as an authenticated HTML sign-in page, the worker MUST treat that response as unavailable, fall back to SDK-based issue mutation when possible, and surface an actionable sync error that points operators to Paperclip board access or the Worker Paperclip API URL setting when labels still cannot be reconciled.

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -18,6 +18,7 @@ import { buildPaperclipUrl, fetchJson, fetchPaperclipHealth, resolveCliAuthPollU
 import { resolveInstalledGitHubSyncPluginId, resolvePluginSettingsHref } from './plugin-installation.ts';
 import {
   mergePluginConfig,
+  type GitHubSyncPluginConfig,
   normalizePaperclipApiBaseUrl,
   normalizePluginConfig,
   resolvePaperclipApiBaseUrlForPluginAction
@@ -6850,7 +6851,29 @@ async function resolveOrCreateCompanySecret(companyId: string, name: string, val
   });
 }
 
-async function patchPluginConfig(pluginId: string, patch: Record<string, unknown>): Promise<void> {
+function isPluginSecretReferencesDisabledError(error: unknown): boolean {
+  return getActionErrorMessage(error, '').toLowerCase().includes('plugin secret references are disabled');
+}
+
+function stripPluginSecretRefConfig(config: GitHubSyncPluginConfig): GitHubSyncPluginConfig {
+  const {
+    githubTokenRefs: _githubTokenRefs,
+    paperclipBoardApiTokenRefs: _paperclipBoardApiTokenRefs,
+    ...safeConfig
+  } = config;
+  return safeConfig;
+}
+
+async function writePluginConfig(pluginId: string, config: GitHubSyncPluginConfig): Promise<void> {
+  await fetchJson(`/api/plugins/${pluginId}/config`, {
+    method: 'POST',
+    body: JSON.stringify({
+      configJson: config
+    })
+  });
+}
+
+export async function patchPluginConfig(pluginId: string, patch: Record<string, unknown>): Promise<void> {
   const currentConfigResponse = await fetchJson<PluginConfigResponse | null>(`/api/plugins/${pluginId}/config`);
   const currentConfig = normalizePluginConfig(currentConfigResponse?.configJson);
   const nextConfig = mergePluginConfig(currentConfig, patch);
@@ -6859,12 +6882,20 @@ async function patchPluginConfig(pluginId: string, patch: Record<string, unknown
     return;
   }
 
-  await fetchJson(`/api/plugins/${pluginId}/config`, {
-    method: 'POST',
-    body: JSON.stringify({
-      configJson: nextConfig
-    })
-  });
+  try {
+    await writePluginConfig(pluginId, nextConfig);
+  } catch (error) {
+    if (!isPluginSecretReferencesDisabledError(error)) {
+      throw error;
+    }
+
+    const safeConfig = stripPluginSecretRefConfig(nextConfig);
+    if (JSON.stringify(safeConfig) === JSON.stringify(nextConfig)) {
+      throw error;
+    }
+
+    await writePluginConfig(pluginId, safeConfig);
+  }
 }
 
 const GITHUB_TOKEN_PROPAGATION_CONCURRENCY_LIMIT = 4;
@@ -12318,6 +12349,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
       await updateBoardAccess({
         companyId,
         paperclipBoardApiTokenRef: secret.id,
+        paperclipBoardApiToken: boardApiToken,
         paperclipBoardAccessIdentity: boardIdentity.label ?? '',
         paperclipBoardAccessUserId: boardIdentity.userId ?? ''
       });

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5505,6 +5505,32 @@ async function clearExternalCompanyPaperclipBoardApiTokenFallback(
     encoding: 'utf8',
     mode: 0o600
   });
+
+  try {
+    await chmod(externalConfigFilePath, 0o600);
+  } catch (error) {
+    ctx.logger.warn('GitHub Sync could not tighten permissions on the worker-local token fallback file.', {
+      filePath: externalConfigFilePath,
+      error: getErrorMessage(error)
+    });
+  }
+}
+
+async function shouldSeedExternalPaperclipBoardTokenFallback(
+  ctx: PluginSetupContext,
+  companyId: string,
+  secretRef: string
+): Promise<boolean> {
+  try {
+    return !(await ctx.secrets.resolve(secretRef)).trim();
+  } catch (error) {
+    ctx.logger.warn('Unable to resolve the saved Paperclip board API token while checking worker fallback necessity.', {
+      companyId,
+      secretRef,
+      error: getErrorMessage(error)
+    });
+    return true;
+  }
 }
 
 function normalizePaperclipBoardApiTokenRefs(value: unknown): PaperclipBoardApiTokenRefs | undefined {
@@ -22121,7 +22147,11 @@ const plugin = definePlugin({
       if (nextSecretRef) {
         nextPaperclipBoardApiTokenRefs[companyId] = nextSecretRef;
         if (nextBoardApiToken) {
-          await writeExternalCompanyPaperclipBoardApiTokenFallback(ctx, companyId, nextBoardApiToken);
+          if (await shouldSeedExternalPaperclipBoardTokenFallback(ctx, companyId, nextSecretRef)) {
+            await writeExternalCompanyPaperclipBoardApiTokenFallback(ctx, companyId, nextBoardApiToken);
+          } else {
+            await clearExternalCompanyPaperclipBoardApiTokenFallback(ctx, companyId);
+          }
         }
       } else {
         delete nextPaperclipBoardApiTokenRefs[companyId];

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -163,6 +163,7 @@ type PaperclipLabelDirectory = Map<string, PaperclipIssueLabel[]>;
 type GitHubTokenRefs = Record<string, string>;
 type GitHubTokensByCompanyId = Record<string, string>;
 type PaperclipBoardApiTokenRefs = Record<string, string>;
+type PaperclipBoardApiTokensByCompanyId = Record<string, string>;
 type GitHubTokenLoginByCompanyId = Record<string, string>;
 type PaperclipBoardAccessIdentityByCompanyId = Record<string, string>;
 type PaperclipBoardAccessUserIdByCompanyId = Record<string, string>;
@@ -515,6 +516,7 @@ interface GitHubSyncConfig {
   githubToken?: string;
   githubTokensByCompanyId?: GitHubTokensByCompanyId;
   paperclipBoardApiTokenRefs?: PaperclipBoardApiTokenRefs;
+  paperclipBoardApiTokensByCompanyId?: PaperclipBoardApiTokensByCompanyId;
   paperclipApiBaseUrl?: string;
 }
 
@@ -2766,6 +2768,28 @@ function normalizeGitHubTokenRefs(value: unknown): GitHubTokenRefs | undefined {
 }
 
 function normalizeGitHubTokensByCompanyId(value: unknown): GitHubTokensByCompanyId | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .map(([companyId, token]) => {
+      const normalizedCompanyId = normalizeCompanyId(companyId);
+      const normalizedToken = normalizeGitHubToken(token);
+      return normalizedCompanyId && normalizedToken
+        ? [normalizedCompanyId, normalizedToken] as const
+        : null;
+    })
+    .filter((entry): entry is readonly [string, string] => entry !== null);
+
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(entries);
+}
+
+function normalizePaperclipBoardApiTokensByCompanyId(value: unknown): PaperclipBoardApiTokensByCompanyId | undefined {
   if (!value || typeof value !== 'object') {
     return undefined;
   }
@@ -5249,6 +5273,7 @@ function normalizeConfig(value: unknown): GitHubSyncConfig {
   const githubToken = normalizeGitHubToken(record.githubToken);
   const githubTokensByCompanyId = normalizeGitHubTokensByCompanyId(record.githubTokensByCompanyId);
   const paperclipBoardApiTokenRefs = normalizePaperclipBoardApiTokenRefs(record.paperclipBoardApiTokenRefs);
+  const paperclipBoardApiTokensByCompanyId = normalizePaperclipBoardApiTokensByCompanyId(record.paperclipBoardApiTokensByCompanyId);
   const paperclipApiBaseUrl = normalizePaperclipApiBaseUrl(record.paperclipApiBaseUrl);
 
   return {
@@ -5257,6 +5282,7 @@ function normalizeConfig(value: unknown): GitHubSyncConfig {
     ...(githubToken ? { githubToken } : {}),
     ...(githubTokensByCompanyId ? { githubTokensByCompanyId } : {}),
     ...(paperclipBoardApiTokenRefs ? { paperclipBoardApiTokenRefs } : {}),
+    ...(paperclipBoardApiTokensByCompanyId ? { paperclipBoardApiTokensByCompanyId } : {}),
     ...(paperclipApiBaseUrl ? { paperclipApiBaseUrl } : {})
   };
 }
@@ -5412,6 +5438,73 @@ async function writeExternalCompanyGitHubTokenFallback(
       error: getErrorMessage(error)
     });
   }
+}
+
+async function writeExternalCompanyPaperclipBoardApiTokenFallback(
+  ctx: PluginSetupContext,
+  companyId: string,
+  token: string
+): Promise<void> {
+  const externalConfigFilePath = getExternalConfigFilePath();
+  if (!externalConfigFilePath) {
+    throw new Error('Could not resolve a Paperclip home directory for the GitHub Sync fallback token config.');
+  }
+
+  const currentRecord = await readExternalConfigRecordForWrite(ctx, externalConfigFilePath);
+  const currentCompanyTokens = normalizePaperclipBoardApiTokensByCompanyId(currentRecord.paperclipBoardApiTokensByCompanyId) ?? {};
+  const nextRecord = {
+    ...currentRecord,
+    paperclipBoardApiTokensByCompanyId: {
+      ...currentCompanyTokens,
+      [companyId]: token
+    }
+  };
+
+  await mkdir(dirname(externalConfigFilePath), { recursive: true });
+  await writeFile(externalConfigFilePath, `${JSON.stringify(nextRecord, null, 2)}\n`, {
+    encoding: 'utf8',
+    mode: 0o600
+  });
+
+  try {
+    await chmod(externalConfigFilePath, 0o600);
+  } catch (error) {
+    ctx.logger.warn('GitHub Sync could not tighten permissions on the worker-local token fallback file.', {
+      filePath: externalConfigFilePath,
+      error: getErrorMessage(error)
+    });
+  }
+}
+
+async function clearExternalCompanyPaperclipBoardApiTokenFallback(
+  ctx: PluginSetupContext,
+  companyId: string
+): Promise<void> {
+  const externalConfigFilePath = getExternalConfigFilePath();
+  if (!externalConfigFilePath) {
+    return;
+  }
+
+  const currentRecord = await readExternalConfigRecordForWrite(ctx, externalConfigFilePath);
+  const currentCompanyTokens = normalizePaperclipBoardApiTokensByCompanyId(currentRecord.paperclipBoardApiTokensByCompanyId) ?? {};
+  if (!(companyId in currentCompanyTokens)) {
+    return;
+  }
+
+  const nextCompanyTokens = { ...currentCompanyTokens };
+  delete nextCompanyTokens[companyId];
+  const nextRecord = { ...currentRecord };
+  if (Object.keys(nextCompanyTokens).length > 0) {
+    nextRecord.paperclipBoardApiTokensByCompanyId = nextCompanyTokens;
+  } else {
+    delete nextRecord.paperclipBoardApiTokensByCompanyId;
+  }
+
+  await mkdir(dirname(externalConfigFilePath), { recursive: true });
+  await writeFile(externalConfigFilePath, `${JSON.stringify(nextRecord, null, 2)}\n`, {
+    encoding: 'utf8',
+    mode: 0o600
+  });
 }
 
 function normalizePaperclipBoardApiTokenRefs(value: unknown): PaperclipBoardApiTokenRefs | undefined {
@@ -14587,7 +14680,7 @@ function getMappingsMissingPaperclipBoardAccess(
 async function resolvePaperclipApiAuthTokens(
   ctx: PluginSetupContext,
   settings: Pick<GitHubSyncSettings, 'paperclipBoardApiTokenRefs'>,
-  config: Pick<GitHubSyncConfig, 'paperclipBoardApiTokenRefs'>,
+  config: Pick<GitHubSyncConfig, 'paperclipBoardApiTokenRefs' | 'paperclipBoardApiTokensByCompanyId'>,
   mappings: RepositoryMapping[]
 ): Promise<Map<string, string>> {
   const companyIds = [
@@ -14602,12 +14695,18 @@ async function resolvePaperclipApiAuthTokens(
   for (const companyId of companyIds) {
     const configuredSecretRef = getConfiguredPaperclipBoardApiTokenRef(config, companyId);
     const savedSecretRef = getSavedPaperclipBoardApiTokenRef(settings, companyId);
+    const fallbackToken = normalizeGitHubToken(config.paperclipBoardApiTokensByCompanyId?.[companyId]);
     const secretRef = configuredSecretRef ?? savedSecretRef;
     if (!secretRef) {
       continue;
     }
 
     if (!configuredSecretRef && savedSecretRef) {
+      if (fallbackToken) {
+        tokensByCompanyId.set(companyId, fallbackToken);
+        continue;
+      }
+
       ctx.logger.warn(
         'Paperclip board access is saved in plugin state but has not been mirrored into plugin config yet. Open plugin settings to finish migrating it, or reconnect board access, before retrying sync.',
         {
@@ -14624,6 +14723,16 @@ async function resolvePaperclipApiAuthTokens(
         tokensByCompanyId.set(companyId, token);
       }
     } catch (error) {
+      if (fallbackToken && isPluginSecretReferenceDisabledError(error)) {
+        ctx.logger.warn('GitHub Sync is using a worker-local Paperclip board token fallback because plugin secret refs are unavailable in this host.', {
+          companyId,
+          secretRef,
+          error: getErrorMessage(error)
+        });
+        tokensByCompanyId.set(companyId, fallbackToken);
+        continue;
+      }
+
       ctx.logger.warn('Unable to resolve the saved Paperclip board API token. Direct REST calls will continue without it.', {
         companyId,
         secretRef,
@@ -21681,6 +21790,7 @@ export const __testing = {
   formatPaperclipApiFetchErrorMessage,
   hasUnresolvedPaperclipIssueBlocker,
   isHealthyMaintainerWaitTransition,
+  resolvePaperclipApiAuthTokens,
   resolveGithubToken,
   resolvePaperclipPullRequestIssueStatus,
   resolveSyncTransitionAssignee
@@ -21997,6 +22107,7 @@ const plugin = definePlugin({
       }
 
       const nextSecretRef = normalizeSecretRef(record.paperclipBoardApiTokenRef);
+      const nextBoardApiToken = normalizeGitHubToken(record.paperclipBoardApiToken);
       const nextPaperclipBoardApiTokenRefs = {
         ...(previous.paperclipBoardApiTokenRefs ?? {})
       };
@@ -22009,10 +22120,14 @@ const plugin = definePlugin({
 
       if (nextSecretRef) {
         nextPaperclipBoardApiTokenRefs[companyId] = nextSecretRef;
+        if (nextBoardApiToken) {
+          await writeExternalCompanyPaperclipBoardApiTokenFallback(ctx, companyId, nextBoardApiToken);
+        }
       } else {
         delete nextPaperclipBoardApiTokenRefs[companyId];
         delete nextPaperclipBoardAccessIdentityByCompanyId[companyId];
         delete nextPaperclipBoardAccessUserIdByCompanyId[companyId];
+        await clearExternalCompanyPaperclipBoardApiTokenFallback(ctx, companyId);
       }
 
       if ('paperclipBoardAccessIdentity' in record) {

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'node:assert';
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -12100,10 +12100,41 @@ test('settings.ensureGitHubTokenAvailable overwrites invalid worker-local config
   });
 });
 
-test('settings.updateBoardAccess writes a company-scoped board token fallback for worker-side REST calls', { concurrency: false }, async () => {
+test('settings.updateBoardAccess skips the board token fallback when the saved secret ref resolves', { concurrency: false }, async () => {
   await withTemporaryPaperclipHome(async ({ configFilePath }) => {
     const harness = createTestHarness({ manifest });
     await plugin.definition.setup(harness.ctx);
+
+    let resolveCount = 0;
+    harness.ctx.secrets.resolve = async (secretRef) => {
+      resolveCount += 1;
+      assert.equal(secretRef, 'board-secret-ref');
+      return 'paperclip-board-token';
+    };
+
+    await harness.performAction('settings.updateBoardAccess', {
+      companyId: 'company-1',
+      paperclipBoardApiTokenRef: 'board-secret-ref',
+      paperclipBoardApiToken: 'paperclip-board-token',
+      paperclipBoardAccessIdentity: 'Jane Operator'
+    });
+
+    await assert.rejects(readFile(configFilePath, 'utf8'), {
+      code: 'ENOENT'
+    });
+    assert.equal(resolveCount, 1);
+  });
+});
+
+test('settings.updateBoardAccess writes a company-scoped board token fallback when secret refs are disabled', { concurrency: false }, async () => {
+  await withTemporaryPaperclipHome(async ({ configFilePath }) => {
+    const harness = createTestHarness({ manifest });
+    await plugin.definition.setup(harness.ctx);
+
+    harness.ctx.secrets.resolve = async (secretRef) => {
+      assert.equal(secretRef, 'board-secret-ref');
+      throw new Error('Plugin secret references are disabled until company-scoped plugin config lands');
+    };
 
     await harness.performAction('settings.updateBoardAccess', {
       companyId: 'company-1',
@@ -12119,6 +12150,39 @@ test('settings.updateBoardAccess writes a company-scoped board token fallback fo
     assert.deepEqual(storedConfig.paperclipBoardApiTokensByCompanyId, {
       'company-1': 'paperclip-board-token'
     });
+  });
+});
+
+test('settings.updateBoardAccess tightens worker-local config permissions when clearing board token fallbacks', { concurrency: false }, async () => {
+  await withTemporaryPaperclipHome(async ({ configFilePath }) => {
+    const harness = createTestHarness({ manifest });
+    await plugin.definition.setup(harness.ctx);
+
+    await mkdir(dirname(configFilePath), { recursive: true });
+    await writeFile(
+      configFilePath,
+      JSON.stringify({
+        paperclipBoardApiTokensByCompanyId: {
+          'company-1': 'paperclip-board-token'
+        }
+      }),
+      {
+        encoding: 'utf8',
+        mode: 0o666
+      }
+    );
+    await chmod(configFilePath, 0o666);
+
+    await harness.performAction('settings.updateBoardAccess', {
+      companyId: 'company-1'
+    });
+
+    const storedConfig = JSON.parse(await readFile(configFilePath, 'utf8')) as {
+      paperclipBoardApiTokensByCompanyId?: Record<string, string>;
+    };
+
+    assert.equal(storedConfig.paperclipBoardApiTokensByCompanyId, undefined);
+    assert.equal((await stat(configFilePath)).mode & 0o777, 0o600);
   });
 });
 

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -23,6 +23,7 @@ import { resolveInstalledGitHubSyncPluginId, resolvePluginSettingsHref } from '.
 import {
   mergePluginConfig,
   normalizePluginConfig,
+  type GitHubSyncPluginConfig,
   resolvePaperclipApiBaseUrlForPluginAction
 } from '../src/ui/plugin-config.ts';
 import {
@@ -4464,6 +4465,85 @@ test('mergePluginConfig preserves existing config while merging token and board 
     'company-2': 'board-secret-ref-2'
   });
   assert.equal(result.customFlag, true);
+});
+
+test('patchPluginConfig retries without plugin secret refs when the host rejects secret refs', async () => {
+  const uiModule = await importFreshUiModule() as {
+    patchPluginConfig?: unknown;
+  };
+
+  assert.equal(typeof uiModule.patchPluginConfig, 'function');
+
+  const patchPluginConfig = uiModule.patchPluginConfig as (
+    pluginId: string,
+    patch: Partial<GitHubSyncPluginConfig>
+  ) => Promise<void>;
+  const originalFetch = globalThis.fetch;
+  const postBodies: unknown[] = [];
+
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = getRequestUrl(input);
+    const method = (init?.method ?? 'GET').toUpperCase();
+
+    if (url === '/api/plugins/plugin-1/config' && method === 'GET') {
+      return jsonResponse({
+        configJson: {
+          githubTokenRefs: {
+            'company-1': 'github-secret-ref'
+          },
+          paperclipBoardApiTokenRefs: {
+            'company-1': 'board-secret-ref'
+          },
+          paperclipApiBaseUrl: 'http://127.0.0.1:3100'
+        }
+      });
+    }
+
+    if (url === '/api/plugins/plugin-1/config' && method === 'POST') {
+      const body = getJsonRequestBody(init);
+      postBodies.push(body);
+
+      if (postBodies.length === 1) {
+        return jsonResponse(
+          {
+            error: 'Plugin secret references are disabled until company-scoped plugin config lands'
+          },
+          422
+        );
+      }
+
+      return jsonResponse({ ok: true });
+    }
+
+    throw new Error(`Unexpected fetch request: ${method} ${url}`);
+  };
+
+  try {
+    await patchPluginConfig('plugin-1', {
+      paperclipApiBaseUrl: 'http://localhost:3100'
+    });
+
+    assert.deepEqual(postBodies, [
+      {
+        configJson: {
+          githubTokenRefs: {
+            'company-1': 'github-secret-ref'
+          },
+          paperclipBoardApiTokenRefs: {
+            'company-1': 'board-secret-ref'
+          },
+          paperclipApiBaseUrl: 'http://localhost:3100'
+        }
+      },
+      {
+        configJson: {
+          paperclipApiBaseUrl: 'http://localhost:3100'
+        }
+      }
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 test('normalizePluginConfig canonicalizes the trusted Paperclip API origin and drops invalid values', () => {
@@ -12018,6 +12098,83 @@ test('settings.ensureGitHubTokenAvailable overwrites invalid worker-local config
       )
     );
   });
+});
+
+test('settings.updateBoardAccess writes a company-scoped board token fallback for worker-side REST calls', { concurrency: false }, async () => {
+  await withTemporaryPaperclipHome(async ({ configFilePath }) => {
+    const harness = createTestHarness({ manifest });
+    await plugin.definition.setup(harness.ctx);
+
+    await harness.performAction('settings.updateBoardAccess', {
+      companyId: 'company-1',
+      paperclipBoardApiTokenRef: 'board-secret-ref',
+      paperclipBoardApiToken: 'paperclip-board-token',
+      paperclipBoardAccessIdentity: 'Jane Operator'
+    });
+
+    const storedConfig = JSON.parse(await readFile(configFilePath, 'utf8')) as {
+      paperclipBoardApiTokensByCompanyId?: Record<string, string>;
+    };
+
+    assert.deepEqual(storedConfig.paperclipBoardApiTokensByCompanyId, {
+      'company-1': 'paperclip-board-token'
+    });
+  });
+});
+
+test('resolvePaperclipApiAuthTokens falls back to the worker-local board token when plugin secret refs are disabled', async () => {
+  const workerModule = await importFreshWorkerModule();
+  const testing = workerModule.__testing as typeof workerModule.__testing & {
+    resolvePaperclipApiAuthTokens?: (
+      ctx: unknown,
+      settings: unknown,
+      config: unknown,
+      mappings: Array<{ companyId?: string }>
+    ) => Promise<Map<string, string>>;
+  };
+
+  assert.equal(typeof testing.resolvePaperclipApiAuthTokens, 'function');
+
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      paperclipBoardApiTokensByCompanyId: {
+        'company-1': 'paperclip-board-token'
+      }
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+
+  let resolveCount = 0;
+  harness.ctx.secrets.resolve = async () => {
+    resolveCount += 1;
+    throw new Error('Plugin secret references are disabled until company-scoped plugin config lands');
+  };
+
+  const tokens = await testing.resolvePaperclipApiAuthTokens(
+    harness.ctx,
+    {
+      paperclipBoardApiTokenRefs: {
+        'company-1': 'board-secret-ref'
+      }
+    },
+    {
+      paperclipBoardApiTokenRefs: {
+        'company-1': 'board-secret-ref'
+      },
+      paperclipBoardApiTokensByCompanyId: {
+        'company-1': 'paperclip-board-token'
+      }
+    },
+    [
+      {
+        companyId: 'company-1'
+      }
+    ]
+  );
+
+  assert.equal(resolveCount, 1);
+  assert.equal(tokens.get('company-1'), 'paperclip-board-token');
 });
 
 test('sync.runNow falls back to a company-scoped external config token when plugin secret refs are disabled', { concurrency: false }, async () => {


### PR DESCRIPTION
## Summary
- retry plugin config saves without GitHub or board-access secret-ref maps when the Paperclip host rejects plugin secret refs
- persist a company-scoped worker-local Paperclip board-token fallback when board access is reconnected, and use it for direct REST sync calls when plugin secret refs are unavailable
- document the worker-local fallback behavior and add regression coverage for setup save and board-token sync auth

## Why
Newer Paperclip hosts can reject plugin config payloads that contain plugin secret refs with `Plugin secret references are disabled until company-scoped plugin config lands`. That could make ordinary setup saves fail if stale secret-ref maps were still present in plugin config. Sync could also fail direct Paperclip REST calls when board-access secret refs could not be resolved by the plugin worker.

## Validation
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm test:e2e

## Operational Note
If an authenticated deployment already had board access connected before this build, reconnect board access once so the worker-local board-token fallback can be seeded.

## Model Used
- Model ID/version: GPT-5 Codex (Codex Desktop)
- Context window size: not exposed by the current Codex runtime
- Relevant capabilities: local shell, git, GitHub CLI, Playwright-based e2e verification, repo file editing
