### PR TITLE
Fix execution state in status API updates

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -13020,7 +13020,7 @@ async function updatePaperclipIssueState(
   });
   const issuePatch: Record<string, unknown> = {
     status: nextStatus,
-    ...(syncExecutionStatePatch === null ? { executionState: null } : {}),
+    ...(syncExecutionStatePatch !== undefined ? { executionState: syncExecutionStatePatch } : {}),
     ...(clearExecutionPolicy ? { executionPolicy: null, executionState: null } : {})
   };
 

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -22974,6 +22974,17 @@ test('worker preserves execution-policy pending review state when the local Pape
     const directStatusPatches = directStatusUpdateCalls.filter((call) => typeof call.patch.status === 'string');
     assert.equal(statusPatchRequests.length, 1);
     assert.equal(statusPatchRequests[0]?.body?.status, 'in_review');
+    assert.deepEqual(statusPatchRequests[0]?.body?.executionState, {
+      status: 'pending',
+      currentStageId: 'review-stage',
+      currentStageIndex: 0,
+      currentStageType: 'review',
+      currentParticipant: { type: 'agent', agentId: 'agent-2', userId: null },
+      returnAssignee: { type: 'agent', agentId: 'agent-1', userId: null },
+      completedStageIds: [],
+      lastDecisionId: null,
+      lastDecisionOutcome: null
+    });
     assert.equal(directStatusPatches.length, 1);
     assert.equal(directStatusPatches[0]?.patch.status, 'in_review');
     assert.equal(directStatusPatches[0]?.patch.assigneeAgentId, 'agent-2');


### PR DESCRIPTION
## Summary

- Include computed executionState patches in local Paperclip API status updates, not only SDK fallback updates
- Add regression coverage proving in_review execution-policy handoffs send the pending participant state in the API request body

## Verification

- CI=true pnpm exec tsx --test --test-name-pattern "pending review state" tests/plugin.spec.ts
- CI=true pnpm typecheck

---
###### ✨ This message was AI-generated using gpt-5.5