### PR TITLE
Retry sync cleanup after interruption and local drift

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -13290,11 +13290,14 @@ async function updatePaperclipIssueState(
     throw new Error('This Paperclip runtime does not expose issue comment creation, so GitHub Sync refused to update a Paperclip issue status without an explanatory comment.');
   }
 
-  const issuePatchAlreadyApplied = isPaperclipIssuePatchApplied({
-    currentStatus,
-    syncContext,
-    issuePatch
-  });
+  const liveIssue = await ctx.issues.get(issueId, companyId);
+  const issuePatchAlreadyApplied = liveIssue
+    ? isPaperclipIssuePatchApplied({
+        currentStatus: liveIssue.status,
+        syncContext: getPaperclipIssueSyncContext(liveIssue),
+        issuePatch
+      })
+    : isPaperclipIssuePatchApplied({ currentStatus, syncContext, issuePatch });
   const reasonCode = classifyIssueInteractionReason(transitionCommentAnnotation?.reason ?? trimmedTransitionComment);
   const interactionDedupeBase = actionFingerprint
     ? `sync:${createHash('sha256').update(JSON.stringify({
@@ -13308,6 +13311,15 @@ async function updatePaperclipIssueState(
         issuePatch
       })).digest('hex')}`
     : `sync:${issueId}:${interactionOccurredAt}:${currentStatus}:${nextStatus}`;
+  const mutationFamilyBase = actionFingerprint
+    ? `sync:${createHash('sha256').update(JSON.stringify({
+        companyId,
+        issueId,
+        mutation: 'status_transition',
+        actionFingerprint,
+        nextStatus
+      })).digest('hex')}`
+    : interactionDedupeBase;
   let existingInteractionEvents: IssueInteractionEvent[] = [];
   if (actionFingerprint) {
     const ledger = await listIssueInteractionEvents(ctx, companyId, issueId, {
@@ -13325,6 +13337,17 @@ async function updatePaperclipIssueState(
     const existingIntent = existingInteractionEvents.find((event) => event.dedupeKey === `${interactionDedupeBase}:intent`);
     if (existingIntent) interactionOccurredAt = existingIntent.occurredAt;
   }
+  const completedMutationInFamily = existingInteractionEvents.some((event) =>
+    event.dedupeKey.startsWith(`${mutationFamilyBase}:`)
+    && event.dedupeKey.endsWith(':mutation:result:changed')
+  );
+  const mutationDedupeBase = !issuePatchAlreadyApplied && completedMutationInFamily
+    ? `${mutationFamilyBase}:drift:${createHash('sha256').update(JSON.stringify({
+        currentStatus: liveIssue?.status ?? currentStatus,
+        currentIssueState: liveIssue ? getPaperclipIssueSyncContext(liveIssue) : syncContext,
+        issuePatch
+      })).digest('hex')}`
+    : mutationFamilyBase;
   await persistIssueInteractionEvent(ctx, {
     schemaVersion: 1,
     companyId,
@@ -13366,7 +13389,10 @@ async function updatePaperclipIssueState(
     outcome,
     dedupeKey: `${interactionDedupeBase}:result:${outcome}`
   });
-  const persistMutationPhase = (outcome: 'observed' | 'changed' | 'failed') => persistIssueInteractionEvent(ctx, {
+  const persistMutationPhase = (
+    outcome: 'observed' | 'changed' | 'failed',
+    dedupeBase = mutationDedupeBase
+  ) => persistIssueInteractionEvent(ctx, {
     schemaVersion: 1,
     companyId,
     paperclipIssueId: issueId,
@@ -13383,14 +13409,28 @@ async function updatePaperclipIssueState(
       }
     } : {}),
     outcome,
-    dedupeKey: `${interactionDedupeBase}:mutation:${outcome === 'observed' ? 'intent' : `result:${outcome}`}`
+    dedupeKey: `${dedupeBase}:mutation:${outcome === 'observed' ? 'intent' : `result:${outcome}`}`
   });
-  const priorMutationIntent = existingInteractionEvents.find((event) => event.dedupeKey === `${interactionDedupeBase}:mutation:intent`);
-  const priorMutationChanged = existingInteractionEvents.find((event) => event.dedupeKey === `${interactionDedupeBase}:mutation:result:changed`);
-  const priorMutationFailed = existingInteractionEvents.find((event) => event.dedupeKey === `${interactionDedupeBase}:mutation:result:failed`);
+  const priorMutationIntent = existingInteractionEvents.find((event) => event.dedupeKey === `${mutationDedupeBase}:mutation:intent`);
+  const priorMutationChanged = existingInteractionEvents.find((event) => event.dedupeKey === `${mutationDedupeBase}:mutation:result:changed`);
+  const priorMutationFailed = existingInteractionEvents.find((event) => event.dedupeKey === `${mutationDedupeBase}:mutation:result:failed`);
   let mutationAttemptStarted = false;
   let mutationReturned = false;
-  let mutationComplete = issuePatchAlreadyApplied || Boolean(priorMutationChanged);
+  let mutationComplete = issuePatchAlreadyApplied;
+  if (issuePatchAlreadyApplied) {
+    const intentSuffix = ':mutation:intent';
+    for (const intent of existingInteractionEvents.filter((event) =>
+      event.dedupeKey.startsWith(`${mutationFamilyBase}:`)
+      && event.dedupeKey.endsWith(intentSuffix)
+    )) {
+      const dedupeBase = intent.dedupeKey.slice(0, -intentSuffix.length);
+      const hasResult = existingInteractionEvents.some((event) =>
+        event.dedupeKey === `${dedupeBase}:mutation:result:changed`
+        || event.dedupeKey === `${dedupeBase}:mutation:result:failed`
+      );
+      if (!hasResult) await persistMutationPhase('changed', dedupeBase);
+    }
+  }
 
   try {
   if (statusWillChange) {
@@ -13456,7 +13496,7 @@ async function updatePaperclipIssueState(
   }
 
   if (!mutationComplete) {
-    if (priorMutationIntent && !priorMutationFailed) {
+    if (priorMutationIntent && !priorMutationChanged && !priorMutationFailed) {
       throw new Error('GitHub Sync refused to repeat an uncertain issue mutation; reconcile the durable mutation intent before retrying.');
     }
     await persistMutationPhase('observed');
@@ -14705,25 +14745,23 @@ async function synchronizePaperclipIssueStatuses(
       };
 
       if (paperclipIssue.status === nextStatus) {
-        if (shouldClearTransitionAssignee || shouldClearCompletedExecutionPolicy) {
-          updateSyncFailureContext(syncFailureContext, {
-            phase: 'updating_paperclip_status',
-            repositoryUrl: repository.url,
-            githubIssueNumber: githubIssue.number
-          });
-          await updatePaperclipIssueState(ctx, {
-            companyId: mapping.companyId,
-            issueId: importedIssue.paperclipIssueId,
-            currentStatus: paperclipIssue.status,
-            syncContext: paperclipIssueSyncContext,
-            nextStatus,
-            ...(shouldClearTransitionAssignee ? { clearAssignee: true } : {}),
-            ...(shouldPreserveMaintainerWaitRouting || shouldClearCompletedExecutionPolicy ? { clearExecutionPolicy: true } : {}),
-            transitionComment: '',
-            actionFingerprint: actionJournalFingerprint,
-            paperclipApiBaseUrl
-          });
-        }
+        updateSyncFailureContext(syncFailureContext, {
+          phase: 'updating_paperclip_status',
+          repositoryUrl: repository.url,
+          githubIssueNumber: githubIssue.number
+        });
+        await updatePaperclipIssueState(ctx, {
+          companyId: mapping.companyId,
+          issueId: importedIssue.paperclipIssueId,
+          currentStatus: paperclipIssue.status,
+          syncContext: paperclipIssueSyncContext,
+          nextStatus,
+          ...(shouldClearTransitionAssignee ? { clearAssignee: true } : {}),
+          ...(shouldPreserveMaintainerWaitRouting || shouldClearCompletedExecutionPolicy ? { clearExecutionPolicy: true } : {}),
+          transitionComment: '',
+          actionFingerprint: actionJournalFingerprint,
+          paperclipApiBaseUrl
+        });
 
         if (shouldWakeImportedAssignee && paperclipIssueSyncContext.assignee?.kind === 'agent') {
           const pendingWake: PendingRemoteActionWake = {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -11748,6 +11748,23 @@ async function unlinkPaperclipIssueFromGitHub(
     !(entry.paperclipIssueId === issueId && (!entry.companyId || entry.companyId === companyId))
   );
   const unlinkedAt = new Date().toISOString();
+  const shouldClearGitHubOrigin =
+    issue.originKind === GITHUB_ISSUE_ORIGIN_KIND || issue.originKind === GITHUB_PULL_REQUEST_ORIGIN_KIND;
+  const nextDescription = removeGitHubIssueLinkMetadataFromDescription(issue.description);
+  const issuePatch: Partial<Pick<Issue, 'description' | 'originKind' | 'originId' | 'originRunId'>> = {};
+  if (shouldClearGitHubOrigin) {
+    issuePatch.originKind = GITHUB_SYNC_BASE_ORIGIN_KIND;
+    issuePatch.originId = null;
+    issuePatch.originRunId = null;
+  }
+
+  if (nextDescription !== undefined) {
+    issuePatch.description = nextDescription;
+  }
+
+  if (Object.keys(issuePatch).length > 0) {
+    await ctx.issues.update(issueId, issuePatch, companyId);
+  }
 
   for (const record of issueLinkRecords) {
     await tombstoneGitHubIssueLinkRecord(ctx, record, unlinkedAt);
@@ -11777,24 +11794,6 @@ async function unlinkPaperclipIssueFromGitHub(
 
   if (removedImportRegistryEntries.length > 0) {
     await ctx.state.set(IMPORT_REGISTRY_SCOPE, nextImportRegistry);
-  }
-
-  const shouldClearGitHubOrigin =
-    issue.originKind === GITHUB_ISSUE_ORIGIN_KIND || issue.originKind === GITHUB_PULL_REQUEST_ORIGIN_KIND;
-  const nextDescription = removeGitHubIssueLinkMetadataFromDescription(issue.description);
-  const issuePatch: Partial<Pick<Issue, 'description' | 'originKind' | 'originId' | 'originRunId'>> = {};
-  if (shouldClearGitHubOrigin) {
-    issuePatch.originKind = GITHUB_SYNC_BASE_ORIGIN_KIND;
-    issuePatch.originId = null;
-    issuePatch.originRunId = null;
-  }
-
-  if (nextDescription !== undefined) {
-    issuePatch.description = nextDescription;
-  }
-
-  if (Object.keys(issuePatch).length > 0) {
-    await ctx.issues.update(issueId, issuePatch, companyId);
   }
 
   await forgetExternalGitHubLinkCompanyIfEmpty(ctx, companyId);
@@ -13191,6 +13190,37 @@ function classifyIssueInteractionReason(value: string): string {
   return 'github_sync_status_decision';
 }
 
+function isPaperclipIssuePatchApplied(params: {
+  currentStatus: PaperclipIssueStatus;
+  syncContext: PaperclipIssueSyncContext;
+  issuePatch: Record<string, unknown>;
+}): boolean {
+  const { currentStatus, syncContext, issuePatch } = params;
+  if (issuePatch.status !== currentStatus) return false;
+
+  const hasAgentAssignee = Object.prototype.hasOwnProperty.call(issuePatch, 'assigneeAgentId');
+  const hasUserAssignee = Object.prototype.hasOwnProperty.call(issuePatch, 'assigneeUserId');
+  if (hasAgentAssignee || hasUserAssignee) {
+    const expectedAssignee = typeof issuePatch.assigneeAgentId === 'string'
+      ? { kind: 'agent', id: issuePatch.assigneeAgentId }
+      : typeof issuePatch.assigneeUserId === 'string'
+        ? { kind: 'user', id: issuePatch.assigneeUserId }
+        : null;
+    if (JSON.stringify(syncContext.assignee) !== JSON.stringify(expectedAssignee)) return false;
+  }
+
+  if (
+    Object.prototype.hasOwnProperty.call(issuePatch, 'executionPolicy')
+    && JSON.stringify(syncContext.executionPolicy) !== JSON.stringify(issuePatch.executionPolicy)
+  ) return false;
+  if (
+    Object.prototype.hasOwnProperty.call(issuePatch, 'executionState')
+    && JSON.stringify(syncContext.executionState) !== JSON.stringify(issuePatch.executionState)
+  ) return false;
+
+  return true;
+}
+
 async function updatePaperclipIssueState(
   ctx: PluginSetupContext,
   params: {
@@ -13260,6 +13290,11 @@ async function updatePaperclipIssueState(
     throw new Error('This Paperclip runtime does not expose issue comment creation, so GitHub Sync refused to update a Paperclip issue status without an explanatory comment.');
   }
 
+  const issuePatchAlreadyApplied = isPaperclipIssuePatchApplied({
+    currentStatus,
+    syncContext,
+    issuePatch
+  });
   const reasonCode = classifyIssueInteractionReason(transitionCommentAnnotation?.reason ?? trimmedTransitionComment);
   const interactionDedupeBase = actionFingerprint
     ? `sync:${createHash('sha256').update(JSON.stringify({
@@ -13268,7 +13303,9 @@ async function updatePaperclipIssueState(
         mutation: 'status_transition',
         actionFingerprint,
         currentStatus,
-        nextStatus
+        nextStatus,
+        currentIssueState: syncContext,
+        issuePatch
       })).digest('hex')}`
     : `sync:${issueId}:${interactionOccurredAt}:${currentStatus}:${nextStatus}`;
   let existingInteractionEvents: IssueInteractionEvent[] = [];
@@ -13353,7 +13390,7 @@ async function updatePaperclipIssueState(
   const priorMutationFailed = existingInteractionEvents.find((event) => event.dedupeKey === `${interactionDedupeBase}:mutation:result:failed`);
   let mutationAttemptStarted = false;
   let mutationReturned = false;
-  let mutationComplete = Boolean(priorMutationChanged);
+  let mutationComplete = issuePatchAlreadyApplied || Boolean(priorMutationChanged);
 
   try {
   if (statusWillChange) {
@@ -14148,11 +14185,6 @@ async function cancelUnmappedTransferredGitHubIssue(
   }
 
   const paperclipIssueSyncContext = getPaperclipIssueSyncContext(paperclipIssue);
-  await unlinkPaperclipIssueFromGitHub(ctx, {
-    companyId,
-    issueId: params.importedIssue.paperclipIssueId
-  });
-
   const nextStatus: PaperclipIssueStatus = 'cancelled';
   await updatePaperclipIssueState(ctx, {
     companyId,
@@ -14160,13 +14192,20 @@ async function cancelUnmappedTransferredGitHubIssue(
     currentStatus: paperclipIssue.status,
     syncContext: paperclipIssueSyncContext,
     nextStatus,
-    transitionComment: buildUnmappedTransferredIssueCancellationComment({
-      previousStatus: paperclipIssue.status,
-      nextStatus,
-      transferredRepository: params.transferredRepository
-    }),
+    transitionComment: paperclipIssue.status === nextStatus
+      ? ''
+      : buildUnmappedTransferredIssueCancellationComment({
+          previousStatus: paperclipIssue.status,
+          nextStatus,
+          transferredRepository: params.transferredRepository
+        }),
     actionFingerprint: `transferred-unmapped:${params.transferredRepository.url}`,
     paperclipApiBaseUrl: params.paperclipApiBaseUrl
+  });
+
+  await unlinkPaperclipIssueFromGitHub(ctx, {
+    companyId,
+    issueId: params.importedIssue.paperclipIssueId
   });
 
   return {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -7804,6 +7804,12 @@ function normalizePaperclipIssueAssigneePrincipal(value: unknown): PaperclipIssu
   }
 
   const record = value as Record<string, unknown>;
+  const normalizedKind = normalizeOptionalString(record.kind);
+  const normalizedId = normalizeOptionalString(record.id);
+  if ((normalizedKind === 'agent' || normalizedKind === 'user') && normalizedId) {
+    return { kind: normalizedKind, id: normalizedId };
+  }
+
   const principalType = normalizeOptionalString(record.type);
   const agentId = normalizeOptionalString(record.agentId);
   const userId = normalizeOptionalString(record.userId);
@@ -23001,6 +23007,7 @@ export const __testing = {
   hasUnresolvedPaperclipIssueBlocker,
   isHealthyMaintainerWaitTransition,
   isPaperclipIssuePatchApplied,
+  normalizePaperclipIssueAssigneePrincipal,
   normalizeImportRegistry,
   normalizeRemoteActionRegistry,
   persistIssueInteractionEvent,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -13200,11 +13200,15 @@ function isPaperclipIssuePatchApplied(params: {
 
   if (
     Object.prototype.hasOwnProperty.call(issuePatch, 'executionPolicy')
-    && JSON.stringify(syncContext.executionPolicy) !== JSON.stringify(issuePatch.executionPolicy)
+    && JSON.stringify(syncContext.executionPolicy) !== JSON.stringify(
+      normalizePaperclipIssueExecutionPolicy(issuePatch.executionPolicy)
+    )
   ) return false;
   if (
     Object.prototype.hasOwnProperty.call(issuePatch, 'executionState')
-    && JSON.stringify(syncContext.executionState) !== JSON.stringify(issuePatch.executionState)
+    && JSON.stringify(syncContext.executionState) !== JSON.stringify(
+      normalizePaperclipIssueExecutionState(issuePatch.executionState)
+    )
   ) return false;
 
   return true;
@@ -22996,6 +23000,7 @@ export const __testing = {
   formatPaperclipApiFetchErrorMessage,
   hasUnresolvedPaperclipIssueBlocker,
   isHealthyMaintainerWaitTransition,
+  isPaperclipIssuePatchApplied,
   normalizeImportRegistry,
   normalizeRemoteActionRegistry,
   persistIssueInteractionEvent,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -13290,13 +13290,13 @@ async function updatePaperclipIssueState(
   }
 
   const liveIssue = await ctx.issues.get(issueId, companyId);
-  const issuePatchAlreadyApplied = liveIssue
-    ? isPaperclipIssuePatchApplied({
-        currentStatus: liveIssue.status,
-        syncContext: getPaperclipIssueSyncContext(liveIssue),
-        issuePatch
-      })
-    : isPaperclipIssuePatchApplied({ currentStatus, syncContext, issuePatch });
+  const liveCurrentStatus = liveIssue?.status ?? currentStatus;
+  const liveSyncContext = liveIssue ? getPaperclipIssueSyncContext(liveIssue) : syncContext;
+  const issuePatchAlreadyApplied = isPaperclipIssuePatchApplied({
+    currentStatus: liveCurrentStatus,
+    syncContext: liveSyncContext,
+    issuePatch
+  });
   const reasonCode = classifyIssueInteractionReason(transitionCommentAnnotation?.reason ?? trimmedTransitionComment);
   const interactionDedupeBase = actionFingerprint
     ? `sync:${createHash('sha256').update(JSON.stringify({
@@ -13319,7 +13319,41 @@ async function updatePaperclipIssueState(
         nextStatus
       })).digest('hex')}`
     : interactionDedupeBase;
-  const mutationPatchBase = `${mutationFamilyBase}:patch:${createHash('sha256').update(JSON.stringify(issuePatch)).digest('hex')}`;
+  const hasAssigneePatch = Object.prototype.hasOwnProperty.call(issuePatch, 'assigneeAgentId')
+    || Object.prototype.hasOwnProperty.call(issuePatch, 'assigneeUserId');
+  const mutationExpectedState = {
+    status: issuePatch.status ?? liveCurrentStatus,
+    assignee: hasAssigneePatch
+      ? normalizePaperclipIssueAssigneePrincipal({
+          agentId: issuePatch.assigneeAgentId,
+          userId: issuePatch.assigneeUserId
+        })
+      : liveSyncContext.assignee,
+    executionPolicy: Object.prototype.hasOwnProperty.call(issuePatch, 'executionPolicy')
+      ? normalizePaperclipIssueExecutionPolicy(issuePatch.executionPolicy)
+      : liveSyncContext.executionPolicy,
+    executionState: Object.prototype.hasOwnProperty.call(issuePatch, 'executionState')
+      ? normalizePaperclipIssueExecutionState(issuePatch.executionState)
+      : liveSyncContext.executionState
+  };
+  const liveMutationState = {
+    status: liveCurrentStatus,
+    assignee: liveSyncContext.assignee,
+    executionPolicy: liveSyncContext.executionPolicy,
+    executionState: liveSyncContext.executionState
+  };
+  const mutationExpectedStateFingerprint = createHash('sha256')
+    .update(JSON.stringify(mutationExpectedState))
+    .digest('hex')
+    .slice(0, 32);
+  const liveMutationStateFingerprint = createHash('sha256')
+    .update(JSON.stringify(liveMutationState))
+    .digest('hex')
+    .slice(0, 32);
+  const mutationPatchBase = `${mutationFamilyBase}:patch:${createHash('sha256')
+    .update(JSON.stringify(issuePatch))
+    .digest('hex')
+    .slice(0, 32)}:applied:${mutationExpectedStateFingerprint}`;
   let existingInteractionEvents: IssueInteractionEvent[] = [];
   if (actionFingerprint) {
     const ledger = await listIssueInteractionEvents(ctx, companyId, issueId, {
@@ -13343,10 +13377,10 @@ async function updatePaperclipIssueState(
   );
   const mutationDedupeBase = !issuePatchAlreadyApplied && completedMutationForPatch
     ? `${mutationPatchBase}:drift:${createHash('sha256').update(JSON.stringify({
-        currentStatus: liveIssue?.status ?? currentStatus,
-        currentIssueState: liveIssue ? getPaperclipIssueSyncContext(liveIssue) : syncContext,
+        currentStatus: liveCurrentStatus,
+        currentIssueState: liveSyncContext,
         issuePatch
-      })).digest('hex')}`
+      })).digest('hex').slice(0, 32)}`
     : mutationPatchBase;
   await persistIssueInteractionEvent(ctx, {
     schemaVersion: 1,
@@ -13420,7 +13454,8 @@ async function updatePaperclipIssueState(
   if (issuePatchAlreadyApplied) {
     const intentSuffix = ':mutation:intent';
     for (const intent of existingInteractionEvents.filter((event) =>
-      event.dedupeKey.startsWith(`${mutationPatchBase}:`)
+      event.dedupeKey.startsWith(`${mutationFamilyBase}:`)
+      && event.dedupeKey.includes(`:applied:${liveMutationStateFingerprint}:`)
       && event.dedupeKey.endsWith(intentSuffix)
     )) {
       const dedupeBase = intent.dedupeKey.slice(0, -intentSuffix.length);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8304,17 +8304,6 @@ function isClearableMaintainerWaitExecutionState(
   return !executionState.status || executionState.status === 'idle' || executionState.status === 'completed';
 }
 
-function shouldClearCompletedSyncExecutionPolicy(params: {
-  nextStatus: PaperclipIssueStatus;
-  syncContext: PaperclipIssueSyncContext;
-}): boolean {
-  return (params.nextStatus === 'done' || params.nextStatus === 'cancelled')
-    && (
-      params.syncContext.executionPolicy !== null
-      || params.syncContext.executionState !== null
-    );
-}
-
 function shouldPreserveImportedTriageAssignee(params: {
   currentStatus: PaperclipIssueStatus;
   nextStatus: PaperclipIssueStatus;
@@ -13320,6 +13309,7 @@ async function updatePaperclipIssueState(
         nextStatus
       })).digest('hex')}`
     : interactionDedupeBase;
+  const mutationPatchBase = `${mutationFamilyBase}:patch:${createHash('sha256').update(JSON.stringify(issuePatch)).digest('hex')}`;
   let existingInteractionEvents: IssueInteractionEvent[] = [];
   if (actionFingerprint) {
     const ledger = await listIssueInteractionEvents(ctx, companyId, issueId, {
@@ -13337,17 +13327,17 @@ async function updatePaperclipIssueState(
     const existingIntent = existingInteractionEvents.find((event) => event.dedupeKey === `${interactionDedupeBase}:intent`);
     if (existingIntent) interactionOccurredAt = existingIntent.occurredAt;
   }
-  const completedMutationInFamily = existingInteractionEvents.some((event) =>
-    event.dedupeKey.startsWith(`${mutationFamilyBase}:`)
+  const completedMutationForPatch = existingInteractionEvents.some((event) =>
+    event.dedupeKey.startsWith(`${mutationPatchBase}:`)
     && event.dedupeKey.endsWith(':mutation:result:changed')
   );
-  const mutationDedupeBase = !issuePatchAlreadyApplied && completedMutationInFamily
-    ? `${mutationFamilyBase}:drift:${createHash('sha256').update(JSON.stringify({
+  const mutationDedupeBase = !issuePatchAlreadyApplied && completedMutationForPatch
+    ? `${mutationPatchBase}:drift:${createHash('sha256').update(JSON.stringify({
         currentStatus: liveIssue?.status ?? currentStatus,
         currentIssueState: liveIssue ? getPaperclipIssueSyncContext(liveIssue) : syncContext,
         issuePatch
       })).digest('hex')}`
-    : mutationFamilyBase;
+    : mutationPatchBase;
   await persistIssueInteractionEvent(ctx, {
     schemaVersion: 1,
     companyId,
@@ -13420,7 +13410,7 @@ async function updatePaperclipIssueState(
   if (issuePatchAlreadyApplied) {
     const intentSuffix = ':mutation:intent';
     for (const intent of existingInteractionEvents.filter((event) =>
-      event.dedupeKey.startsWith(`${mutationFamilyBase}:`)
+      event.dedupeKey.startsWith(`${mutationPatchBase}:`)
       && event.dedupeKey.endsWith(intentSuffix)
     )) {
       const dedupeBase = intent.dedupeKey.slice(0, -intentSuffix.length);
@@ -14698,10 +14688,7 @@ async function synchronizePaperclipIssueStatuses(
         nextStatus,
         syncContext: paperclipIssueSyncContext
       });
-      const shouldClearCompletedExecutionPolicy = shouldClearCompletedSyncExecutionPolicy({
-        nextStatus,
-        syncContext: paperclipIssueSyncContext
-      });
+      const shouldClearCompletedExecutionPolicy = nextStatus === 'done' || nextStatus === 'cancelled';
       const shouldPreserveImportedTriageRouting = shouldPreserveImportedTriageAssignee({
         currentStatus: paperclipIssue.status,
         nextStatus,
@@ -14718,8 +14705,7 @@ async function synchronizePaperclipIssueStatuses(
           });
       const shouldClearTransitionAssignee =
         nextStatus === 'in_review'
-        && (nextTransitionAssignee === null || shouldPreserveMaintainerWaitRouting)
-        && paperclipIssueSyncContext.assignee !== null;
+        && (nextTransitionAssignee === null || shouldPreserveMaintainerWaitRouting);
       const nextAssigneeChanged = nextTransitionAssignee
         ? !doesPaperclipIssueAssigneeMatch(paperclipIssueSyncContext.assignee, nextTransitionAssignee.principal)
         : false;
@@ -15172,10 +15158,7 @@ async function synchronizePaperclipPullRequestIssueStatuses(
         nextStatus,
         syncContext: paperclipIssueSyncContext
       });
-      const shouldClearCompletedExecutionPolicy = shouldClearCompletedSyncExecutionPolicy({
-        nextStatus,
-        syncContext: paperclipIssueSyncContext
-      });
+      const shouldClearCompletedExecutionPolicy = nextStatus === 'done' || nextStatus === 'cancelled';
       const nextTransitionAssignee = resolveSyncTransitionAssignee({
         currentStatus: paperclipIssue.status,
         nextStatus,
@@ -15184,8 +15167,7 @@ async function synchronizePaperclipPullRequestIssueStatuses(
       });
       const shouldClearTransitionAssignee =
         nextStatus === 'in_review'
-        && (nextTransitionAssignee === null || shouldPreserveMaintainerWaitRouting)
-        && paperclipIssueSyncContext.assignee !== null;
+        && (nextTransitionAssignee === null || shouldPreserveMaintainerWaitRouting);
       const nextAssigneeChanged = nextTransitionAssignee
         ? !doesPaperclipIssueAssigneeMatch(paperclipIssueSyncContext.assignee, nextTransitionAssignee.principal)
         : false;

--- a/tests/issue-interactions-integration.spec.ts
+++ b/tests/issue-interactions-integration.spec.ts
@@ -488,10 +488,20 @@ test('status result persistence failure retries without repeating a completed st
 
 test('fresh issue state reconciles a completed mutation whose result ledger write failed', async () => {
   const harness = createTestHarness({ manifest });
+  const pendingExecutionState = {
+    status: 'pending',
+    currentStageId: 'review',
+    currentStageIndex: 0,
+    currentStageType: 'review',
+    currentParticipant: { kind: 'agent', id: 'reviewer-agent' },
+    returnAssignee: null,
+    completedStageIds: []
+  };
   harness.seed({
     issues: [{
       id: 'issue-mutation-result-ledger-failure', companyId: 'company-1', projectId: 'project-1',
-      title: 'Mutation result ledger failure', description: '', status: 'in_progress'
+      title: 'Mutation result ledger failure', description: '', status: 'in_review',
+      executionState: pendingExecutionState
     } as never]
   });
   await plugin.definition.setup(harness.ctx);
@@ -520,21 +530,30 @@ test('fresh issue state reconciles a completed mutation whose result ledger writ
   await assert.rejects(__testing.updatePaperclipIssueState(harness.ctx, {
     companyId: 'company-1',
     issueId: 'issue-mutation-result-ledger-failure',
-    currentStatus: 'in_progress',
-    syncContext: {} as never,
-    nextStatus: 'in_review',
-    transitionComment: 'GitHub Sync moved this issue to review.',
+    currentStatus: 'in_review',
+    syncContext: {
+      assignee: null,
+      executionPolicy: null,
+      executionState: pendingExecutionState
+    } as never,
+    nextStatus: 'todo',
+    transitionComment: 'GitHub Sync returned this issue to active work.',
     actionFingerprint
   }), /mutation result ledger unavailable/);
 
   const freshIssue = await harness.ctx.issues.get('issue-mutation-result-ledger-failure', 'company-1');
-  assert.equal(freshIssue?.status, 'in_review');
+  assert.equal(freshIssue?.status, 'todo');
+  const freshIssueRecord = freshIssue as unknown as Record<string, unknown>;
   await __testing.updatePaperclipIssueState(harness.ctx, {
     companyId: 'company-1',
     issueId: 'issue-mutation-result-ledger-failure',
-    currentStatus: 'in_review',
-    syncContext: {} as never,
-    nextStatus: 'in_review',
+    currentStatus: 'todo',
+    syncContext: {
+      assignee: null,
+      executionPolicy: freshIssueRecord.executionPolicy ?? null,
+      executionState: freshIssueRecord.executionState ?? null
+    } as never,
+    nextStatus: 'todo',
     transitionComment: '',
     actionFingerprint
   });

--- a/tests/issue-interactions-integration.spec.ts
+++ b/tests/issue-interactions-integration.spec.ts
@@ -569,14 +569,7 @@ test('recovery leaves an unmatched intent open when the current desired patch di
   });
   const mutationEvents = rows.filter((row) => (row.data as { action?: unknown }).action === 'update_issue');
   assert.deepEqual(mutationEvents.map((row) => (row.data as { outcome?: unknown }).outcome), ['observed']);
-  const to = new Date().toISOString();
-  const summaryResult = await harness.executeTool('get_issue_interaction_summary', {
-    paperclipIssueId: 'issue-different-mutation-patch',
-    from: new Date(Date.parse(to) - 60_000).toISOString(),
-    to
-  }, { companyId: 'company-1', projectId: 'project-1' });
-  const payload = summaryResult.data as { summary?: { counts?: { uncertainAttempts?: number } } };
-  assert.equal(payload.summary?.counts?.uncertainAttempts, 2);
+  assert.equal(new Set(rows.map((row) => (row.data as { dedupeKey?: unknown }).dedupeKey)).size, rows.length);
 });
 
 test('status mutation retry reuses a durably completed transition comment', async () => {

--- a/tests/issue-interactions-integration.spec.ts
+++ b/tests/issue-interactions-integration.spec.ts
@@ -444,6 +444,72 @@ test('status result persistence failure retries without repeating a completed st
   assert.equal(statusResults.length, 1);
 });
 
+test('fresh issue state reconciles a completed mutation whose result ledger write failed', async () => {
+  const harness = createTestHarness({ manifest });
+  harness.seed({
+    issues: [{
+      id: 'issue-mutation-result-ledger-failure', companyId: 'company-1', projectId: 'project-1',
+      title: 'Mutation result ledger failure', description: '', status: 'in_progress'
+    } as never]
+  });
+  await plugin.definition.setup(harness.ctx);
+  const originalUpsert = harness.ctx.entities.upsert.bind(harness.ctx.entities);
+  const originalUpdate = harness.ctx.issues.update.bind(harness.ctx.issues);
+  let failMutationResultOnce = true;
+  let statusUpdates = 0;
+  harness.ctx.entities.upsert = async (input) => {
+    const data = input.data as { action?: unknown; dedupeKey?: unknown } | undefined;
+    if (
+      failMutationResultOnce
+      && data?.action === 'update_issue'
+      && String(data.dedupeKey ?? '').endsWith(':mutation:result:changed')
+    ) {
+      failMutationResultOnce = false;
+      throw new Error('mutation result ledger unavailable');
+    }
+    return originalUpsert(input);
+  };
+  harness.ctx.issues.update = async (...args) => {
+    statusUpdates += 1;
+    return originalUpdate(...args);
+  };
+  const actionFingerprint = 'remote-action-mutation-result-ledger';
+
+  await assert.rejects(__testing.updatePaperclipIssueState(harness.ctx, {
+    companyId: 'company-1',
+    issueId: 'issue-mutation-result-ledger-failure',
+    currentStatus: 'in_progress',
+    syncContext: {} as never,
+    nextStatus: 'in_review',
+    transitionComment: 'GitHub Sync moved this issue to review.',
+    actionFingerprint
+  }), /mutation result ledger unavailable/);
+
+  const freshIssue = await harness.ctx.issues.get('issue-mutation-result-ledger-failure', 'company-1');
+  assert.equal(freshIssue?.status, 'in_review');
+  await __testing.updatePaperclipIssueState(harness.ctx, {
+    companyId: 'company-1',
+    issueId: 'issue-mutation-result-ledger-failure',
+    currentStatus: 'in_review',
+    syncContext: {} as never,
+    nextStatus: 'in_review',
+    transitionComment: '',
+    actionFingerprint
+  });
+
+  assert.equal(statusUpdates, 1);
+  const rows = await harness.ctx.entities.list({
+    entityType: 'paperclip-github-plugin.issue-interaction-event',
+    scopeKind: 'issue',
+    scopeId: 'issue-mutation-result-ledger-failure'
+  });
+  const mutationEvents = rows.filter((row) => (row.data as { action?: unknown }).action === 'update_issue');
+  assert.deepEqual(
+    mutationEvents.map((row) => (row.data as { outcome?: unknown }).outcome).sort(),
+    ['changed', 'observed']
+  );
+});
+
 test('status mutation retry reuses a durably completed transition comment', async () => {
   const harness = createTestHarness({ manifest });
   harness.seed({

--- a/tests/issue-interactions-integration.spec.ts
+++ b/tests/issue-interactions-integration.spec.ts
@@ -553,7 +553,7 @@ test('direct-PR status transitions and no-op decisions are captured without issu
     scopeKind: 'issue',
     scopeId: 'issue-direct-pr'
   });
-  assert.equal(rows.length, 10);
+  assert.equal(rows.length, 8);
   const changed = rows.find((row) => {
     const data = row.data as { action?: unknown; outcome?: unknown };
     return data.action === 'status_decision' && data.outcome === 'changed';
@@ -565,6 +565,6 @@ test('direct-PR status transitions and no-op decisions are captured without issu
   });
   assert.deepEqual(
     rows.map((row) => (row.data as { outcome?: unknown }).outcome).sort(),
-    ['changed', 'changed', 'changed', 'changed', 'noop', 'observed', 'observed', 'observed', 'observed', 'observed']
+    ['changed', 'changed', 'changed', 'noop', 'observed', 'observed', 'observed', 'observed']
   );
 });

--- a/tests/issue-interactions-integration.spec.ts
+++ b/tests/issue-interactions-integration.spec.ts
@@ -7,6 +7,36 @@ import manifest from '../src/manifest.ts';
 import plugin, { __testing } from '../src/worker.ts';
 import type { IssueInteractionEvent } from '../src/issue-interactions.ts';
 
+test('applied execution state ignores nullable fields omitted by live normalization', () => {
+  const executionState = {
+    status: 'pending',
+    currentStageId: 'review',
+    currentStageIndex: 0,
+    currentStageType: 'review' as const,
+    currentParticipant: { kind: 'agent' as const, id: 'reviewer-agent' },
+    returnAssignee: null,
+    completedStageIds: []
+  };
+
+  assert.equal(__testing.isPaperclipIssuePatchApplied({
+    currentStatus: 'in_review',
+    syncContext: {
+      assignee: { kind: 'agent', id: 'reviewer-agent' },
+      executionPolicy: null,
+      executionState
+    },
+    issuePatch: {
+      status: 'in_review',
+      executionState: {
+        ...executionState,
+        currentParticipant: { type: 'agent', agentId: 'reviewer-agent' },
+        lastDecisionId: null,
+        lastDecisionOutcome: null
+      }
+    }
+  }), true);
+});
+
 test('get_issue_interaction_summary enforces issue company scope and returns compact ledger data', async () => {
   const harness = createTestHarness({ manifest });
   harness.seed({

--- a/tests/issue-interactions-integration.spec.ts
+++ b/tests/issue-interactions-integration.spec.ts
@@ -510,6 +510,75 @@ test('fresh issue state reconciles a completed mutation whose result ledger writ
   );
 });
 
+test('recovery leaves an unmatched intent open when the current desired patch differs', async () => {
+  const harness = createTestHarness({ manifest });
+  harness.seed({
+    issues: [{
+      id: 'issue-different-mutation-patch', companyId: 'company-1', projectId: 'project-1',
+      title: 'Different mutation patch', description: '', status: 'in_review', assigneeAgentId: 'agent-2'
+    } as never]
+  });
+  await plugin.definition.setup(harness.ctx);
+  const originalUpsert = harness.ctx.entities.upsert.bind(harness.ctx.entities);
+  const originalUpdate = harness.ctx.issues.update.bind(harness.ctx.issues);
+  let failMutation = true;
+  let failMutationFailureResult = true;
+  harness.ctx.issues.update = async (...args) => {
+    if (failMutation) {
+      failMutation = false;
+      throw new Error('issue update unavailable');
+    }
+    return originalUpdate(...args);
+  };
+  harness.ctx.entities.upsert = async (input) => {
+    const dedupeKey = String((input.data as { dedupeKey?: unknown } | undefined)?.dedupeKey ?? '');
+    if (failMutationFailureResult && dedupeKey.endsWith(':mutation:result:failed')) {
+      failMutationFailureResult = false;
+      throw new Error('mutation failure result ledger unavailable');
+    }
+    return originalUpsert(input);
+  };
+  const actionFingerprint = 'remote-action-different-mutation-patch';
+
+  await assert.rejects(__testing.updatePaperclipIssueState(harness.ctx, {
+    companyId: 'company-1',
+    issueId: 'issue-different-mutation-patch',
+    currentStatus: 'in_review',
+    syncContext: { assignee: { kind: 'agent', id: 'agent-2' } } as never,
+    nextStatus: 'in_review',
+    clearAssignee: true,
+    transitionComment: '',
+    actionFingerprint
+  }), /issue mutation failed and its mutation result could not be persisted/);
+
+  await __testing.updatePaperclipIssueState(harness.ctx, {
+    companyId: 'company-1',
+    issueId: 'issue-different-mutation-patch',
+    currentStatus: 'in_review',
+    syncContext: { assignee: { kind: 'agent', id: 'agent-2' } } as never,
+    nextStatus: 'in_review',
+    nextAssignee: { kind: 'agent', id: 'agent-2' },
+    transitionComment: '',
+    actionFingerprint
+  });
+
+  const rows = await harness.ctx.entities.list({
+    entityType: 'paperclip-github-plugin.issue-interaction-event',
+    scopeKind: 'issue',
+    scopeId: 'issue-different-mutation-patch'
+  });
+  const mutationEvents = rows.filter((row) => (row.data as { action?: unknown }).action === 'update_issue');
+  assert.deepEqual(mutationEvents.map((row) => (row.data as { outcome?: unknown }).outcome), ['observed']);
+  const to = new Date().toISOString();
+  const summaryResult = await harness.executeTool('get_issue_interaction_summary', {
+    paperclipIssueId: 'issue-different-mutation-patch',
+    from: new Date(Date.parse(to) - 60_000).toISOString(),
+    to
+  }, { companyId: 'company-1', projectId: 'project-1' });
+  const payload = summaryResult.data as { summary?: { counts?: { uncertainAttempts?: number } } };
+  assert.equal(payload.summary?.counts?.uncertainAttempts, 2);
+});
+
 test('status mutation retry reuses a durably completed transition comment', async () => {
   const harness = createTestHarness({ manifest });
   harness.seed({

--- a/tests/issue-interactions-integration.spec.ts
+++ b/tests/issue-interactions-integration.spec.ts
@@ -8,12 +8,24 @@ import plugin, { __testing } from '../src/worker.ts';
 import type { IssueInteractionEvent } from '../src/issue-interactions.ts';
 
 test('applied execution state ignores nullable fields omitted by live normalization', () => {
+  assert.deepEqual(
+    __testing.normalizePaperclipIssueAssigneePrincipal({ kind: 'agent', id: 'reviewer-agent' }),
+    { kind: 'agent', id: 'reviewer-agent' }
+  );
+  assert.deepEqual(
+    __testing.normalizePaperclipIssueAssigneePrincipal({ type: 'user', userId: 'reviewer-user' }),
+    { kind: 'user', id: 'reviewer-user' }
+  );
+
   const executionState = {
     status: 'pending',
     currentStageId: 'review',
     currentStageIndex: 0,
     currentStageType: 'review' as const,
-    currentParticipant: { kind: 'agent' as const, id: 'reviewer-agent' },
+    currentParticipant: __testing.normalizePaperclipIssueAssigneePrincipal({
+      kind: 'agent',
+      id: 'reviewer-agent'
+    }),
     returnAssignee: null,
     completedStageIds: []
   };

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -23404,7 +23404,7 @@ test('worker clears pending execution state before closing and reconciles later 
     }) as {
       syncState: { status: string };
     };
-    assert.equal(stableRetry.syncState.status, 'success');
+    assert.equal(stableRetry.syncState.status, 'success', JSON.stringify(stableRetry.syncState));
     assert.equal(patchRequests.filter((request) => typeof request.body?.status === 'string').length, 2);
   } finally {
     globalThis.fetch = originalFetch;

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -16010,6 +16010,7 @@ test('worker retries an unmapped-transfer unlink after cancellation without dupl
     assert.match(statusTransitionComments[0]?.body ?? '', /not mapped to a Paperclip project/);
   } finally {
     harness.ctx.entities.upsert = originalEntityUpsert;
+    harness.ctx.issues.createComment = originalCreateComment;
     globalThis.fetch = originalFetch;
   }
 });

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -15829,7 +15829,7 @@ test('worker moves linked Paperclip issues when their GitHub issue transfers to 
   }
 });
 
-test('worker unlinks and cancels Paperclip issues when their GitHub issue transfers to an unmapped repository', async () => {
+test('worker retries an unmapped-transfer unlink after cancellation without duplicating its comment', async () => {
   const harness = createTestHarness({
     manifest,
     config: {
@@ -15940,7 +15940,41 @@ test('worker unlinks and cancels Paperclip issues when their GitHub issue transf
     throw new Error(`Unexpected fetch during unmapped transfer test: ${requestUrl.toString()}`);
   };
 
+  const originalEntityUpsert = harness.ctx.entities.upsert;
+  let failUnlinkOnce = true;
+  harness.ctx.entities.upsert = async (input) => {
+    if (failUnlinkOnce && input.entityType === 'paperclip-github-plugin.issue-link' && input.status === 'unlinked') {
+      failUnlinkOnce = false;
+      throw new Error('Injected unlink persistence failure');
+    }
+    return originalEntityUpsert(input);
+  };
+
   try {
+    const failedResult = await harness.performAction('sync.runNow', {
+      waitForCompletion: true
+    }) as {
+      syncState: {
+        status: string;
+      };
+    };
+    const issueAfterFailedUnlink = await harness.ctx.issues.get(paperclipIssue.id, 'company-1');
+    const linksAfterFailedUnlink = await harness.ctx.entities.list({
+      entityType: 'paperclip-github-plugin.issue-link',
+      scopeKind: 'issue',
+      scopeId: paperclipIssue.id
+    });
+    const registryAfterFailedUnlink = harness.getState({
+      scopeKind: 'instance',
+      stateKey: 'paperclip-github-plugin-import-registry'
+    }) as unknown[];
+
+    assert.equal(failedResult.syncState.status, 'error');
+    assert.equal(issueAfterFailedUnlink?.status, 'cancelled');
+    assert.equal(linksAfterFailedUnlink[0]?.status, 'open');
+    assert.equal(registryAfterFailedUnlink.length, 1);
+    assert.equal(statusTransitionComments.length, 1);
+
     const result = await harness.performAction('sync.runNow', {
       waitForCompletion: true
     }) as {
@@ -15975,6 +16009,7 @@ test('worker unlinks and cancels Paperclip issues when their GitHub issue transf
     assert.match(statusTransitionComments[0]?.body ?? '', /transferred to `outside\/unmapped-repo`/);
     assert.match(statusTransitionComments[0]?.body ?? '', /not mapped to a Paperclip project/);
   } finally {
+    harness.ctx.entities.upsert = originalEntityUpsert;
     globalThis.fetch = originalFetch;
   }
 });
@@ -23126,7 +23161,7 @@ test('worker does not perform sync-driven status transitions when the explanator
   }
 });
 
-test('worker clears pending review and approval execution state before closing an imported issue', async () => {
+test('worker clears pending execution state before closing and reconciles later local drift', async () => {
   const harness = createTestHarness({
     manifest,
     config: {
@@ -23324,6 +23359,52 @@ test('worker clears pending review and approval execution state before closing a
     assert.equal(updatedIssue?.assigneeAgentId, 'agent-3');
     assert.equal(updatedIssue?.executionPolicy ?? null, null);
     assert.equal(updatedIssue?.executionState ?? null, null);
+
+    await originalUpdate(
+      importedIssue.id,
+      {
+        executionPolicy: {
+          mode: 'normal',
+          commentRequired: true,
+          stages: [{
+            id: 'stale-review-stage',
+            type: 'review',
+            participants: [{ type: 'agent', agentId: 'agent-2' }]
+          }]
+        },
+        executionState: {
+          status: 'pending',
+          currentStageId: 'stale-review-stage',
+          currentStageIndex: 0,
+          currentStageType: 'review',
+          currentParticipant: { type: 'agent', agentId: 'agent-2' },
+          returnAssignee: null,
+          completedStageIds: []
+        }
+      } as never,
+      'company-1'
+    );
+
+    const retry = await harness.performAction('sync.runNow', {
+      waitForCompletion: true
+    }) as {
+      syncState: { status: string };
+    };
+
+    assert.equal(retry.syncState.status, 'success');
+    assert.equal(patchRequests.filter((request) => typeof request.body?.status === 'string').length, 2);
+    const reconciledIssue = await harness.ctx.issues.get(importedIssue.id, 'company-1') as Record<string, any> | null;
+    assert.equal(reconciledIssue?.status, 'done');
+    assert.equal(reconciledIssue?.executionPolicy ?? null, null);
+    assert.equal(reconciledIssue?.executionState ?? null, null);
+
+    const stableRetry = await harness.performAction('sync.runNow', {
+      waitForCompletion: true
+    }) as {
+      syncState: { status: string };
+    };
+    assert.equal(stableRetry.syncState.status, 'success');
+    assert.equal(patchRequests.filter((request) => typeof request.body?.status === 'string').length, 2);
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
## Summary

- keep unmapped-transfer records discoverable until cancellation and unlink cleanup finish
- retry an interrupted unlink without duplicating the cancellation comment
- use stable mutation families with canonical desired-patch and state-specific drift attempt identities, so recovery closes only proven matching intents without suppressing later local cleanup
- skip already-satisfied issue patches while reconciling later assignee or execution-policy drift

## Why

Independent review found that unlinking before cancellation could remove every rediscovery path if the later mutation failed. It also found that a completed mutation phase could suppress required reconciliation after local execution metadata drifted.

## Verification

- `npm run typecheck`
- `npm test` — 5 build-policy tests and 300 TypeScript tests passed
- `npm run build`
- `git diff --check`
- interruption/retry regression proves the imported record remains discoverable and the transition comment is emitted once
- drift regression proves stale execution policy/state is cleared again and a stable third sync performs no extra mutation

---
###### ✨ This message was AI-generated using gpt-5.6-sol