### PR TITLE
Strip raw token config on retry

### DIFF
--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -6855,7 +6855,7 @@ function isPluginSecretReferencesDisabledError(error: unknown): boolean {
   return getActionErrorMessage(error, '').toLowerCase().includes('plugin secret references are disabled');
 }
 
-const PLUGIN_CONFIG_SECRET_KEY_PATTERN = /(?:secret|token).*ref|ref.*(?:secret|token)|secretid|token$/iu;
+const PLUGIN_CONFIG_SECRET_KEY_PATTERN = /secret|token/iu;
 
 function isPlainConfigRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -4492,13 +4492,22 @@ test('patchPluginConfig retries without plugin secret refs when the host rejects
             'company-1': 'github-secret-ref'
           },
           githubTokenRef: 'legacy-github-secret-ref',
+          githubTokensByCompanyId: {
+            'company-1': 'ghp_raw_github_token'
+          },
           paperclipBoardApiTokenRefs: {
             'company-1': 'board-secret-ref'
           },
           paperclipBoardApiTokenRef: 'legacy-board-secret-ref',
+          paperclipBoardApiTokensByCompanyId: {
+            'company-1': 'raw-paperclip-board-token'
+          },
           legacyNestedSecret: {
             type: 'secret_ref',
             secretId: '00000000-0000-4000-8000-000000000099'
+          },
+          nestedRawToken: {
+            token: 'raw-nested-token'
           },
           customFlag: true,
           paperclipApiBaseUrl: 'http://127.0.0.1:3100'
@@ -4537,13 +4546,22 @@ test('patchPluginConfig retries without plugin secret refs when the host rejects
             'company-1': 'github-secret-ref'
           },
           githubTokenRef: 'legacy-github-secret-ref',
+          githubTokensByCompanyId: {
+            'company-1': 'ghp_raw_github_token'
+          },
           paperclipBoardApiTokenRefs: {
             'company-1': 'board-secret-ref'
           },
           paperclipBoardApiTokenRef: 'legacy-board-secret-ref',
+          paperclipBoardApiTokensByCompanyId: {
+            'company-1': 'raw-paperclip-board-token'
+          },
           legacyNestedSecret: {
             type: 'secret_ref',
             secretId: '00000000-0000-4000-8000-000000000099'
+          },
+          nestedRawToken: {
+            token: 'raw-nested-token'
           },
           customFlag: true,
           paperclipApiBaseUrl: 'http://localhost:3100'


### PR DESCRIPTION
## Summary
- strip all token/secret-looking config keys from the retry payload when Paperclip rejects plugin secret refs
- cover leaked raw fallback token maps such as githubTokensByCompanyId and paperclipBoardApiTokensByCompanyId
- preserve non-secret config like paperclipApiBaseUrl and unrelated flags

## Why
Production can still have stale plugin config containing raw token fallback maps or other token-shaped keys. The 0.9.3 retry stripped ref-shaped values but could preserve raw token maps, causing the host to keep rejecting setup saves.

## Validation
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm test:e2e

## Model Used
- Model ID/version: GPT-5 Codex (Codex Desktop)
- Context window size: not exposed by the current Codex runtime
- Relevant capabilities: local shell, git, GitHub CLI, Playwright-based e2e verification, repo file editing
