### PR TITLE
Retain Board token fallback until config sync

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -23364,7 +23364,10 @@ const plugin = definePlugin({
 
     ctx.actions.register('settings.updateBoardAccess', async (input, actionContext) => {
       const previous = normalizeSettings(await ctx.state.get(SETTINGS_SCOPE));
-      const config = await getResolvedConfig(ctx);
+      const [config, trustedConfig] = await Promise.all([
+        getResolvedConfig(ctx),
+        ctx.config.get().then((value) => normalizeConfig(value))
+      ]);
       const record = normalizeActionRecord(input, actionContext);
       const companyId = normalizeCompanyId(record.companyId);
       if (!companyId) {
@@ -23386,7 +23389,7 @@ const plugin = definePlugin({
       if (nextSecretRef) {
         nextPaperclipBoardApiTokenRefs[companyId] = nextSecretRef;
         if (nextBoardApiToken) {
-          const configuredSecretRef = getConfiguredPaperclipBoardApiTokenRef(config, companyId);
+          const configuredSecretRef = getConfiguredPaperclipBoardApiTokenRef(trustedConfig, companyId);
           if (
             configuredSecretRef !== nextSecretRef
             || await shouldSeedExternalPaperclipBoardTokenFallback(ctx, companyId, nextSecretRef)

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -23386,7 +23386,11 @@ const plugin = definePlugin({
       if (nextSecretRef) {
         nextPaperclipBoardApiTokenRefs[companyId] = nextSecretRef;
         if (nextBoardApiToken) {
-          if (await shouldSeedExternalPaperclipBoardTokenFallback(ctx, companyId, nextSecretRef)) {
+          const configuredSecretRef = getConfiguredPaperclipBoardApiTokenRef(config, companyId);
+          if (
+            configuredSecretRef !== nextSecretRef
+            || await shouldSeedExternalPaperclipBoardTokenFallback(ctx, companyId, nextSecretRef)
+          ) {
             await writeExternalCompanyPaperclipBoardApiTokenFallback(ctx, companyId, nextBoardApiToken);
           } else {
             await clearExternalCompanyPaperclipBoardApiTokenFallback(ctx, companyId);

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -13302,6 +13302,16 @@ test('settings.updateBoardAccess keeps a board token fallback until the secret r
   await withTemporaryPaperclipHome(async ({ configFilePath }) => {
     const harness = createTestHarness({ manifest });
     await plugin.definition.setup(harness.ctx);
+    await mkdir(dirname(configFilePath), { recursive: true });
+    await writeFile(
+      configFilePath,
+      JSON.stringify({
+        paperclipBoardApiTokenRefs: {
+          'company-1': 'board-secret-ref'
+        }
+      }),
+      'utf8'
+    );
 
     let resolveCount = 0;
     harness.ctx.secrets.resolve = async (secretRef) => {

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -13298,9 +13298,45 @@ test('settings.ensureGitHubTokenAvailable overwrites invalid worker-local config
   });
 });
 
-test('settings.updateBoardAccess skips the board token fallback when the saved secret ref resolves', { concurrency: false }, async () => {
+test('settings.updateBoardAccess keeps a board token fallback until the secret ref is mirrored into plugin config', { concurrency: false }, async () => {
   await withTemporaryPaperclipHome(async ({ configFilePath }) => {
     const harness = createTestHarness({ manifest });
+    await plugin.definition.setup(harness.ctx);
+
+    let resolveCount = 0;
+    harness.ctx.secrets.resolve = async (secretRef) => {
+      resolveCount += 1;
+      assert.equal(secretRef, 'board-secret-ref');
+      return 'paperclip-board-token';
+    };
+
+    await harness.performAction('settings.updateBoardAccess', {
+      companyId: 'company-1',
+      paperclipBoardApiTokenRef: 'board-secret-ref',
+      paperclipBoardApiToken: 'paperclip-board-token',
+      paperclipBoardAccessIdentity: 'Jane Operator'
+    });
+
+    const storedConfig = JSON.parse(await readFile(configFilePath, 'utf8')) as {
+      paperclipBoardApiTokensByCompanyId?: Record<string, string>;
+    };
+    assert.deepEqual(storedConfig.paperclipBoardApiTokensByCompanyId, {
+      'company-1': 'paperclip-board-token'
+    });
+    assert.equal(resolveCount, 0);
+  });
+});
+
+test('settings.updateBoardAccess skips the board token fallback after the secret ref is mirrored into plugin config', { concurrency: false }, async () => {
+  await withTemporaryPaperclipHome(async ({ configFilePath }) => {
+    const harness = createTestHarness({
+      manifest,
+      config: {
+        paperclipBoardApiTokenRefs: {
+          'company-1': 'board-secret-ref'
+        }
+      }
+    });
     await plugin.definition.setup(harness.ctx);
 
     let resolveCount = 0;


### PR DESCRIPTION
## Summary

- retain the worker-local Paperclip Board token fallback while a company-scoped secret ref exists only in plugin state
- clear the fallback only after the same secret ref is mirrored into trusted plugin config and resolves successfully
- cover both the saved-only and fully mirrored configuration paths

## Staging reproduction

On frozen staging, `settings.updateBoardAccess` accepted a valid Board token and saved its secret ref, but skipped the worker fallback because the secret resolved during the action. During sync, the saved-only ref was intentionally not resolved because it had not reached trusted plugin config, so label API requests were sent without Board authentication and returned HTTP 401.

The existing test encoded the incorrect assumption that secret resolvability alone was enough to remove the fallback.

## Verification

- focused Board-access fallback tests: 4 passed
- TypeScript typecheck passed
- build-policy tests: 5 passed
- TypeScript tests: 301 passed
- production build passed
- `git diff --check` passed

Production remains unchanged.

---
###### ✨ This message was AI-generated using gpt-5.6-sol
