### PR TITLE
Clear stale monitor execution state

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8133,8 +8133,30 @@ function isHealthyMaintainerWaitTransition(params: {
 
   return nextStatus === 'in_review'
     && (currentStatus === 'done' || currentStatus === 'in_review')
-    && syncContext.executionState === null
-    && syncContext.executionPolicy !== null;
+    && isClearableMaintainerWaitExecutionState(syncContext.executionState);
+}
+
+function isClearableMaintainerWaitExecutionState(
+  executionState: PaperclipIssueExecutionState | null
+): boolean {
+  if (executionState === null) {
+    return true;
+  }
+
+  if (
+    executionState.currentParticipant !== null ||
+    executionState.returnAssignee !== null ||
+    executionState.currentStageId !== null ||
+    executionState.currentStageIndex !== null ||
+    executionState.currentStageType !== null ||
+    executionState.completedStageIds.length > 0 ||
+    executionState.lastDecisionId ||
+    executionState.lastDecisionOutcome
+  ) {
+    return false;
+  }
+
+  return !executionState.status || executionState.status === 'idle' || executionState.status === 'completed';
 }
 
 function shouldClearCompletedSyncExecutionPolicy(params: {
@@ -12967,6 +12989,17 @@ async function updatePaperclipIssueState(
 
       if (!payloadResult.failure) {
         issueUpdated = true;
+        if (
+          issuePatch.executionState === null &&
+          ctx.issues &&
+          typeof ctx.issues.update === 'function'
+        ) {
+          await ctx.issues.update(
+            issueId,
+            { executionState: null } as PaperclipIssueUpdatePatchWithLabels,
+            companyId
+          );
+        }
       }
 
       if (payloadResult.failure && (payloadResult.failure.status ?? response.status) !== 404 && (payloadResult.failure.status ?? response.status) !== 405) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12994,11 +12994,22 @@ async function updatePaperclipIssueState(
           ctx.issues &&
           typeof ctx.issues.update === 'function'
         ) {
-          await ctx.issues.update(
-            issueId,
-            { executionState: null } as PaperclipIssueUpdatePatchWithLabels,
-            companyId
-          );
+          try {
+            await ctx.issues.update(
+              issueId,
+              { executionState: null } as PaperclipIssueUpdatePatchWithLabels,
+              companyId
+            );
+          } catch (error) {
+            issueUpdated = false;
+            ctx.logger.warn('GitHub sync could not clear Paperclip issue execution state after the local API update. Falling back to direct issue mutation.', {
+              companyId,
+              issueId,
+              paperclipApiBaseUrl,
+              nextStatus,
+              error: getErrorMessage(error)
+            });
+          }
         }
       }
 

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -18881,17 +18881,16 @@ test('worker routes non-review-ready GitHub merge state statuses back to active 
       });
 
       const initialStatus = scenario.initialStatus ?? 'in_review';
-      return harness.ctx.issues.update(
-        created.id,
-        {
-          ...(created.status === initialStatus ? {} : { status: initialStatus }),
-          ...(scenario.initialExecutionState ? {
-            assigneeAgentId: 'agent-1',
-            executionState: scenario.initialExecutionState
-          } : {})
-        } as never,
-        'company-1'
-      );
+      const patch: Record<string, unknown> = {
+        ...(created.status === initialStatus ? {} : { status: initialStatus }),
+        ...(scenario.initialExecutionState ? {
+          assigneeAgentId: 'agent-1',
+          executionState: scenario.initialExecutionState
+        } : {})
+      };
+      return Object.keys(patch).length === 0
+        ? created
+        : harness.ctx.issues.update(created.id, patch as never, 'company-1');
     })
   );
 

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -18834,6 +18834,41 @@ test('worker routes non-review-ready GitHub merge state statuses back to active 
       mergeStateStatus: 'UNKNOWN',
       expectedStatus: 'in_review' as const,
       expectedReason: /unknown mergeability/
+    },
+    {
+      githubIssueId: 5001,
+      githubIssueNumber: 50,
+      pullRequestNumber: 500,
+      title: 'Triggered monitor wait',
+      initialStatus: 'in_review' as const,
+      initialExecutionState: {
+        status: 'idle',
+        currentStageId: null,
+        currentStageIndex: null,
+        currentStageType: null,
+        currentParticipant: null,
+        returnAssignee: null,
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+        monitor: {
+          status: 'triggered',
+          nextCheckAt: null,
+          lastTriggeredAt: '2026-04-09T09:10:00.000Z',
+          attemptCount: 1,
+          notes: 'Check GitHub pull request status.',
+          scheduledBy: 'board',
+          kind: 'external_service',
+          serviceName: 'GitHub',
+          externalRef: null,
+          timeoutAt: null,
+          maxAttempts: null,
+          recoveryPolicy: null,
+          clearedAt: null,
+          clearReason: null
+        }
+      },
+      expectedStatus: 'in_review' as const
     }
   ];
 
@@ -18846,9 +18881,17 @@ test('worker routes non-review-ready GitHub merge state statuses back to active 
       });
 
       const initialStatus = scenario.initialStatus ?? 'in_review';
-      return created.status === initialStatus
-        ? created
-        : harness.ctx.issues.update(created.id, { status: initialStatus }, 'company-1');
+      return harness.ctx.issues.update(
+        created.id,
+        {
+          ...(created.status === initialStatus ? {} : { status: initialStatus }),
+          ...(scenario.initialExecutionState ? {
+            assigneeAgentId: 'agent-1',
+            executionState: scenario.initialExecutionState
+          } : {})
+        } as never,
+        'company-1'
+      );
     })
   );
 
@@ -19010,6 +19053,9 @@ test('worker routes non-review-ready GitHub merge state statuses back to active 
         );
       } else {
         assert.equal(issue?.assigneeAgentId ?? null, null);
+        if (scenario.initialExecutionState) {
+          assert.equal(issue?.executionState ?? null, null);
+        }
         const transitionComment = statusTransitionComments.find((comment) => comment.issueId === issue?.id);
         if (scenario.initialStatus === 'done') {
           assert.match(transitionComment?.body ?? '', /from `done` to `in review`/);


### PR DESCRIPTION
## Summary
- Clear stale monitor-only `executionState` when GitHub Sync turns a fired monitor PR wait into a healthy unassigned `in_review` state.
- Add regression coverage for a triggered Paperclip monitor whose linked PR remains review-ready.
- Repair the real host path where local Paperclip REST status patches succeed but do not clear raw `executionState` by issuing a focused SDK state-clear patch afterward.

## Root Cause
Paperclip issue monitors leave historical monitor state in `executionState.monitor` after a monitor fires. When GitHub Sync later observed the linked PR as a healthy maintainer/review wait, it cleared the assignee but left that monitor-only execution state behind. Paperclip liveness recovery then saw an `in_review` issue with `executionState` but no resolvable `currentParticipant`, and created `invalid_review_participant` recovery work.

## Validation
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- Disposable real-host verification with rebuilt local plugin installed into `paperclipai@2026.512.0`:
  - Created an `in_review` Monitor PR child assigned to a test `Micronaut Engineer` agent.
  - Scheduled and triggered a Paperclip monitor so the issue had fired monitor-only `executionState`.
  - Linked the issue to real GitHub PR `micronaut-projects/micronaut-core#12668`, verified `CLEAN` with green checks.
  - Ran installed plugin `sync.runNow` through the Paperclip plugin action bridge.
  - Confirmed final issue state: `status=in_review`, no assignee, `executionState=null`.
  - Confirmed Paperclip liveness preview returned `findings=0` and no `invalid_review_participant` item.

## Model Used
- Model ID/version: Codex GPT-5, as exposed by this Codex session.
- Context window size: not exposed by the local Codex desktop runtime to this agent.
- Capabilities used: shell commands, local file edits, git/GitHub CLI, Paperclip disposable host verification, GitHub API via `gh`.
