### PR TITLE
Envelope Board access token action input

### DIFF
--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -12138,7 +12138,9 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
         companyId,
         paperclipBoardApiTokenRef: secret.id,
         paperclipBoardAccess: {
-          token: boardApiToken
+          authorization: {
+            bearer: boardApiToken
+          }
         },
         paperclipBoardAccessIdentity: boardIdentity.label ?? '',
         paperclipBoardAccessUserId: boardIdentity.userId ?? ''

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -12137,7 +12137,9 @@ export function GitHubSyncSettingsPage(): React.JSX.Element {
       await updateBoardAccess({
         companyId,
         paperclipBoardApiTokenRef: secret.id,
-        paperclipBoardApiToken: boardApiToken,
+        paperclipBoardAccess: {
+          token: boardApiToken
+        },
         paperclipBoardAccessIdentity: boardIdentity.label ?? '',
         paperclipBoardAccessUserId: boardIdentity.userId ?? ''
       });

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -23375,7 +23375,11 @@ const plugin = definePlugin({
       }
 
       const nextSecretRef = normalizeSecretRef(record.paperclipBoardApiTokenRef);
-      const nextBoardApiToken = normalizeGitHubToken(record.paperclipBoardApiToken);
+      const boardAccessRecord = record.paperclipBoardAccess && typeof record.paperclipBoardAccess === 'object'
+        ? record.paperclipBoardAccess as Record<string, unknown>
+        : {};
+      const nextBoardApiToken = normalizeGitHubToken(record.paperclipBoardApiToken)
+        ?? normalizeGitHubToken(boardAccessRecord.token);
       const nextPaperclipBoardApiTokenRefs = {
         ...(previous.paperclipBoardApiTokenRefs ?? {})
       };

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -23378,8 +23378,11 @@ const plugin = definePlugin({
       const boardAccessRecord = record.paperclipBoardAccess && typeof record.paperclipBoardAccess === 'object'
         ? record.paperclipBoardAccess as Record<string, unknown>
         : {};
+      const boardAuthorizationRecord = boardAccessRecord.authorization && typeof boardAccessRecord.authorization === 'object'
+        ? boardAccessRecord.authorization as Record<string, unknown>
+        : {};
       const nextBoardApiToken = normalizeGitHubToken(record.paperclipBoardApiToken)
-        ?? normalizeGitHubToken(boardAccessRecord.token);
+        ?? normalizeGitHubToken(boardAuthorizationRecord.bearer);
       const nextPaperclipBoardApiTokenRefs = {
         ...(previous.paperclipBoardApiTokenRefs ?? {})
       };

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -13323,7 +13323,9 @@ test('settings.updateBoardAccess keeps a board token fallback until the secret r
     await harness.performAction('settings.updateBoardAccess', {
       companyId: 'company-1',
       paperclipBoardApiTokenRef: 'board-secret-ref',
-      paperclipBoardApiToken: 'paperclip-board-token',
+      paperclipBoardAccess: {
+        token: 'paperclip-board-token'
+      },
       paperclipBoardAccessIdentity: 'Jane Operator'
     });
 

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -13324,7 +13324,9 @@ test('settings.updateBoardAccess keeps a board token fallback until the secret r
       companyId: 'company-1',
       paperclipBoardApiTokenRef: 'board-secret-ref',
       paperclipBoardAccess: {
-        token: 'paperclip-board-token'
+        authorization: {
+          bearer: 'paperclip-board-token'
+        }
       },
       paperclipBoardAccessIdentity: 'Jane Operator'
     });


### PR DESCRIPTION
## Summary

- send the short-lived Paperclip Board credential inside a nested `{ authorization: { bearer } }` envelope from the settings UI
- accept both the new envelope and the legacy top-level field in the worker
- preserve host error-log redaction because the server recursively redacts the complete `authorization` object

## Frozen-staging reproduction

With official `0.15.5` loaded after a full server restart, authenticated `settings.updateBoardAccess` calls persisted the secret ref, identity, and user ID but did not deliver the top-level `paperclipBoardApiToken` value to the action handler. The worker-local fallback remained absent even for an intentionally unmirrored test ref. A non-secret diagnostic value behaved identically, ruling out token-format validation.

The production UI currently uses that same top-level action shape, so authenticated deployments with disabled plugin secret references cannot self-seed the worker fallback.

## Verification

- focused Board-access fallback tests: 4 passed
- typecheck passed
- build-policy tests: 5 passed
- TypeScript tests: 301 passed
- production build passed
- `git diff --check` passed

Production remains unchanged.

---
###### ✨ This message was AI-generated using gpt-5.6-sol
