### PR TITLE
Strip legacy secret refs from config retry

### DIFF
--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -6876,9 +6876,7 @@ function shouldStripPluginConfigValue(key: string, value: unknown): boolean {
 
 function stripPluginSecretRefValue(value: unknown): unknown {
   if (Array.isArray(value)) {
-    return value
-      .map((entry) => stripPluginSecretRefValue(entry))
-      .filter((entry) => entry !== undefined);
+    return value.map((entry) => stripPluginSecretRefValue(entry));
   }
 
   if (!isPlainConfigRecord(value)) {
@@ -6892,9 +6890,7 @@ function stripPluginSecretRefValue(value: unknown): unknown {
     }
 
     const nextValue = stripPluginSecretRefValue(entryValue);
-    if (nextValue !== undefined) {
-      nextEntries.push([key, nextValue] as const);
-    }
+    nextEntries.push([key, nextValue] as const);
   }
 
   return Object.fromEntries(nextEntries);

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -6855,13 +6855,53 @@ function isPluginSecretReferencesDisabledError(error: unknown): boolean {
   return getActionErrorMessage(error, '').toLowerCase().includes('plugin secret references are disabled');
 }
 
+const PLUGIN_CONFIG_SECRET_KEY_PATTERN = /(?:secret|token).*ref|ref.*(?:secret|token)|secretid|token$/iu;
+
+function isPlainConfigRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function shouldStripPluginConfigValue(key: string, value: unknown): boolean {
+  const normalizedKey = key.replace(/[^a-z0-9]/giu, '').toLowerCase();
+  if (PLUGIN_CONFIG_SECRET_KEY_PATTERN.test(normalizedKey)) {
+    return true;
+  }
+
+  if (!isPlainConfigRecord(value)) {
+    return false;
+  }
+
+  return value.type === 'secret_ref' || typeof value.secretId === 'string';
+}
+
+function stripPluginSecretRefValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => stripPluginSecretRefValue(entry))
+      .filter((entry) => entry !== undefined);
+  }
+
+  if (!isPlainConfigRecord(value)) {
+    return value;
+  }
+
+  const nextEntries: Array<readonly [string, unknown]> = [];
+  for (const [key, entryValue] of Object.entries(value)) {
+    if (shouldStripPluginConfigValue(key, entryValue)) {
+      continue;
+    }
+
+    const nextValue = stripPluginSecretRefValue(entryValue);
+    if (nextValue !== undefined) {
+      nextEntries.push([key, nextValue] as const);
+    }
+  }
+
+  return Object.fromEntries(nextEntries);
+}
+
 function stripPluginSecretRefConfig(config: GitHubSyncPluginConfig): GitHubSyncPluginConfig {
-  const {
-    githubTokenRefs: _githubTokenRefs,
-    paperclipBoardApiTokenRefs: _paperclipBoardApiTokenRefs,
-    ...safeConfig
-  } = config;
-  return safeConfig;
+  return stripPluginSecretRefValue(config) as GitHubSyncPluginConfig;
 }
 
 async function writePluginConfig(pluginId: string, config: GitHubSyncPluginConfig): Promise<void> {

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -4491,9 +4491,16 @@ test('patchPluginConfig retries without plugin secret refs when the host rejects
           githubTokenRefs: {
             'company-1': 'github-secret-ref'
           },
+          githubTokenRef: 'legacy-github-secret-ref',
           paperclipBoardApiTokenRefs: {
             'company-1': 'board-secret-ref'
           },
+          paperclipBoardApiTokenRef: 'legacy-board-secret-ref',
+          legacyNestedSecret: {
+            type: 'secret_ref',
+            secretId: '00000000-0000-4000-8000-000000000099'
+          },
+          customFlag: true,
           paperclipApiBaseUrl: 'http://127.0.0.1:3100'
         }
       });
@@ -4529,14 +4536,22 @@ test('patchPluginConfig retries without plugin secret refs when the host rejects
           githubTokenRefs: {
             'company-1': 'github-secret-ref'
           },
+          githubTokenRef: 'legacy-github-secret-ref',
           paperclipBoardApiTokenRefs: {
             'company-1': 'board-secret-ref'
           },
+          paperclipBoardApiTokenRef: 'legacy-board-secret-ref',
+          legacyNestedSecret: {
+            type: 'secret_ref',
+            secretId: '00000000-0000-4000-8000-000000000099'
+          },
+          customFlag: true,
           paperclipApiBaseUrl: 'http://localhost:3100'
         }
       },
       {
         configJson: {
+          customFlag: true,
           paperclipApiBaseUrl: 'http://localhost:3100'
         }
       }


### PR DESCRIPTION
## Summary
- make the plugin-config retry sanitizer remove legacy singular token/board secret ref keys and nested secret_ref objects, not just the newest secret-ref maps
- keep non-secret config values such as Worker Paperclip API URL and unrelated flags intact on retry
- expand regression coverage for production configs that still carry older secret-ref shapes

## Why
Production still failed to save settings on 0.9.2 because the retry payload could preserve legacy or nested secret-ref-shaped values from older plugin config. Paperclip rejects any plugin-config secret refs while company-scoped plugin config is unavailable, so the fallback retry must strip all secret-ref shapes, not just top-level maps.

## Validation
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm test:e2e

## Model Used
- Model ID/version: GPT-5 Codex (Codex Desktop)
- Context window size: not exposed by the current Codex runtime
- Relevant capabilities: local shell, git, GitHub CLI, Playwright-based e2e verification, repo file editing
