### PR TITLE
Align GitHub Sync with Paperclip 2026.529

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ They can also link a Paperclip issue to a GitHub issue or pull request in any ac
 ## Requirements
 
 - Node.js 20+
-- a Paperclip host with plugin installation enabled. GitHub Sync is built and tested against Paperclip `2026.517.0`; the manifest relies on explicit capabilities instead of a strict host-version gate because current latest/development hosts can report `0.0.0` during plugin upgrade.
+- a Paperclip host with plugin installation enabled. GitHub Sync is built and tested against Paperclip `2026.529.0`; the manifest relies on explicit capabilities instead of a strict host-version gate because current latest/development hosts can report `0.0.0` during plugin upgrade.
 - a GitHub token with API access to the repositories you want to sync
 
 ## Install from npm
@@ -366,8 +366,8 @@ Useful scripts:
 
 - `pnpm dev` watches the manifest, worker, and UI bundles and rebuilds them into `dist/`
 - `pnpm dev:ui` starts a local Paperclip plugin UI dev server from `dist/ui` on port `4177`
-- `pnpm test:e2e` builds the plugin, boots an isolated Paperclip `2026.517.0` instance, installs the plugin, and verifies the hosted settings page renders
-- `pnpm verify:manual` builds the plugin, boots a local-trusted Paperclip `2026.517.0` instance for manual inspection, seeds a `Dummy Company` with a mapped review project and a `CEO` agent on the Codex local adapter using model `gpt-5.4`, installs the plugin, and opens the company dashboard without seeding KPI history.
+- `pnpm test:e2e` builds the plugin, boots an isolated Paperclip `2026.529.0` instance, installs the plugin, and verifies the hosted settings page renders
+- `pnpm verify:manual` builds the plugin, boots a local-trusted Paperclip `2026.529.0` instance for manual inspection, seeds a `Dummy Company` with a mapped review project and a `CEO` agent on the Codex local adapter using model `gpt-5.4`, installs the plugin, and opens the company dashboard without seeding KPI history.
 
 For fast hosted UI iteration, run `pnpm dev` in one terminal and `pnpm dev:ui` in another.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -149,8 +149,8 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 ## Host integration requirements
 
 - The plugin MUST register successfully in Paperclip.
-- The plugin manifest MUST NOT declare a strict `minimumHostVersion` or `minimumPaperclipVersion` gate while current latest/development Paperclip hosts may report `0.0.0` during plugin upgrade. Required host surfaces MUST remain represented by manifest capabilities and guarded by worker fallbacks where possible, and the docs MUST still state the intended Paperclip `2026.517.0` support baseline.
-- Disposable e2e and manual host verification MUST pin the Paperclip CLI to `2026.517.0` by default, while retaining an explicit environment override for forward and backward compatibility checks.
+- The plugin manifest MUST NOT declare a strict `minimumHostVersion` or `minimumPaperclipVersion` gate while current latest/development Paperclip hosts may report `0.0.0` during plugin upgrade. Required host surfaces MUST remain represented by manifest capabilities and guarded by worker fallbacks where possible, and the docs MUST still state the intended Paperclip `2026.529.0` support baseline.
+- Disposable e2e and manual host verification MUST pin the Paperclip CLI to `2026.529.0` by default, while retaining an explicit environment override for forward and backward compatibility checks.
 - The plugin MUST expose a dashboard widget contribution for sync readiness and setup.
 - The plugin MUST expose a separate dashboard KPI widget contribution.
 - The plugin MUST expose a settings page contribution.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "paperclip-github-plugin",
-  "version": "0.9.10",
+  "version": "0.9.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paperclip-github-plugin",
-      "version": "0.9.10",
+      "version": "0.9.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@octokit/rest": "^22.0.1",
-        "@paperclipai/plugin-sdk": "^2026.517.0",
+        "@paperclipai/plugin-sdk": "^2026.529.0",
         "react": "^19.2.6",
         "react-markdown": "^10.1.0",
         "rehype-raw": "^7.0.0",
@@ -628,12 +628,12 @@
       }
     },
     "node_modules/@paperclipai/plugin-sdk": {
-      "version": "2026.517.0",
-      "resolved": "https://registry.npmjs.org/@paperclipai/plugin-sdk/-/plugin-sdk-2026.517.0.tgz",
-      "integrity": "sha512-p8FlMUy5cds4fQjKoi9fD60XJWlnoLhBa+AsCPvVfilbulL9vpnAD0M8KBXJO+rEgmI/PZ9kHAiLuYVE1g0Now==",
+      "version": "2026.529.0",
+      "resolved": "https://registry.npmjs.org/@paperclipai/plugin-sdk/-/plugin-sdk-2026.529.0.tgz",
+      "integrity": "sha512-mYSs+gcIGPiF5RqtOjoMJp1NP0pxqS27ceRnkFeVhGgNFC/M5UIs+rpYdeUozGEZWfybwUlxnXbEX+yTWAMCLg==",
       "license": "MIT",
       "dependencies": {
-        "@paperclipai/shared": "2026.517.0",
+        "@paperclipai/shared": "2026.529.0",
         "zod": "^3.24.2"
       },
       "bin": {
@@ -649,9 +649,9 @@
       }
     },
     "node_modules/@paperclipai/shared": {
-      "version": "2026.517.0",
-      "resolved": "https://registry.npmjs.org/@paperclipai/shared/-/shared-2026.517.0.tgz",
-      "integrity": "sha512-wAaP+rkOmCVm5GZvjYAyUkm3MGa3J7BH3D8ftFt1802N7d4l8ARXNqvGq55wzTYYZRrIs4DRpZxxiSSD5PrSng==",
+      "version": "2026.529.0",
+      "resolved": "https://registry.npmjs.org/@paperclipai/shared/-/shared-2026.529.0.tgz",
+      "integrity": "sha512-KDHhBn88murStIQ6XZCnRj5exRQla3ycj5IihEIXd8cH0bNWqacD9a/Ofq5ONriaO1mzcMp3evrbDl/jLx5Zdg==",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.24.2"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@octokit/rest": "^22.0.1",
-    "@paperclipai/plugin-sdk": "^2026.517.0",
+    "@paperclipai/plugin-sdk": "^2026.529.0",
     "react": "^19.2.6",
     "react-markdown": "^10.1.0",
     "rehype-raw": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@paperclipai/plugin-sdk':
-        specifier: ^2026.517.0
-        version: 2026.517.0(react@19.2.6)
+        specifier: ^2026.529.0
+        version: 2026.529.0(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -259,8 +259,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@paperclipai/plugin-sdk@2026.517.0':
-    resolution: {integrity: sha512-p8FlMUy5cds4fQjKoi9fD60XJWlnoLhBa+AsCPvVfilbulL9vpnAD0M8KBXJO+rEgmI/PZ9kHAiLuYVE1g0Now==}
+  '@paperclipai/plugin-sdk@2026.529.0':
+    resolution: {integrity: sha512-mYSs+gcIGPiF5RqtOjoMJp1NP0pxqS27ceRnkFeVhGgNFC/M5UIs+rpYdeUozGEZWfybwUlxnXbEX+yTWAMCLg==}
     hasBin: true
     peerDependencies:
       react: '>=18'
@@ -268,8 +268,8 @@ packages:
       react:
         optional: true
 
-  '@paperclipai/shared@2026.517.0':
-    resolution: {integrity: sha512-wAaP+rkOmCVm5GZvjYAyUkm3MGa3J7BH3D8ftFt1802N7d4l8ARXNqvGq55wzTYYZRrIs4DRpZxxiSSD5PrSng==}
+  '@paperclipai/shared@2026.529.0':
+    resolution: {integrity: sha512-KDHhBn88murStIQ6XZCnRj5exRQla3ycj5IihEIXd8cH0bNWqacD9a/Ofq5ONriaO1mzcMp3evrbDl/jLx5Zdg==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
@@ -837,14 +837,14 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@paperclipai/plugin-sdk@2026.517.0(react@19.2.6)':
+  '@paperclipai/plugin-sdk@2026.529.0(react@19.2.6)':
     dependencies:
-      '@paperclipai/shared': 2026.517.0
+      '@paperclipai/shared': 2026.529.0
       zod: 3.25.76
     optionalDependencies:
       react: 19.2.6
 
-  '@paperclipai/shared@2026.517.0':
+  '@paperclipai/shared@2026.529.0':
     dependencies:
       zod: 3.25.76
 

--- a/scripts/e2e/manual-paperclip-verify.mjs
+++ b/scripts/e2e/manual-paperclip-verify.mjs
@@ -23,7 +23,7 @@ const seededAgentName = 'CEO';
 const seededAgentModel = 'gpt-5.4';
 const seededAgentHireDecisionNote = 'Approved automatically for GitHub Sync manual verification seeding.';
 const seededCompanyAttachmentMaxBytes = 10 * 1024 * 1024;
-const defaultPaperclipaiVersion = '2026.517.0';
+const defaultPaperclipaiVersion = '2026.529.0';
 const paperclipaiVersion = process.env.PAPERCLIP_E2E_PAPERCLIPAI_VERSION?.trim() || defaultPaperclipaiVersion;
 const paperclipaiPackageSpec = paperclipaiVersion.startsWith('paperclipai@')
   ? paperclipaiVersion

--- a/scripts/e2e/run-paperclip-smoke.mjs
+++ b/scripts/e2e/run-paperclip-smoke.mjs
@@ -23,7 +23,7 @@ const seededGitHubPullRequestUrl = 'https://github.com/paperclipai/example-repo/
 const manualGitHubIssueLinkTitle = 'Manual GitHub Issue Link Smoke';
 const manualGitHubPullRequestLinkTitle = 'Manual GitHub PR Link Smoke';
 const seededCompanyAttachmentMaxBytes = 10 * 1024 * 1024;
-const defaultPaperclipaiVersion = '2026.517.0';
+const defaultPaperclipaiVersion = '2026.529.0';
 const paperclipaiVersion = process.env.PAPERCLIP_E2E_PAPERCLIPAI_VERSION?.trim() || defaultPaperclipaiVersion;
 const paperclipaiPackageSpec = paperclipaiVersion.startsWith('paperclipai@')
   ? paperclipaiVersion

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -13,6 +13,7 @@ import {
   type IssueComment,
   type PluginApiRequestInput,
   type PluginApiResponse,
+  type PluginPerformActionContext,
   type ToolResult,
   type ToolRunContext
 } from '@paperclipai/plugin-sdk';
@@ -602,6 +603,17 @@ interface SyncCancellationRequest {
 
 function normalizeCompanyId(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function normalizeActionRecord(input: unknown, context?: PluginPerformActionContext | null): Record<string, unknown> {
+  const record = input && typeof input === 'object' ? { ...(input as Record<string, unknown>) } : {};
+  const scopedCompanyId = normalizeCompanyId(context?.companyId);
+
+  if (scopedCompanyId) {
+    record.companyId = scopedCompanyId;
+  }
+
+  return record;
 }
 
 let activeSyncPromise: Promise<GitHubSyncSettings> | null = null;
@@ -22103,8 +22115,8 @@ const plugin = definePlugin({
       return buildCommentAnnotationData(ctx, record);
     });
 
-    ctx.actions.register('issue.linkGitHubItem', async (input) => {
-      const record = input && typeof input === 'object' ? input as Record<string, unknown> : {};
+    ctx.actions.register('issue.linkGitHubItem', async (input, actionContext) => {
+      const record = normalizeActionRecord(input, actionContext);
       const kind = normalizeIssueGitHubLinkKind(record.kind);
       if (!kind) {
         throw new Error('kind must be "issue" or "pull_request".');
@@ -22136,8 +22148,8 @@ const plugin = definePlugin({
           });
     });
 
-    ctx.actions.register('issue.unlinkGitHubItem', async (input) => {
-      const record = input && typeof input === 'object' ? input as Record<string, unknown> : {};
+    ctx.actions.register('issue.unlinkGitHubItem', async (input, actionContext) => {
+      const record = normalizeActionRecord(input, actionContext);
       const companyId = normalizeCompanyId(record.companyId);
       const issueId = normalizeOptionalString(record.issueId);
       if (!companyId || !issueId) {
@@ -22150,10 +22162,10 @@ const plugin = definePlugin({
       });
     });
 
-    ctx.actions.register('settings.saveRegistration', async (input) => {
+    ctx.actions.register('settings.saveRegistration', async (input, actionContext) => {
       const previous = normalizeSettings(await ctx.state.get(SETTINGS_SCOPE));
       const config = await getResolvedConfig(ctx);
-      const record = input && typeof input === 'object' ? input as Record<string, unknown> : {};
+      const record = normalizeActionRecord(input, actionContext);
       const requestedCompanyId = normalizeCompanyId(record.companyId);
       const requestedGitHubTokenLogin =
         'githubTokenLogin' in record ? normalizeOptionalString(record.githubTokenLogin) : undefined;
@@ -22295,10 +22307,10 @@ const plugin = definePlugin({
       };
     });
 
-    ctx.actions.register('settings.updateBoardAccess', async (input) => {
+    ctx.actions.register('settings.updateBoardAccess', async (input, actionContext) => {
       const previous = normalizeSettings(await ctx.state.get(SETTINGS_SCOPE));
       const config = await getResolvedConfig(ctx);
-      const record = input && typeof input === 'object' ? input as Record<string, unknown> : {};
+      const record = normalizeActionRecord(input, actionContext);
       const companyId = normalizeCompanyId(record.companyId);
       if (!companyId) {
         throw new Error('A company id is required to update Paperclip board access.');
@@ -22383,8 +22395,9 @@ const plugin = definePlugin({
       };
     });
 
-    ctx.actions.register('settings.validateToken', async (input) => {
-      const token = input && typeof input === 'object' && 'token' in input ? (input as { token?: unknown }).token : undefined;
+    ctx.actions.register('settings.validateToken', async (input, actionContext) => {
+      const record = normalizeActionRecord(input, actionContext);
+      const token = 'token' in record ? record.token : undefined;
       const trimmedToken = typeof token === 'string' ? token.trim() : '';
 
       if (!trimmedToken) {
@@ -22394,8 +22407,8 @@ const plugin = definePlugin({
       return validateGithubToken(ctx, trimmedToken);
     });
 
-    ctx.actions.register('settings.ensureGitHubTokenAvailable', async (input) => {
-      const record = input && typeof input === 'object' ? input as Record<string, unknown> : {};
+    ctx.actions.register('settings.ensureGitHubTokenAvailable', async (input, actionContext) => {
+      const record = normalizeActionRecord(input, actionContext);
       const companyId = normalizeCompanyId(record.companyId);
       const githubTokenRef = normalizeSecretRef(record.githubTokenRef);
       const token = normalizeGitHubToken(record.token);
@@ -22439,71 +22452,72 @@ const plugin = definePlugin({
       };
     });
 
-    ctx.actions.register('project.pullRequests.createIssue', async (input) => {
-      const record = input && typeof input === 'object' ? input as Record<string, unknown> : {};
+    ctx.actions.register('project.pullRequests.createIssue', async (input, actionContext) => {
+      const record = normalizeActionRecord(input, actionContext);
       return createProjectPullRequestPaperclipIssue(ctx, record);
     });
 
-    ctx.actions.register('project.pullRequests.refresh', async (input) => {
-      const record = input && typeof input === 'object' ? input as Record<string, unknown> : {};
+    ctx.actions.register('project.pullRequests.refresh', async (input, actionContext) => {
+      const record = normalizeActionRecord(input, actionContext);
       return refreshProjectPullRequests(ctx, record);
     });
 
-    ctx.actions.register('project.pullRequests.updateBranch', async (input) => {
-      const record = input && typeof input === 'object' ? input as Record<string, unknown> : {};
+    ctx.actions.register('project.pullRequests.updateBranch', async (input, actionContext) => {
+      const record = normalizeActionRecord(input, actionContext);
       return updateProjectPullRequestBranch(ctx, record);
     });
 
-    ctx.actions.register('project.pullRequests.requestCopilotAction', async (input) => {
-      const record = input && typeof input === 'object' ? input as Record<string, unknown> : {};
+    ctx.actions.register('project.pullRequests.requestCopilotAction', async (input, actionContext) => {
+      const record = normalizeActionRecord(input, actionContext);
       return requestProjectPullRequestCopilotAction(ctx, record);
     });
 
-    ctx.actions.register('project.pullRequests.merge', async (input) => {
-      const record = input && typeof input === 'object' ? input as Record<string, unknown> : {};
+    ctx.actions.register('project.pullRequests.merge', async (input, actionContext) => {
+      const record = normalizeActionRecord(input, actionContext);
       return mergeProjectPullRequest(ctx, record);
     });
 
-    ctx.actions.register('project.pullRequests.close', async (input) => {
-      const record = input && typeof input === 'object' ? input as Record<string, unknown> : {};
+    ctx.actions.register('project.pullRequests.close', async (input, actionContext) => {
+      const record = normalizeActionRecord(input, actionContext);
       return closeProjectPullRequest(ctx, record);
     });
 
-    ctx.actions.register('project.pullRequests.addComment', async (input) => {
-      const record = input && typeof input === 'object' ? input as Record<string, unknown> : {};
+    ctx.actions.register('project.pullRequests.addComment', async (input, actionContext) => {
+      const record = normalizeActionRecord(input, actionContext);
       return addProjectPullRequestComment(ctx, record);
     });
 
-    ctx.actions.register('project.pullRequests.review', async (input) => {
-      const record = input && typeof input === 'object' ? input as Record<string, unknown> : {};
+    ctx.actions.register('project.pullRequests.review', async (input, actionContext) => {
+      const record = normalizeActionRecord(input, actionContext);
       return reviewProjectPullRequest(ctx, record);
     });
 
-    ctx.actions.register('project.pullRequests.rerunCi', async (input) => {
-      const record = input && typeof input === 'object' ? input as Record<string, unknown> : {};
+    ctx.actions.register('project.pullRequests.rerunCi', async (input, actionContext) => {
+      const record = normalizeActionRecord(input, actionContext);
       return rerunProjectPullRequestCi(ctx, record);
     });
 
-    ctx.actions.register('sync.runNow', async (input) => {
+    ctx.actions.register('sync.runNow', async (input, actionContext) => {
+      const record = normalizeActionRecord(input, actionContext);
       const waitForCompletion =
-        input && typeof input === 'object' && 'waitForCompletion' in input
-          ? Boolean((input as { waitForCompletion?: unknown }).waitForCompletion)
+        'waitForCompletion' in record
+          ? Boolean(record.waitForCompletion)
           : false;
       const paperclipApiBaseUrl =
-        input && typeof input === 'object' && 'paperclipApiBaseUrl' in input
-          ? (input as { paperclipApiBaseUrl?: unknown }).paperclipApiBaseUrl
+        'paperclipApiBaseUrl' in record
+          ? record.paperclipApiBaseUrl
           : undefined;
       const companyId =
-        input && typeof input === 'object' && 'companyId' in input && typeof (input as { companyId?: unknown }).companyId === 'string'
-          ? (input as { companyId?: string }).companyId
+        'companyId' in record && typeof record.companyId === 'string'
+          ? record.companyId
           : undefined;
       const projectId =
-        input && typeof input === 'object' && 'projectId' in input && typeof (input as { projectId?: unknown }).projectId === 'string'
-          ? (input as { projectId?: string }).projectId
+        'projectId' in record && typeof record.projectId === 'string'
+          ? record.projectId
           : undefined;
       const issueId =
-        input && typeof input === 'object' && 'issueId' in input && typeof (input as { issueId?: unknown }).issueId === 'string'
-          ? (input as { issueId?: string }).issueId
+        'issueId' in record && typeof record.issueId === 'string'
+          ? record.issueId
           : undefined;
       const currentSettings = normalizeSettings(await ctx.state.get(SETTINGS_SCOPE));
       const target = await resolveManualSyncTarget(ctx, currentSettings, {

--- a/tests/build-script.spec.mjs
+++ b/tests/build-script.spec.mjs
@@ -7,7 +7,7 @@ import test from 'node:test';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
-const RELEASE_UNDER_TEST = '2026.517.0';
+const RELEASE_UNDER_TEST = '2026.529.0';
 const PNPM_ACTION_SETUP_SHA_PATTERN = '[0-9a-f]{40}';
 
 test('build script reports missing local dependencies clearly when node_modules is absent', async () => {

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -12262,6 +12262,119 @@ test('worker scopes mapping saves and settings reads to the requested company', 
   });
 });
 
+test('worker uses the host-authorized company scope for settings save actions', async () => {
+  const harness = createTestHarness({ manifest });
+  await plugin.definition.setup(harness.ctx);
+
+  await harness.performAction('settings.saveRegistration', {
+    companyId: 'company-2',
+    mappings: [
+      {
+        id: 'mapping-b',
+        repositoryUrl: 'https://github.com/paperclipai/another-repo',
+        paperclipProjectName: 'Operations',
+        paperclipProjectId: 'project-2'
+      }
+    ],
+    syncState: {
+      status: 'idle'
+    }
+  });
+
+  const result = await harness.performAction('settings.saveRegistration', {
+    companyId: 'company-2',
+    mappings: [
+      {
+        id: 'mapping-a',
+        repositoryUrl: 'https://github.com/paperclipai/example-repo',
+        paperclipProjectName: 'Engineering',
+        paperclipProjectId: 'project-1',
+        companyId: 'company-2'
+      }
+    ],
+    advancedSettings: {
+      defaultAssigneeUserId: 'user-1',
+      defaultStatus: 'todo',
+      ignoredIssueAuthorUsernames: ['renovate', 'dependabot']
+    },
+    syncState: {
+      status: 'idle'
+    }
+  }, {
+    companyId: 'company-1'
+  }) as {
+    mappings: Array<{
+      id: string;
+      repositoryUrl: string;
+      paperclipProjectName: string;
+      paperclipProjectId?: string;
+      companyId?: string;
+    }>;
+    advancedSettings: {
+      defaultAssigneeUserId?: string;
+      defaultStatus: string;
+      ignoredIssueAuthorUsernames: string[];
+    };
+  };
+
+  assert.deepEqual(result.mappings, [
+    {
+      id: 'mapping-a',
+      repositoryUrl: 'https://github.com/paperclipai/example-repo',
+      paperclipProjectName: 'Engineering',
+      paperclipProjectId: 'project-1',
+      companyId: 'company-1'
+    }
+  ]);
+  assert.deepEqual(result.advancedSettings, {
+    defaultAssigneeUserId: 'user-1',
+    defaultStatus: 'todo',
+    ignoredIssueAuthorUsernames: ['renovate', 'dependabot']
+  });
+
+  const savedSettings = harness.getState({
+    scopeKind: 'instance',
+    stateKey: 'paperclip-github-plugin-settings'
+  }) as {
+    mappings: Array<{
+      id: string;
+      repositoryUrl: string;
+      paperclipProjectName: string;
+      paperclipProjectId?: string;
+      companyId?: string;
+    }>;
+    companyAdvancedSettingsByCompanyId: Record<string, {
+      defaultAssigneeUserId?: string;
+      defaultStatus: string;
+      ignoredIssueAuthorUsernames: string[];
+    }>;
+  };
+
+  assert.deepEqual(savedSettings.mappings, [
+    {
+      id: 'mapping-b',
+      repositoryUrl: 'https://github.com/paperclipai/another-repo',
+      paperclipProjectName: 'Operations',
+      paperclipProjectId: 'project-2',
+      companyId: 'company-2'
+    },
+    {
+      id: 'mapping-a',
+      repositoryUrl: 'https://github.com/paperclipai/example-repo',
+      paperclipProjectName: 'Engineering',
+      paperclipProjectId: 'project-1',
+      companyId: 'company-1'
+    }
+  ]);
+  assert.deepEqual(savedSettings.companyAdvancedSettingsByCompanyId, {
+    'company-1': {
+      defaultAssigneeUserId: 'user-1',
+      defaultStatus: 'todo',
+      ignoredIssueAuthorUsernames: ['renovate', 'dependabot']
+    }
+  });
+});
+
 test('worker scopes github token propagation agent selections to the requested company', async () => {
   const harness = createTestHarness({ manifest });
   await plugin.definition.setup(harness.ctx);


### PR DESCRIPTION
## Summary
- Bump the Paperclip plugin SDK and disposable verification baseline to 2026.529.0.
- Prefer the host-authorized action company scope when handling worker actions.
- Add regression coverage for settings saves under the new host-scoped action bridge.

## Validation
- pnpm typecheck
- pnpm test
- pnpm build
- node ./scripts/e2e/run-paperclip-smoke.mjs confirmed paperclipai@2026.529.0, then Paperclip exited before plugin install during embedded PostgreSQL bootstrap with initdb code 1.

## Model Used
GPT-5 Codex coding agent. Exact API model slug and context window size were not exposed by this Codex desktop runtime; reasoning and tool use were enabled.