### PR TITLE
chore: target Paperclip 2026.618

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ They can also link a Paperclip issue to a GitHub issue or pull request in any ac
 ## Requirements
 
 - Node.js 20+
-- a Paperclip host with plugin installation enabled. GitHub Sync is built and tested against Paperclip `2026.609.0`; the manifest relies on explicit capabilities instead of a strict host-version gate because current latest/development hosts can report `0.0.0` during plugin upgrade.
+- a Paperclip host with plugin installation enabled. GitHub Sync is built and tested against Paperclip `2026.618.0`; the manifest relies on explicit capabilities instead of a strict host-version gate because current latest/development hosts can report `0.0.0` during plugin upgrade.
 - a GitHub token with API access to the repositories you want to sync
 
 ## Install from npm
@@ -279,7 +279,7 @@ curl -X POST "${PAPERCLIP_API_URL%/}/api/plugins/paperclip-github-plugin/api/com
 
 The worker deduplicates repeated PR events by preferring the pull request URL, then `repository + pullRequestNumber`, before falling back to the explicit `eventKey`. When `paperclipIssueId` is present, the worker verifies the live pull request and persists the same PR-link metadata used by scheduled/manual status syncs.
 
-Paperclip `2026.609.0` accepts agent authentication for plugin tool discovery and execution, so agents should use the declared GitHub Sync tools for first-class workflow operations. The KPI attribution endpoint remains a native plugin JSON route for PRs created outside the plugin tool path.
+Paperclip `2026.618.0` accepts agent authentication for plugin tool discovery and execution, so agents should use the declared GitHub Sync tools for first-class workflow operations. The KPI attribution endpoint remains a native plugin JSON route for PRs created outside the plugin tool path.
 
 ### Pull request asset upload
 
@@ -328,7 +328,7 @@ Example tool payload:
 - If an older GitHub Sync build fails upgrade with `requires host version 2026.427.0 or newer, but this server is running 0.0.0`, upgrade to a build that removes the strict manifest host-version gate. The host is reporting a development-version sentinel, so the plugin now relies on declared capabilities and runtime fallbacks instead.
 - If setup is reported as incomplete, confirm that a GitHub token has been saved or that `${PAPERCLIP_HOME:-~/.paperclip}/plugins/github-sync/config.json` contains `githubToken`, and make sure at least one mapping has a created Paperclip project or at least one Paperclip issue has been linked to GitHub.
 - If Paperclip says board access is required, open plugin settings inside the affected company and complete the Paperclip board access flow before retrying sync.
-- If GitHub Sync agent tools fail on `/api/plugins/tools` or `/api/plugins/tools/execute`, confirm the Paperclip host is `2026.609.0` or newer and that the tool request includes the agent run context required by Paperclip.
+- If GitHub Sync agent tools fail on `/api/plugins/tools` or `/api/plugins/tools/execute`, confirm the Paperclip host is `2026.618.0` or newer and that the tool request includes the agent run context required by Paperclip.
 - If a KPI API route call is rejected, make sure the request includes `Authorization: Bearer ${PAPERCLIP_API_KEY}`, that the token is still valid for the current run, and that any `companyId` in the payload matches the calling agent's company.
 - If the worker reaches an authenticated HTML page instead of the Paperclip API JSON responses it expects, connect Paperclip board access for that company or set **Worker Paperclip API URL** in GitHub Sync settings to a worker-accessible Paperclip API origin.
 - If a Paperclip API fetch fails before any HTTP response is returned, the saved diagnostics include the method, URL, primary error, nested cause, and cause code when Node exposes them.
@@ -354,8 +354,10 @@ Useful scripts:
 
 - `pnpm dev` watches the manifest, worker, and UI bundles and rebuilds them into `dist/`
 - `pnpm dev:ui` starts a local Paperclip plugin UI dev server from `dist/ui` on port `4177`
-- `pnpm test:e2e` builds the plugin, boots an isolated Paperclip `2026.609.0` instance, installs the plugin, and verifies the hosted settings page renders
-- `pnpm verify:manual` builds the plugin, boots a local-trusted Paperclip `2026.609.0` instance for manual inspection, seeds a `Dummy Company` with a mapped review project and a `CEO` agent on the Codex local adapter using model `gpt-5.4`, installs the plugin, and opens the company dashboard without seeding KPI history.
+- `pnpm test:e2e` builds the plugin, boots an isolated Paperclip `2026.618.0` instance, installs the plugin, and verifies the hosted settings page renders
+- `pnpm verify:manual` builds the plugin, boots a local-trusted Paperclip `2026.618.0` instance for manual inspection, seeds a `Dummy Company` with a mapped review project and a `CEO` agent on the Codex local adapter using model `gpt-5.4`, installs the plugin, and opens the company dashboard without seeding KPI history.
+
+The disposable Paperclip harnesses run `paperclipai@2026.618.0` under `node@24`, matching the release's Docker baseline and avoiding Node 20's missing `node:sqlite` runtime module.
 
 For fast hosted UI iteration, run `pnpm dev` in one terminal and `pnpm dev:ui` in another.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -148,8 +148,8 @@ The plugin MUST persist repository mappings, company-scoped advanced issue defau
 ## Host integration requirements
 
 - The plugin MUST register successfully in Paperclip.
-- The plugin manifest MUST NOT declare a strict `minimumHostVersion` or `minimumPaperclipVersion` gate while current latest/development Paperclip hosts may report `0.0.0` during plugin upgrade. Required host surfaces MUST remain represented by manifest capabilities and guarded by worker fallbacks where possible, and the docs MUST still state the intended Paperclip `2026.609.0` support baseline.
-- Disposable e2e and manual host verification MUST pin the Paperclip CLI to `2026.609.0` by default, while retaining an explicit environment override for forward and backward compatibility checks.
+- The plugin manifest MUST NOT declare a strict `minimumHostVersion` or `minimumPaperclipVersion` gate while current latest/development Paperclip hosts may report `0.0.0` during plugin upgrade. Required host surfaces MUST remain represented by manifest capabilities and guarded by worker fallbacks where possible, and the docs MUST still state the intended Paperclip `2026.618.0` support baseline.
+- Disposable e2e and manual host verification MUST pin the Paperclip CLI to `2026.618.0` by default, while retaining an explicit environment override for forward and backward compatibility checks.
 - The plugin MUST expose a dashboard widget contribution for sync readiness and setup.
 - The plugin MUST expose a separate dashboard KPI widget contribution.
 - The plugin MUST expose a settings page contribution.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@octokit/rest": "^22.0.1",
-        "@paperclipai/plugin-sdk": "^2026.609.0",
+        "@paperclipai/plugin-sdk": "^2026.618.0",
         "react": "^19.2.7",
         "react-markdown": "^10.1.0",
         "rehype-raw": "^7.0.0",
@@ -627,12 +627,12 @@
       }
     },
     "node_modules/@paperclipai/plugin-sdk": {
-      "version": "2026.609.0",
-      "resolved": "https://registry.npmjs.org/@paperclipai/plugin-sdk/-/plugin-sdk-2026.609.0.tgz",
-      "integrity": "sha512-/Bn9lN4JWPKevhuwK0w54IHMqOKc+4z6ZEAwoE7HR+u2V1lPbSdlNZat3LCP+m0BTOweLO7s/dwhEay8nw+rNQ==",
+      "version": "2026.618.0",
+      "resolved": "https://registry.npmjs.org/@paperclipai/plugin-sdk/-/plugin-sdk-2026.618.0.tgz",
+      "integrity": "sha512-/8hoPh4x70/1HoaAe8Hofej1Ww5RLpMfbQb8fiXpRcLY9MkEN7XjzR0jVqTw4y2bwed+xQRhPJ5QRcviM/lPkA==",
       "license": "MIT",
       "dependencies": {
-        "@paperclipai/shared": "2026.609.0",
+        "@paperclipai/shared": "2026.618.0",
         "zod": "^3.24.2"
       },
       "bin": {
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/@paperclipai/shared": {
-      "version": "2026.609.0",
-      "resolved": "https://registry.npmjs.org/@paperclipai/shared/-/shared-2026.609.0.tgz",
-      "integrity": "sha512-+jiu1EGcqMNIleX7w62B8K0yc0VxumCIyGCfCbtIVup9F3AbB1eQ8AIi/hySffFF+0SvgmkzcZsJCYvV1REzDw==",
+      "version": "2026.618.0",
+      "resolved": "https://registry.npmjs.org/@paperclipai/shared/-/shared-2026.618.0.tgz",
+      "integrity": "sha512-DqfQLUiWHhYRXFtMpPCeXpB+21obNYFnqcr4bEPdRrA83l5YS/SolsqfnHu8Mj65iiSrHGhQGGc7q4kvQkV2qw==",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.24.2"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@octokit/rest": "^22.0.1",
-    "@paperclipai/plugin-sdk": "^2026.609.0",
+    "@paperclipai/plugin-sdk": "^2026.618.0",
     "react": "^19.2.7",
     "react-markdown": "^10.1.0",
     "rehype-raw": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@paperclipai/plugin-sdk':
-        specifier: ^2026.609.0
-        version: 2026.609.0(react@19.2.7)
+        specifier: ^2026.618.0
+        version: 2026.618.0(react@19.2.7)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -415,8 +415,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@paperclipai/plugin-sdk@2026.609.0':
-    resolution: {integrity: sha512-/Bn9lN4JWPKevhuwK0w54IHMqOKc+4z6ZEAwoE7HR+u2V1lPbSdlNZat3LCP+m0BTOweLO7s/dwhEay8nw+rNQ==}
+  '@paperclipai/plugin-sdk@2026.618.0':
+    resolution: {integrity: sha512-/8hoPh4x70/1HoaAe8Hofej1Ww5RLpMfbQb8fiXpRcLY9MkEN7XjzR0jVqTw4y2bwed+xQRhPJ5QRcviM/lPkA==}
     hasBin: true
     peerDependencies:
       react: '>=18'
@@ -424,8 +424,8 @@ packages:
       react:
         optional: true
 
-  '@paperclipai/shared@2026.609.0':
-    resolution: {integrity: sha512-+jiu1EGcqMNIleX7w62B8K0yc0VxumCIyGCfCbtIVup9F3AbB1eQ8AIi/hySffFF+0SvgmkzcZsJCYvV1REzDw==}
+  '@paperclipai/shared@2026.618.0':
+    resolution: {integrity: sha512-DqfQLUiWHhYRXFtMpPCeXpB+21obNYFnqcr4bEPdRrA83l5YS/SolsqfnHu8Mj65iiSrHGhQGGc7q4kvQkV2qw==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
@@ -1072,14 +1072,14 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@paperclipai/plugin-sdk@2026.609.0(react@19.2.7)':
+  '@paperclipai/plugin-sdk@2026.618.0(react@19.2.7)':
     dependencies:
-      '@paperclipai/shared': 2026.609.0
+      '@paperclipai/shared': 2026.618.0
       zod: 3.25.76
     optionalDependencies:
       react: 19.2.7
 
-  '@paperclipai/shared@2026.609.0':
+  '@paperclipai/shared@2026.618.0':
     dependencies:
       zod: 3.25.76
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
 allowBuilds:
   esbuild: true
+minimumReleaseAgeExclude:
+  - '@paperclipai/plugin-sdk@2026.618.0'
+  - '@paperclipai/shared@2026.618.0'

--- a/scripts/e2e/manual-paperclip-verify.mjs
+++ b/scripts/e2e/manual-paperclip-verify.mjs
@@ -23,7 +23,7 @@ const seededAgentName = 'CEO';
 const seededAgentModel = 'gpt-5.4';
 const seededAgentHireDecisionNote = 'Approved automatically for GitHub Sync manual verification seeding.';
 const seededCompanyAttachmentMaxBytes = 10 * 1024 * 1024;
-const defaultPaperclipaiVersion = '2026.609.0';
+const defaultPaperclipaiVersion = '2026.618.0';
 const paperclipaiVersion = process.env.PAPERCLIP_E2E_PAPERCLIPAI_VERSION?.trim() || defaultPaperclipaiVersion;
 const paperclipaiPackageSpec = paperclipaiVersion.startsWith('paperclipai@')
   ? paperclipaiVersion
@@ -71,7 +71,7 @@ function log(message) {
 }
 
 function getPaperclipCommandArgs(args) {
-  return ['-p', 'node@20', '-p', paperclipaiPackageSpec, 'paperclipai', ...args];
+  return ['-p', 'node@24', '-p', paperclipaiPackageSpec, 'paperclipai', ...args];
 }
 
 function runCommand(command, args, options = {}) {

--- a/scripts/e2e/run-paperclip-smoke.mjs
+++ b/scripts/e2e/run-paperclip-smoke.mjs
@@ -23,7 +23,7 @@ const seededGitHubPullRequestUrl = 'https://github.com/paperclipai/example-repo/
 const manualGitHubIssueLinkTitle = 'Manual GitHub Issue Link Smoke';
 const manualGitHubPullRequestLinkTitle = 'Manual GitHub PR Link Smoke';
 const seededCompanyAttachmentMaxBytes = 10 * 1024 * 1024;
-const defaultPaperclipaiVersion = '2026.609.0';
+const defaultPaperclipaiVersion = '2026.618.0';
 const paperclipaiVersion = process.env.PAPERCLIP_E2E_PAPERCLIPAI_VERSION?.trim() || defaultPaperclipaiVersion;
 const paperclipaiPackageSpec = paperclipaiVersion.startsWith('paperclipai@')
   ? paperclipaiVersion
@@ -59,7 +59,7 @@ function log(message) {
 }
 
 function getPaperclipCommandArgs(args) {
-  return ['-p', 'node@20', '-p', paperclipaiPackageSpec, 'paperclipai', ...args];
+  return ['-p', 'node@24', '-p', paperclipaiPackageSpec, 'paperclipai', ...args];
 }
 
 function runCommand(command, args, options = {}) {

--- a/tests/build-script.spec.mjs
+++ b/tests/build-script.spec.mjs
@@ -7,7 +7,7 @@ import test from 'node:test';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
-const RELEASE_UNDER_TEST = '2026.609.0';
+const RELEASE_UNDER_TEST = '2026.618.0';
 const PNPM_ACTION_SETUP_SHA_PATTERN = '[0-9a-f]{40}';
 
 test('build script reports missing local dependencies clearly when node_modules is absent', async () => {
@@ -47,6 +47,8 @@ test('release verification harnesses default to the current Paperclip release', 
 
   assert.match(smokeScript, new RegExp(`const defaultPaperclipaiVersion = '${RELEASE_UNDER_TEST.replaceAll('.', '\\.')}'`));
   assert.match(manualScript, new RegExp(`const defaultPaperclipaiVersion = '${RELEASE_UNDER_TEST.replaceAll('.', '\\.')}'`));
+  assert.match(smokeScript, /node@24/);
+  assert.match(manualScript, /node@24/);
 });
 
 test('plugin SDK dependency targets the current Paperclip release', async () => {
@@ -66,5 +68,6 @@ test('GitHub workflows let packageManager select the pnpm version', async () => 
   assert.match(releaseWorkflow, new RegExp(`pnpm/action-setup@${PNPM_ACTION_SETUP_SHA_PATTERN} # v6`));
   assert.doesNotMatch(ciWorkflow, /pnpm\/action-setup@[\s\S]*?with:[\s\S]*?\n\s*version:\s/);
   assert.doesNotMatch(releaseWorkflow, /pnpm\/action-setup@[\s\S]*?with:[\s\S]*?\n\s*version:\s/);
-  assert.match(pnpmWorkspace, /^allowBuilds:\n  esbuild: true\n?$/);
+  assert.match(pnpmWorkspace, /^allowBuilds:\n  esbuild: true\n/);
+  assert.match(pnpmWorkspace, /minimumReleaseAgeExclude:\n  - '@paperclipai\/plugin-sdk@2026\.618\.0'\n  - '@paperclipai\/shared@2026\.618\.0'\n?$/);
 });


### PR DESCRIPTION
## Summary
- target Paperclip/plugin-sdk 2026.618.0 in package manifests and lockfiles
- run disposable Paperclip verification under node@24 to match the 2026.618 Docker/runtime baseline and avoid Node 20's missing node:sqlite module
- refresh README/SPEC support baseline and add regression checks for the release target and Node runtime

## Verification
- pnpm typecheck
- pnpm test
- pnpm build
- PAPERCLIP_E2E_PORT=3410 PAPERCLIP_E2E_DB_PORT=55410 pnpm test:e2e
