### PR TITLE
Fix setup token propagation after config stripping

### DIFF
--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -7092,6 +7092,34 @@ export async function syncGitHubTokenPropagationForAgents(params: {
   }
 }
 
+function normalizeGitHubTokenSecretRefCandidate(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+export function resolveGitHubTokenSecretRefForPropagation(params: {
+  explicitSecretRef?: unknown;
+  settingsSecretRef?: unknown;
+  companyId?: string | null;
+  pluginConfig?: GitHubSyncPluginConfig | null;
+}): string | undefined {
+  const explicitSecretRef = normalizeGitHubTokenSecretRefCandidate(params.explicitSecretRef);
+  if (explicitSecretRef) {
+    return explicitSecretRef;
+  }
+
+  const settingsSecretRef = normalizeGitHubTokenSecretRefCandidate(params.settingsSecretRef);
+  if (settingsSecretRef) {
+    return settingsSecretRef;
+  }
+
+  const companyId = normalizeGitHubTokenSecretRefCandidate(params.companyId);
+  if (!companyId || !params.pluginConfig) {
+    return undefined;
+  }
+
+  return normalizePluginConfig(params.pluginConfig).githubTokenRefs?.[companyId];
+}
+
 function normalizeCliAuthPollIntervalMs(value: unknown): number {
   if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
     return CLI_AUTH_POLL_INTERVAL_FALLBACK_MS;
@@ -12170,11 +12198,12 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
       return;
     }
 
-    let githubTokenSecretRef =
-      typeof options.githubTokenSecretRef === 'string' && options.githubTokenSecretRef.trim()
-        ? options.githubTokenSecretRef.trim()
-        : undefined;
     const companyId = hostContext.companyId;
+    let githubTokenSecretRef = resolveGitHubTokenSecretRefForPropagation({
+      explicitSecretRef: options.githubTokenSecretRef,
+      settingsSecretRef: currentSettings?.githubTokenConfigSyncRef ?? settings.data?.githubTokenConfigSyncRef,
+      companyId
+    });
 
     if (!githubTokenSecretRef) {
       if (!companyId) {
@@ -12187,8 +12216,10 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
       }
 
       const currentConfigResponse = await fetchJson<PluginConfigResponse | null>(`/api/plugins/${pluginId}/config`);
-      const normalizedConfig = normalizePluginConfig(currentConfigResponse?.configJson);
-      githubTokenSecretRef = normalizedConfig.githubTokenRefs?.[companyId];
+      githubTokenSecretRef = resolveGitHubTokenSecretRefForPropagation({
+        companyId,
+        pluginConfig: normalizePluginConfig(currentConfigResponse?.configJson)
+      });
     }
 
     if (!githubTokenSecretRef) {
@@ -12505,9 +12536,15 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
 
       let propagationError: unknown = null;
       try {
+        const githubTokenSecretRef = resolveGitHubTokenSecretRefForPropagation({
+          explicitSecretRef: result.githubTokenConfigSyncRef,
+          settingsSecretRef: currentSettings?.githubTokenConfigSyncRef ?? settings.data?.githubTokenConfigSyncRef,
+          companyId
+        });
         await propagateGitHubTokenToSelectedAgents({
           selectedAgentIds: normalizeAgentIds(normalizeAdvancedSettings(result.advancedSettings).githubTokenPropagationAgentIds),
-          previousAgentIds: normalizeAgentIds(currentSettings?.advancedSettings?.githubTokenPropagationAgentIds)
+          previousAgentIds: normalizeAgentIds(currentSettings?.advancedSettings?.githubTokenPropagationAgentIds),
+          githubTokenSecretRef
         });
       } catch (error) {
         propagationError = error;

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -7092,7 +7092,7 @@ export async function syncGitHubTokenPropagationForAgents(params: {
   }
 }
 
-function normalizeGitHubTokenSecretRefCandidate(value: unknown): string | undefined {
+function normalizeTrimmedString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
 
@@ -7102,17 +7102,17 @@ export function resolveGitHubTokenSecretRefForPropagation(params: {
   companyId?: string | null;
   pluginConfig?: GitHubSyncPluginConfig | null;
 }): string | undefined {
-  const explicitSecretRef = normalizeGitHubTokenSecretRefCandidate(params.explicitSecretRef);
+  const explicitSecretRef = normalizeTrimmedString(params.explicitSecretRef);
   if (explicitSecretRef) {
     return explicitSecretRef;
   }
 
-  const settingsSecretRef = normalizeGitHubTokenSecretRefCandidate(params.settingsSecretRef);
+  const settingsSecretRef = normalizeTrimmedString(params.settingsSecretRef);
   if (settingsSecretRef) {
     return settingsSecretRef;
   }
 
-  const companyId = normalizeGitHubTokenSecretRefCandidate(params.companyId);
+  const companyId = normalizeTrimmedString(params.companyId);
   if (!companyId || !params.pluginConfig) {
     return undefined;
   }

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -1465,6 +1465,56 @@ test('syncGitHubTokenPropagationForAgents batches propagation updates with a sma
   }
 });
 
+test('resolveGitHubTokenSecretRefForPropagation uses saved settings ref when plugin config refs are stripped', async () => {
+  const uiModule = await importFreshUiModule() as {
+    resolveGitHubTokenSecretRefForPropagation?: unknown;
+  };
+
+  assert.equal(typeof uiModule.resolveGitHubTokenSecretRefForPropagation, 'function');
+
+  const resolveGitHubTokenSecretRefForPropagation = uiModule.resolveGitHubTokenSecretRefForPropagation as (params: {
+    explicitSecretRef?: unknown;
+    settingsSecretRef?: unknown;
+    companyId?: string | null;
+    pluginConfig?: GitHubSyncPluginConfig | null;
+  }) => string | undefined;
+
+  assert.equal(
+    resolveGitHubTokenSecretRefForPropagation({
+      explicitSecretRef: ' explicit-secret-ref ',
+      settingsSecretRef: 'settings-secret-ref',
+      companyId: 'company-1',
+      pluginConfig: {
+        githubTokenRefs: {
+          'company-1': 'config-secret-ref'
+        }
+      }
+    }),
+    'explicit-secret-ref'
+  );
+
+  assert.equal(
+    resolveGitHubTokenSecretRefForPropagation({
+      settingsSecretRef: 'settings-secret-ref',
+      companyId: 'company-1',
+      pluginConfig: {}
+    }),
+    'settings-secret-ref'
+  );
+
+  assert.equal(
+    resolveGitHubTokenSecretRefForPropagation({
+      companyId: 'company-1',
+      pluginConfig: {
+        githubTokenRefs: {
+          'company-1': 'config-secret-ref'
+        }
+      }
+    }),
+    'config-secret-ref'
+  );
+});
+
 test('resolveInstalledGitHubSyncPluginId finds the GitHub Sync installation id from plugin listings', () => {
   const records = [
     {


### PR DESCRIPTION
## Summary
- Resolve GitHub token propagation from the freshly returned/saved settings secret ref before falling back to plugin config.
- Keep plugin-config lookup only as a legacy fallback for older state.
- Add a regression for the 0.9.4 failure mode where config secret-ref maps are stripped but settings.registration still exposes the saved GitHub secret ref.

## Root Cause
PRs 122 and 123 correctly stopped writing secret refs back into plugin config when the host rejects plugin secret references. The setup save path for adding propagation agents still tried to rediscover the GitHub token ref from plugin config unless the token was saved in that exact submit flow. In production 0.9.4, that leaves no config ref to read, so the UI throws: `GitHub token propagation requires a GitHub token saved through this settings page.`

The worker already returns `githubTokenConfigSyncRef` from `settings.registration`; setup save now uses that state-backed ref directly.

## Production Evidence
- Confirmed `paperclip-github-plugin@0.9.4` is installed on `cliponaut.duckdns.org`.
- Confirmed the installed UI bundle has the failing branch: `propagateGitHubTokenToSelectedAgents()` only checks an explicit option, then `/api/plugins/:id/config`, then throws the exact production message.

## Validation
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm test:e2e`

## Model Used
GPT-5.5 (`gpt-5.5`), 400k token context window, medium reasoning, with shell, SSH, GitHub CLI, and local patch tool use.