### PR TITLE
Trust only host config for secret-ref sync status

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -23073,11 +23073,14 @@ const plugin = definePlugin({
       const saved = await ctx.state.get(SETTINGS_SCOPE);
       const importRegistry = normalizeImportRegistry(await ctx.state.get(IMPORT_REGISTRY_SCOPE));
       const normalizedSettings = normalizeSettings(saved);
-      const config = await getResolvedConfig(ctx);
+      const [config, trustedConfig] = await Promise.all([
+        getResolvedConfig(ctx),
+        ctx.config.get().then((value) => normalizeConfig(value))
+      ]);
       const githubTokenConfigured = hasConfiguredGithubToken(normalizedSettings, config, requestedCompanyId);
-      const configuredGitHubTokenRef = getConfiguredGitHubTokenRef(config, requestedCompanyId);
+      const configuredGitHubTokenRef = getConfiguredGitHubTokenRef(trustedConfig, requestedCompanyId);
       const savedGitHubTokenRef = getSavedGitHubTokenRef(normalizedSettings, requestedCompanyId);
-      const configuredBoardTokenRef = getConfiguredPaperclipBoardApiTokenRef(config, requestedCompanyId);
+      const configuredBoardTokenRef = getConfiguredPaperclipBoardApiTokenRef(trustedConfig, requestedCompanyId);
       const savedBoardTokenRef = getSavedPaperclipBoardApiTokenRef(normalizedSettings, requestedCompanyId);
       const settingsForResponse = sanitizeSettingsForCurrentSetup(
         materializeScopedSettings(normalizedSettings, config, requestedCompanyId),
@@ -23111,7 +23114,9 @@ const plugin = definePlugin({
         ...(savedGitHubTokenRef ? { githubTokenConfigSyncRef: savedGitHubTokenRef } : {}),
         githubTokenNeedsConfigSync: Boolean(savedGitHubTokenRef && configuredGitHubTokenRef !== savedGitHubTokenRef),
         ...(savedBoardTokenRef ? { paperclipBoardAccessConfigSyncRef: savedBoardTokenRef } : {}),
-        paperclipBoardAccessNeedsConfigSync: Boolean(savedBoardTokenRef && !configuredBoardTokenRef)
+        paperclipBoardAccessNeedsConfigSync: Boolean(
+          savedBoardTokenRef && configuredBoardTokenRef !== savedBoardTokenRef
+        )
       };
     });
 

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -13599,6 +13599,64 @@ test('settings.registration reports company-specific board access without resolv
   assert.equal(resolveCount, 0);
 });
 
+test('settings.registration does not treat an external board secret ref as trusted config sync', { concurrency: false }, async () => {
+  await withTemporaryPaperclipHome(async ({ configFilePath }) => {
+    await mkdir(dirname(configFilePath), { recursive: true });
+    await writeFile(
+      configFilePath,
+      JSON.stringify({
+        paperclipBoardApiTokenRefs: {
+          'company-1': 'board-secret-ref'
+        }
+      }),
+      'utf8'
+    );
+
+    const harness = createTestHarness({ manifest });
+    await plugin.definition.setup(harness.ctx);
+    await harness.performAction('settings.updateBoardAccess', {
+      companyId: 'company-1',
+      paperclipBoardApiTokenRef: 'board-secret-ref'
+    });
+
+    const result = await harness.getData<{
+      paperclipBoardAccessNeedsConfigSync?: boolean;
+      paperclipBoardAccessConfigSyncRef?: string;
+    }>('settings.registration', {
+      companyId: 'company-1'
+    });
+
+    assert.equal(result.paperclipBoardAccessNeedsConfigSync, true);
+    assert.equal(result.paperclipBoardAccessConfigSyncRef, 'board-secret-ref');
+  });
+});
+
+test('settings.registration requests config sync when the trusted board secret ref differs', async () => {
+  const harness = createTestHarness({
+    manifest,
+    config: {
+      paperclipBoardApiTokenRefs: {
+        'company-1': 'old-board-secret-ref'
+      }
+    }
+  });
+  await plugin.definition.setup(harness.ctx);
+  await harness.performAction('settings.updateBoardAccess', {
+    companyId: 'company-1',
+    paperclipBoardApiTokenRef: 'new-board-secret-ref'
+  });
+
+  const result = await harness.getData<{
+    paperclipBoardAccessNeedsConfigSync?: boolean;
+    paperclipBoardAccessConfigSyncRef?: string;
+  }>('settings.registration', {
+    companyId: 'company-1'
+  });
+
+  assert.equal(result.paperclipBoardAccessNeedsConfigSync, true);
+  assert.equal(result.paperclipBoardAccessConfigSyncRef, 'new-board-secret-ref');
+});
+
 test('settings.updateBoardAccess persists a company-specific board access identity label and exposes Me as an assignee option', async () => {
   const harness = createTestHarness({ manifest });
   await plugin.definition.setup(harness.ctx);


### PR DESCRIPTION
## Summary

- compute GitHub and Board secret-ref config-sync status from trusted host plugin configuration only
- prevent worker-local external config refs from masquerading as mirrored host configuration
- request Board config repair when the trusted ref differs, not only when it is absent

## Why

The worker-local fallback file is intentionally untrusted for deciding whether the UI has mirrored a secret reference into host plugin configuration. Treating the merged external config as authoritative could suppress the repair signal and leave fallback credentials in place indefinitely.

## Validation

- focused config-sync regressions: 4/4 passed
- TypeScript typecheck passed
- build-policy tests: 5/5 passed
- TypeScript tests: 303/303 passed
- production build passed
- `git diff --check` passed

## Staging plan

1. deploy only the official release to frozen staging
2. confirm registration requests config sync while only the fallback carries the ref
3. mirror the ref through supported host config
4. confirm the repair signal clears and label/status sync remains authenticated
5. repeat idempotency and cleanup assertions

---
###### ✨ This message was AI-generated using gpt-5.6-sol
