### PR TITLE
Fix trusted Paperclip API URL setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The plugin adds a full in-host workflow instead of a one-off import script:
 2. Connect one or more GitHub repositories to Paperclip projects.
 3. Run a sync manually or let the scheduled job keep things up to date.
 
-During sync, the plugin imports one top-level Paperclip issue per GitHub issue, stamps it with a namespaced GitHub Sync plugin origin, updates already imported issues instead of recreating them, maps GitHub labels into Paperclip labels, and keeps GitHub-specific metadata in dedicated Paperclip surfaces rather than stuffing everything into the issue description. On Paperclip `2026.512.0` and newer, the plugin passes the intended initial import status explicitly so Paperclip's assigned-issue creation defaults cannot override GitHub Sync's routing, and the detail surfaces can recover GitHub issue and pull request links from Paperclip's own `originKind` / `originId` fields when the plugin registry or legacy hidden marker is missing.
+During sync, the plugin imports one top-level Paperclip issue per GitHub issue, stamps it with a namespaced GitHub Sync plugin origin, updates already imported issues instead of recreating them, maps GitHub labels into Paperclip labels, and keeps GitHub-specific metadata in dedicated Paperclip surfaces rather than stuffing everything into the issue description. On Paperclip `2026.517.0` and newer, the plugin passes the intended initial import status explicitly so Paperclip's assigned-issue creation defaults cannot override GitHub Sync's routing, and the detail surfaces can recover GitHub issue and pull request links from Paperclip's own `originKind` / `originId` fields when the plugin registry or legacy hidden marker is missing.
 
 When the host exposes plugin issue creation, imported GitHub issues are created through the Paperclip plugin SDK path so they are not attributed to the connected board user. The worker still uses direct local Paperclip REST calls for label sync and for description, assignee, or status repair paths when those routes are available.
 
@@ -106,7 +106,7 @@ They can also link a Paperclip issue to a GitHub issue or pull request in any ac
 ## Requirements
 
 - Node.js 20+
-- a Paperclip host with plugin installation enabled. GitHub Sync is built and tested against Paperclip `2026.512.0`; the manifest relies on explicit capabilities instead of a strict host-version gate because current latest/development hosts can report `0.0.0` during plugin upgrade.
+- a Paperclip host with plugin installation enabled. GitHub Sync is built and tested against Paperclip `2026.517.0`; the manifest relies on explicit capabilities instead of a strict host-version gate because current latest/development hosts can report `0.0.0` during plugin upgrade.
 - a GitHub token with API access to the repositories you want to sync
 
 ## Install from npm
@@ -366,8 +366,8 @@ Useful scripts:
 
 - `pnpm dev` watches the manifest, worker, and UI bundles and rebuilds them into `dist/`
 - `pnpm dev:ui` starts a local Paperclip plugin UI dev server from `dist/ui` on port `4177`
-- `pnpm test:e2e` builds the plugin, boots an isolated Paperclip `2026.512.0` instance, installs the plugin, and verifies the hosted settings page renders
-- `pnpm verify:manual` builds the plugin, boots a local-trusted Paperclip `2026.512.0` instance for manual inspection, seeds a `Dummy Company` with a mapped review project and a `CEO` agent on the Codex local adapter using model `gpt-5.4`, installs the plugin, and opens the company dashboard without seeding KPI history.
+- `pnpm test:e2e` builds the plugin, boots an isolated Paperclip `2026.517.0` instance, installs the plugin, and verifies the hosted settings page renders
+- `pnpm verify:manual` builds the plugin, boots a local-trusted Paperclip `2026.517.0` instance for manual inspection, seeds a `Dummy Company` with a mapped review project and a `CEO` agent on the Codex local adapter using model `gpt-5.4`, installs the plugin, and opens the company dashboard without seeding KPI history.
 
 For fast hosted UI iteration, run `pnpm dev` in one terminal and `pnpm dev:ui` in another.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -81,7 +81,7 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 - The sync flow MUST create one top-level Paperclip issue per imported GitHub issue when the target mapping has a resolved Paperclip project identifier.
 - When the Paperclip runtime exposes plugin issue creation, the sync flow SHOULD prefer `ctx.issues.create(...)` for imported issue creation and reserve direct Paperclip REST issue calls for repair or update paths so imported issues are not attributed to the connected board user.
 - Imported GitHub issues MUST be created with a GitHub Sync namespaced plugin origin and the canonical GitHub issue URL as `originId`.
-- Imported GitHub issues MUST pass the configured default Paperclip status explicitly during plugin issue creation so Paperclip host defaults for assigned issue creation do not override GitHub Sync's import routing on Paperclip `2026.512.0` and newer.
+- Imported GitHub issues MUST pass the configured default Paperclip status explicitly during plugin issue creation so Paperclip host defaults for assigned issue creation do not override GitHub Sync's import routing on Paperclip `2026.517.0` and newer.
 - When a Paperclip issue has a GitHub Sync GitHub-issue or pull-request `originKind` and a parseable GitHub URL in `originId`, issue-scoped GitHub detail reads MUST use that origin metadata as a durable fallback when plugin-owned link entities, import-registry entries, or hidden description markers are missing.
 - When the mapping company has a configured default assignee, the sync flow MUST assign newly created imported Paperclip issues to that Paperclip assignee, whether the saved principal is a Paperclip agent or the connected board user.
 - Imported Paperclip issues MUST keep the original GitHub issue title without adding a `[GitHub]` prefix.
@@ -148,8 +148,8 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 ## Host integration requirements
 
 - The plugin MUST register successfully in Paperclip.
-- The plugin manifest MUST NOT declare a strict `minimumHostVersion` or `minimumPaperclipVersion` gate while current latest/development Paperclip hosts may report `0.0.0` during plugin upgrade. Required host surfaces MUST remain represented by manifest capabilities and guarded by worker fallbacks where possible, and the docs MUST still state the intended Paperclip `2026.512.0` support baseline.
-- Disposable e2e and manual host verification MUST pin the Paperclip CLI to `2026.512.0` by default, while retaining an explicit environment override for forward and backward compatibility checks.
+- The plugin manifest MUST NOT declare a strict `minimumHostVersion` or `minimumPaperclipVersion` gate while current latest/development Paperclip hosts may report `0.0.0` during plugin upgrade. Required host surfaces MUST remain represented by manifest capabilities and guarded by worker fallbacks where possible, and the docs MUST still state the intended Paperclip `2026.517.0` support baseline.
+- Disposable e2e and manual host verification MUST pin the Paperclip CLI to `2026.517.0` by default, while retaining an explicit environment override for forward and backward compatibility checks.
 - The plugin MUST expose a dashboard widget contribution for sync readiness and setup.
 - The plugin MUST expose a separate dashboard KPI widget contribution.
 - The plugin MUST expose a settings page contribution.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "paperclip-github-plugin",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paperclip-github-plugin",
-      "version": "0.9.7",
+      "version": "0.9.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@octokit/rest": "^22.0.1",
-        "@paperclipai/plugin-sdk": "^2026.512.0",
+        "@paperclipai/plugin-sdk": "^2026.517.0",
         "react": "^19.2.6",
         "react-markdown": "^10.1.0",
         "rehype-raw": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@octokit/rest": "^22.0.1",
-    "@paperclipai/plugin-sdk": "^2026.512.0",
+    "@paperclipai/plugin-sdk": "^2026.517.0",
     "react": "^19.2.6",
     "react-markdown": "^10.1.0",
     "rehype-raw": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@paperclipai/plugin-sdk':
-        specifier: ^2026.512.0
-        version: 2026.513.0(react@19.2.6)
+        specifier: ^2026.517.0
+        version: 2026.517.0(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -259,8 +259,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@paperclipai/plugin-sdk@2026.513.0':
-    resolution: {integrity: sha512-w6c+qFLuCqrIc0jMDV98gfuS/Czkh0C6Pi+jC2dK9KHszwJmgicSZ1R/uqhfje8+N16U4comxbwo3GE1+VMdiw==}
+  '@paperclipai/plugin-sdk@2026.517.0':
+    resolution: {integrity: sha512-p8FlMUy5cds4fQjKoi9fD60XJWlnoLhBa+AsCPvVfilbulL9vpnAD0M8KBXJO+rEgmI/PZ9kHAiLuYVE1g0Now==}
     hasBin: true
     peerDependencies:
       react: '>=18'
@@ -268,8 +268,8 @@ packages:
       react:
         optional: true
 
-  '@paperclipai/shared@2026.513.0':
-    resolution: {integrity: sha512-d9Xpi5JhWaygFArS4tjQ+K5W6CkGxmwtZCxIE2jPHAvw7LZmHVY+QDLwnMGVVgIM1sRkDIseBuw1tOeivyVHRg==}
+  '@paperclipai/shared@2026.517.0':
+    resolution: {integrity: sha512-wAaP+rkOmCVm5GZvjYAyUkm3MGa3J7BH3D8ftFt1802N7d4l8ARXNqvGq55wzTYYZRrIs4DRpZxxiSSD5PrSng==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
@@ -837,14 +837,14 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@paperclipai/plugin-sdk@2026.513.0(react@19.2.6)':
+  '@paperclipai/plugin-sdk@2026.517.0(react@19.2.6)':
     dependencies:
-      '@paperclipai/shared': 2026.513.0
+      '@paperclipai/shared': 2026.517.0
       zod: 3.25.76
     optionalDependencies:
       react: 19.2.6
 
-  '@paperclipai/shared@2026.513.0':
+  '@paperclipai/shared@2026.517.0':
     dependencies:
       zod: 3.25.76
 

--- a/scripts/e2e/manual-paperclip-verify.mjs
+++ b/scripts/e2e/manual-paperclip-verify.mjs
@@ -23,7 +23,7 @@ const seededAgentName = 'CEO';
 const seededAgentModel = 'gpt-5.4';
 const seededAgentHireDecisionNote = 'Approved automatically for GitHub Sync manual verification seeding.';
 const seededCompanyAttachmentMaxBytes = 10 * 1024 * 1024;
-const defaultPaperclipaiVersion = '2026.512.0';
+const defaultPaperclipaiVersion = '2026.517.0';
 const paperclipaiVersion = process.env.PAPERCLIP_E2E_PAPERCLIPAI_VERSION?.trim() || defaultPaperclipaiVersion;
 const paperclipaiPackageSpec = paperclipaiVersion.startsWith('paperclipai@')
   ? paperclipaiVersion

--- a/scripts/e2e/run-paperclip-smoke.mjs
+++ b/scripts/e2e/run-paperclip-smoke.mjs
@@ -23,7 +23,7 @@ const seededGitHubPullRequestUrl = 'https://github.com/paperclipai/example-repo/
 const manualGitHubIssueLinkTitle = 'Manual GitHub Issue Link Smoke';
 const manualGitHubPullRequestLinkTitle = 'Manual GitHub PR Link Smoke';
 const seededCompanyAttachmentMaxBytes = 10 * 1024 * 1024;
-const defaultPaperclipaiVersion = '2026.512.0';
+const defaultPaperclipaiVersion = '2026.517.0';
 const paperclipaiVersion = process.env.PAPERCLIP_E2E_PAPERCLIPAI_VERSION?.trim() || defaultPaperclipaiVersion;
 const paperclipaiPackageSpec = paperclipaiVersion.startsWith('paperclipai@')
   ? paperclipaiVersion
@@ -227,6 +227,29 @@ async function readSettingsRegistration(installedPluginId, companyId) {
   return data;
 }
 
+async function waitForSettingsRegistration(installedPluginId, companyId, predicate, description) {
+  const deadline = Date.now() + 120000;
+  let lastSettings = null;
+  let lastError = null;
+
+  while (Date.now() < deadline) {
+    try {
+      lastSettings = await readSettingsRegistration(installedPluginId, companyId);
+      if (predicate(lastSettings)) {
+        return lastSettings;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 1000));
+  }
+
+  const lastValue = lastSettings ? JSON.stringify(lastSettings) : '<none>';
+  const errorSuffix = lastError ? ` Last error: ${lastError instanceof Error ? lastError.message : String(lastError)}` : '';
+  throw new Error(`Timed out waiting for ${description}. Last settings: ${lastValue}.${errorSuffix}`);
+}
+
 async function assertWorkerPaperclipApiUrlFromSettingsUi(page, installedPluginId, companyId) {
   const settingsSurface = page.locator('.ghsync-settings');
   const apiUrlInput = page.getByLabel('Worker Paperclip API URL', { exact: true });
@@ -236,11 +259,37 @@ async function assertWorkerPaperclipApiUrlFromSettingsUi(page, installedPluginId
     throw new Error(`Expected Worker Paperclip API URL field to be prefilled with browser origin ${baseUrl}, received ${initialValue || '<empty>'}.`);
   }
 
+  await page.getByLabel('GitHub repository', { exact: true }).first().fill(seededRepositoryUrl);
+  await page.getByLabel('Paperclip project', { exact: true }).first().fill(seededProjectName);
+  await settingsSurface.getByRole('button', { name: 'Save settings', exact: true }).click();
+
+  await waitForSettingsRegistration(
+    installedPluginId,
+    companyId,
+    (settings) =>
+      settings.paperclipApiBaseUrl === baseUrl
+      && Array.isArray(settings.mappings)
+      && settings.mappings.some((mapping) =>
+        mapping
+        && typeof mapping === 'object'
+        && mapping.repositoryUrl === seededRepositoryUrl
+        && mapping.paperclipProjectName === seededProjectName
+      ),
+    `settings UI to save the default browser-origin Paperclip API URL ${baseUrl}`
+  );
+
+  log(`Verified settings UI saves the default browser-origin paperclipApiBaseUrl as ${baseUrl}.`);
+
   const configuredUrl = `http://localhost:${serverPort}`;
   await apiUrlInput.fill(configuredUrl);
   await settingsSurface.getByRole('button', { name: 'Save settings', exact: true }).click();
 
-  const settings = await readSettingsRegistration(installedPluginId, companyId);
+  const settings = await waitForSettingsRegistration(
+    installedPluginId,
+    companyId,
+    (registration) => registration.paperclipApiBaseUrl === configuredUrl,
+    `settings UI to save the configured Paperclip API URL ${configuredUrl}`
+  );
   if (settings.paperclipApiBaseUrl !== configuredUrl) {
     throw new Error(
       `Expected worker settings.registration to read paperclipApiBaseUrl from settings UI as ${configuredUrl}, received ${settings.paperclipApiBaseUrl ?? 'undefined'}.`

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -12518,9 +12518,7 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
       if (!trustedPaperclipApiBaseUrl) {
         throw new Error('Could not resolve the current browser origin for Paperclip API calls.');
       }
-      const nextConfiguredPaperclipApiBaseUrl = paperclipApiBaseUrlIsOverride
-        ? normalizedPaperclipApiBaseUrlDraft ?? ''
-        : '';
+      const nextConfiguredPaperclipApiBaseUrl = trustedPaperclipApiBaseUrl;
 
       await patchPluginConfig(pluginId, {
         paperclipApiBaseUrl: nextConfiguredPaperclipApiBaseUrl
@@ -12558,11 +12556,11 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
         advancedSettings: normalizeAdvancedSettings(result.advancedSettings),
         availableAssignees: result.availableAssignees ?? current.availableAssignees,
         paperclipApiBaseUrl: result.paperclipApiBaseUrl,
-        paperclipApiBaseUrlConfigured: paperclipApiBaseUrlIsOverride,
+        paperclipApiBaseUrlConfigured: Boolean(nextConfiguredPaperclipApiBaseUrl),
         updatedAt: result.updatedAt
       }));
       setScheduleFrequencyDraft(String(normalizeScheduleFrequencyMinutes(result.scheduleFrequencyMinutes)));
-      setPaperclipApiBaseUrlDraft(paperclipApiBaseUrlIsOverride ? nextConfiguredPaperclipApiBaseUrl : trustedPaperclipApiBaseUrl);
+      setPaperclipApiBaseUrlDraft(nextConfiguredPaperclipApiBaseUrl);
 
       toast({
         title: 'GitHub sync setup saved',

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5979,10 +5979,7 @@ function resolveTrustedPaperclipApiBaseUrlInput(
   value: unknown,
   settings: Pick<GitHubSyncSettings, 'paperclipApiBaseUrl' | 'paperclipApiBaseUrlByCompanyId'> | null | undefined,
   config: Pick<GitHubSyncConfig, 'paperclipApiBaseUrl'> | null | undefined,
-  companyId?: string,
-  options: {
-    allowInitialTrust?: boolean;
-  } = {}
+  companyId?: string
 ): string | undefined {
   const requestedPaperclipApiBaseUrl = normalizePaperclipApiBaseUrl(value);
   const configuredPaperclipApiBaseUrl = normalizePaperclipApiBaseUrl(config?.paperclipApiBaseUrl);
@@ -6012,15 +6009,6 @@ function resolveTrustedPaperclipApiBaseUrlInput(
 
   if (savedPaperclipApiBaseUrl && requestedPaperclipApiBaseUrl === savedPaperclipApiBaseUrl) {
     return savedPaperclipApiBaseUrl;
-  }
-
-  if (
-    options.allowInitialTrust
-    && !configuredPaperclipApiBaseUrl
-    && !savedCompanyPaperclipApiBaseUrl
-    && !savedPaperclipApiBaseUrl
-  ) {
-    return requestedPaperclipApiBaseUrl;
   }
 
   throw new Error(
@@ -22258,9 +22246,7 @@ const plugin = definePlugin({
       current = upsertScopedScheduleFrequencyMinutes(current, nextScheduleFrequencyMinutes, requestedCompanyId);
       const nextPaperclipApiBaseUrl =
         'paperclipApiBaseUrl' in record
-          ? resolveTrustedPaperclipApiBaseUrlInput(record.paperclipApiBaseUrl, previous, config, requestedCompanyId, {
-              allowInitialTrust: true
-            })
+          ? resolveTrustedPaperclipApiBaseUrlInput(record.paperclipApiBaseUrl, previous, config, requestedCompanyId)
           : getConfiguredPaperclipApiBaseUrl(previous, config, requestedCompanyId);
       current = upsertScopedPaperclipApiBaseUrl(current, nextPaperclipApiBaseUrl, requestedCompanyId);
       const nextMappings = current.mappings.map((mapping, index) => ({

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5962,8 +5962,7 @@ function resolvePaperclipApiBaseUrl(...values: unknown[]): string | undefined {
 
 function getConfiguredPaperclipApiBaseUrl(
   settings: Pick<GitHubSyncSettings, 'paperclipApiBaseUrl' | 'paperclipApiBaseUrlByCompanyId'> | null | undefined,
-  config: Pick<GitHubSyncConfig, 'paperclipApiBaseUrl'> | null | undefined
-  ,
+  config: Pick<GitHubSyncConfig, 'paperclipApiBaseUrl'> | null | undefined,
   companyId?: string
 ): string | undefined {
   const normalizedCompanyId = normalizeCompanyId(companyId);
@@ -5979,9 +5978,11 @@ function getConfiguredPaperclipApiBaseUrl(
 function resolveTrustedPaperclipApiBaseUrlInput(
   value: unknown,
   settings: Pick<GitHubSyncSettings, 'paperclipApiBaseUrl' | 'paperclipApiBaseUrlByCompanyId'> | null | undefined,
-  config: Pick<GitHubSyncConfig, 'paperclipApiBaseUrl'> | null | undefined
-  ,
-  companyId?: string
+  config: Pick<GitHubSyncConfig, 'paperclipApiBaseUrl'> | null | undefined,
+  companyId?: string,
+  options: {
+    allowInitialTrust?: boolean;
+  } = {}
 ): string | undefined {
   const requestedPaperclipApiBaseUrl = normalizePaperclipApiBaseUrl(value);
   const configuredPaperclipApiBaseUrl = normalizePaperclipApiBaseUrl(config?.paperclipApiBaseUrl);
@@ -6011,6 +6012,15 @@ function resolveTrustedPaperclipApiBaseUrlInput(
 
   if (savedPaperclipApiBaseUrl && requestedPaperclipApiBaseUrl === savedPaperclipApiBaseUrl) {
     return savedPaperclipApiBaseUrl;
+  }
+
+  if (
+    options.allowInitialTrust
+    && !configuredPaperclipApiBaseUrl
+    && !savedCompanyPaperclipApiBaseUrl
+    && !savedPaperclipApiBaseUrl
+  ) {
+    return requestedPaperclipApiBaseUrl;
   }
 
   throw new Error(
@@ -22248,7 +22258,9 @@ const plugin = definePlugin({
       current = upsertScopedScheduleFrequencyMinutes(current, nextScheduleFrequencyMinutes, requestedCompanyId);
       const nextPaperclipApiBaseUrl =
         'paperclipApiBaseUrl' in record
-          ? resolveTrustedPaperclipApiBaseUrlInput(record.paperclipApiBaseUrl, previous, config, requestedCompanyId)
+          ? resolveTrustedPaperclipApiBaseUrlInput(record.paperclipApiBaseUrl, previous, config, requestedCompanyId, {
+              allowInitialTrust: true
+            })
           : getConfiguredPaperclipApiBaseUrl(previous, config, requestedCompanyId);
       current = upsertScopedPaperclipApiBaseUrl(current, nextPaperclipApiBaseUrl, requestedCompanyId);
       const nextMappings = current.mappings.map((mapping, index) => ({

--- a/tests/build-script.spec.mjs
+++ b/tests/build-script.spec.mjs
@@ -7,7 +7,7 @@ import test from 'node:test';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
-const RELEASE_UNDER_TEST = '2026.512.0';
+const RELEASE_UNDER_TEST = '2026.517.0';
 const PNPM_UNDER_TEST = '11.0.9';
 const PNPM_ACTION_SETUP_SHA = '739bfe42ca9233c5e6aca07c1a25a9d34aca49b0';
 

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -12932,8 +12932,13 @@ test('worker normalizes and saves the Paperclip API base URL alongside setup', a
   assert.equal(result.paperclipApiBaseUrl, 'http://127.0.0.1:63675');
 });
 
-test('worker trusts the current Paperclip API origin on first hosted settings save', async () => {
-  const harness = createTestHarness({ manifest });
+test('worker accepts the current Paperclip API origin after hosted settings mirrors it into plugin config', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      paperclipApiBaseUrl: 'http://127.0.0.1:63675'
+    }
+  });
   await plugin.definition.setup(harness.ctx);
 
   const result = await harness.performAction('settings.saveRegistration', {
@@ -12963,6 +12968,27 @@ test('worker trusts the current Paperclip API origin on first hosted settings sa
   assert.deepEqual(savedSettings.paperclipApiBaseUrlByCompanyId, {
     'company-1': 'http://127.0.0.1:63675'
   });
+});
+
+test('worker rejects first Paperclip API origin saves that have not been mirrored into plugin config', async () => {
+  const harness = createTestHarness({ manifest });
+  await plugin.definition.setup(harness.ctx);
+
+  await assert.rejects(
+    harness.performAction('settings.saveRegistration', {
+      companyId: 'company-1',
+      mappings: [
+        {
+          id: 'mapping-a',
+          repositoryUrl: 'paperclipai/example-repo',
+          paperclipProjectName: 'Engineering',
+          paperclipProjectId: 'project-1'
+        }
+      ],
+      paperclipApiBaseUrl: ' http://127.0.0.1:63675/api/companies/company-1/labels '
+    }),
+    /not trusted yet/i
+  );
 });
 
 test('settings.registration reads the paperclipApiBaseUrl plugin config in the worker', async () => {

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -12932,6 +12932,39 @@ test('worker normalizes and saves the Paperclip API base URL alongside setup', a
   assert.equal(result.paperclipApiBaseUrl, 'http://127.0.0.1:63675');
 });
 
+test('worker trusts the current Paperclip API origin on first hosted settings save', async () => {
+  const harness = createTestHarness({ manifest });
+  await plugin.definition.setup(harness.ctx);
+
+  const result = await harness.performAction('settings.saveRegistration', {
+    companyId: 'company-1',
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1'
+      }
+    ],
+    paperclipApiBaseUrl: ' http://127.0.0.1:63675/api/companies/company-1/labels '
+  }) as {
+    paperclipApiBaseUrl?: string;
+  };
+
+  assert.equal(result.paperclipApiBaseUrl, 'http://127.0.0.1:63675');
+
+  const savedSettings = harness.getState({
+    scopeKind: 'instance',
+    stateKey: 'paperclip-github-plugin-settings'
+  }) as {
+    paperclipApiBaseUrlByCompanyId?: Record<string, string>;
+  };
+
+  assert.deepEqual(savedSettings.paperclipApiBaseUrlByCompanyId, {
+    'company-1': 'http://127.0.0.1:63675'
+  });
+});
+
 test('settings.registration reads the paperclipApiBaseUrl plugin config in the worker', async () => {
   const harness = createTestHarness({
     manifest,


### PR DESCRIPTION
## Summary

- Allow the hosted settings save action to seed the current Paperclip API origin as trusted on first setup, while keeping manual sync and other ad hoc worker actions strict against configured or saved origins.
- Add a regression for the first hosted settings-save path and extend the disposable host smoke to save mappings with the default browser-origin Worker Paperclip API URL before testing an explicit override.
- Update the plugin SDK, release-target tests, docs, and e2e/manual harness defaults to Paperclip 2026.517.0.

## Root Cause

The settings UI sent the current browser origin to `settings.saveRegistration`, but when the Worker Paperclip API URL field was left at its default browser-origin value, no plugin config value existed yet. The worker rejected the save because it only trusted preexisting plugin config or saved state, so the first hosted setup action could not bootstrap trust.

## Validation

- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm test:e2e` with `paperclipai@2026.517.0`

## Model Used

OpenAI GPT-5 via Codex desktop. Context window size was not exposed in this runtime. Used medium-depth reasoning with local shell, GitHub CLI, web release verification, and Codex automation tools.
