### PR TITLE
Fix effective CI attempt aggregation

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1162,6 +1162,13 @@ type GitHubCiContextNode =
       conclusion?: string | null;
       startedAt?: string | null;
       completedAt?: string | null;
+      checkSuite?: {
+        createdAt?: string | null;
+        app?: {
+          id?: string | null;
+          slug?: string | null;
+        } | null;
+      } | null;
     }
   | {
       __typename?: 'StatusContext';
@@ -1613,6 +1620,13 @@ const GITHUB_PULL_REQUEST_CI_CONTEXTS_QUERY = `
                 conclusion
                 startedAt
                 completedAt
+                checkSuite {
+                  createdAt
+                  app {
+                    id
+                    slug
+                  }
+                }
               }
               ... on StatusContext {
                 context
@@ -1697,6 +1711,13 @@ const GITHUB_REPOSITORY_OPEN_PULL_REQUEST_STATUSES_QUERY = `
                   conclusion
                   startedAt
                   completedAt
+                  checkSuite {
+                    createdAt
+                    app {
+                      id
+                      slug
+                    }
+                  }
                 }
                 ... on StatusContext {
                   context
@@ -1799,6 +1820,13 @@ const GITHUB_PROJECT_PULL_REQUEST_INSIGHT_FIELDS = `
                   conclusion
                   startedAt
                   completedAt
+                  checkSuite {
+                    createdAt
+                    app {
+                      id
+                      slug
+                    }
+                  }
                 }
                 ... on StatusContext {
                   context
@@ -1862,6 +1890,13 @@ const GITHUB_PROJECT_PULL_REQUEST_METRICS_FIELDS = `
                   conclusion
                   startedAt
                   completedAt
+                  checkSuite {
+                    createdAt
+                    app {
+                      id
+                      slug
+                    }
+                  }
                 }
                 ... on StatusContext {
                   context
@@ -7763,10 +7798,12 @@ function sliceProjectPullRequestNumbers(
 }
 
 function getGitHubCiContextAttemptTimestamp(context: GitHubCiContextRecord): number | undefined {
-  const value = context.completedAt
-    ?? context.updatedAt
-    ?? context.startedAt
-    ?? context.createdAt;
+  const value = context.type === 'checkRun'
+    // Completion time is not attempt order: an older long-running check can finish
+    // after a newer check. A queued check without start/suite creation time remains
+    // ungrouped below rather than being allowed to hide another attempt.
+    ? context.startedAt ?? context.createdAt
+    : context.updatedAt ?? context.createdAt;
   if (!value) {
     return undefined;
   }
@@ -9180,15 +9217,25 @@ function extractGitHubCiContextRecords(
     }
 
     if (node.__typename === 'CheckRun') {
+      const app = node.checkSuite?.app;
+      const appId = typeof app?.id === 'string' && app.id.trim() ? app.id.trim() : undefined;
+      const appSlug = typeof app?.slug === 'string' && app.slug.trim() ? app.slug.trim() : undefined;
+      const producerIdentity = appId
+        ? `app:${appId}`
+        : appSlug
+          ? `appSlug:${appSlug}`
+          : undefined;
+
       contexts.push({
         type: 'checkRun',
-        ...(typeof node.name === 'string' && node.name.trim()
-          ? { identity: `checkRun:${node.name.trim()}` }
+        ...(typeof node.name === 'string' && node.name.trim() && producerIdentity
+          ? { identity: `checkRun:${producerIdentity}:${node.name.trim()}` }
           : {}),
         status: node.status ?? undefined,
         conclusion: node.conclusion ?? undefined,
         startedAt: node.startedAt ?? undefined,
-        completedAt: node.completedAt ?? undefined
+        completedAt: node.completedAt ?? undefined,
+        createdAt: node.checkSuite?.createdAt ?? undefined
       });
       continue;
     }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -976,18 +976,7 @@ interface GitHubPullRequestCiContextsQueryResult {
       statusCheckRollup?: {
         contexts?: {
           pageInfo?: GitHubPageInfo | null;
-          nodes?: Array<
-            | {
-                __typename?: 'CheckRun';
-                status?: string | null;
-                conclusion?: string | null;
-              }
-            | {
-                __typename?: 'StatusContext';
-                state?: string | null;
-              }
-            | null
-          > | null;
+          nodes?: Array<GitHubCiContextNode | null> | null;
         } | null;
       } | null;
     } | null;
@@ -1037,18 +1026,7 @@ interface GitHubRepositoryOpenPullRequestStatusesQueryResult {
         statusCheckRollup?: {
           contexts?: {
             pageInfo?: GitHubPageInfo | null;
-            nodes?: Array<
-              | {
-                  __typename?: 'CheckRun';
-                  status?: string | null;
-                  conclusion?: string | null;
-                }
-              | {
-                  __typename?: 'StatusContext';
-                  state?: string | null;
-                }
-              | null
-            > | null;
+            nodes?: Array<GitHubCiContextNode | null> | null;
           } | null;
         } | null;
       } | null> | null;
@@ -1166,10 +1144,32 @@ interface GitHubRequestPullRequestCopilotReviewMutationResult {
 
 interface GitHubCiContextRecord {
   type: 'checkRun' | 'statusContext';
+  identity?: string;
   status?: string;
   conclusion?: string;
   state?: string;
+  startedAt?: string;
+  completedAt?: string;
+  createdAt?: string;
+  updatedAt?: string;
 }
+
+type GitHubCiContextNode =
+  | {
+      __typename?: 'CheckRun';
+      name?: string | null;
+      status?: string | null;
+      conclusion?: string | null;
+      startedAt?: string | null;
+      completedAt?: string | null;
+    }
+  | {
+      __typename?: 'StatusContext';
+      context?: string | null;
+      state?: string | null;
+      createdAt?: string | null;
+      updatedAt?: string | null;
+    };
 
 interface GitHubIssueCommentRecord {
   id: number;
@@ -1424,18 +1424,7 @@ interface GitHubProjectPullRequestsQueryResult {
         statusCheckRollup?: {
           contexts?: {
             pageInfo?: GitHubPageInfo | null;
-            nodes?: Array<
-              | {
-                  __typename?: 'CheckRun';
-                  status?: string | null;
-                  conclusion?: string | null;
-                }
-              | {
-                  __typename?: 'StatusContext';
-                  state?: string | null;
-                }
-              | null
-            > | null;
+            nodes?: Array<GitHubCiContextNode | null> | null;
           } | null;
         } | null;
       } | null> | null;
@@ -1488,18 +1477,7 @@ interface GitHubProjectPullRequestMetricsQueryResult {
         statusCheckRollup?: {
           contexts?: {
             pageInfo?: GitHubPageInfo | null;
-            nodes?: Array<
-              | {
-                  __typename?: 'CheckRun';
-                  status?: string | null;
-                  conclusion?: string | null;
-                }
-              | {
-                  __typename?: 'StatusContext';
-                  state?: string | null;
-                }
-              | null
-            > | null;
+            nodes?: Array<GitHubCiContextNode | null> | null;
           } | null;
         } | null;
       } | null> | null;
@@ -1630,11 +1608,17 @@ const GITHUB_PULL_REQUEST_CI_CONTEXTS_QUERY = `
             nodes {
               __typename
               ... on CheckRun {
+                name
                 status
                 conclusion
+                startedAt
+                completedAt
               }
               ... on StatusContext {
+                context
                 state
+                createdAt
+                updatedAt
               }
             }
           }
@@ -1708,11 +1692,17 @@ const GITHUB_REPOSITORY_OPEN_PULL_REQUEST_STATUSES_QUERY = `
               nodes {
                 __typename
                 ... on CheckRun {
+                  name
                   status
                   conclusion
+                  startedAt
+                  completedAt
                 }
                 ... on StatusContext {
+                  context
                   state
+                  createdAt
+                  updatedAt
                 }
               }
             }
@@ -1804,11 +1794,17 @@ const GITHUB_PROJECT_PULL_REQUEST_INSIGHT_FIELDS = `
               nodes {
                 __typename
                 ... on CheckRun {
+                  name
                   status
                   conclusion
+                  startedAt
+                  completedAt
                 }
                 ... on StatusContext {
+                  context
                   state
+                  createdAt
+                  updatedAt
                 }
               }
             }
@@ -1861,11 +1857,17 @@ const GITHUB_PROJECT_PULL_REQUEST_METRICS_FIELDS = `
               nodes {
                 __typename
                 ... on CheckRun {
+                  name
                   status
                   conclusion
+                  startedAt
+                  completedAt
                 }
                 ... on StatusContext {
+                  context
                   state
+                  createdAt
+                  updatedAt
                 }
               }
             }
@@ -7760,14 +7762,62 @@ function sliceProjectPullRequestNumbers(
   };
 }
 
+function getGitHubCiContextAttemptTimestamp(context: GitHubCiContextRecord): number | undefined {
+  const value = context.completedAt
+    ?? context.updatedAt
+    ?? context.startedAt
+    ?? context.createdAt;
+  if (!value) {
+    return undefined;
+  }
+
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : undefined;
+}
+
+function getEffectiveGitHubCiContexts(contexts: GitHubCiContextRecord[]): GitHubCiContextRecord[] {
+  const ungroupedContexts: GitHubCiContextRecord[] = [];
+  const latestContexts = new Map<string, { context: GitHubCiContextRecord; timestamp: number }>();
+
+  for (const context of contexts) {
+    const timestamp = getGitHubCiContextAttemptTimestamp(context);
+    if (!context.identity || timestamp === undefined) {
+      // Without both a stable check identity and an ordering timestamp, retaining the
+      // context is safer than accidentally hiding a distinct required check.
+      ungroupedContexts.push(context);
+      continue;
+    }
+
+    const existing = latestContexts.get(context.identity);
+    if (!existing) {
+      latestContexts.set(context.identity, { context, timestamp });
+      continue;
+    }
+
+    if (timestamp > existing.timestamp) {
+      latestContexts.set(context.identity, { context, timestamp });
+      continue;
+    }
+
+    if (timestamp === existing.timestamp) {
+      // GitHub can report separate checks with an equal timestamp. Keep both unless
+      // the API gives us enough ordering evidence to prove one supersedes the other.
+      ungroupedContexts.push(context);
+    }
+  }
+
+  return [...ungroupedContexts, ...[...latestContexts.values()].map(({ context }) => context)];
+}
+
 function classifyGitHubPullRequestCiState(contexts: GitHubCiContextRecord[]): GitHubPullRequestCiState {
-  if (contexts.length === 0) {
+  const effectiveContexts = getEffectiveGitHubCiContexts(contexts);
+  if (effectiveContexts.length === 0) {
     return 'unfinished';
   }
 
   let hasPendingContext = false;
 
-  for (const context of contexts) {
+  for (const context of effectiveContexts) {
     if (context.type === 'statusContext') {
       const state = context.state?.toUpperCase();
       if (!state) {
@@ -9120,18 +9170,7 @@ async function loadLinkedPullRequestsForOpenIssues(
 }
 
 function extractGitHubCiContextRecords(
-  nodes: Array<
-    | {
-        __typename?: 'CheckRun';
-        status?: string | null;
-        conclusion?: string | null;
-      }
-    | {
-        __typename?: 'StatusContext';
-        state?: string | null;
-      }
-    | null
-  >
+  nodes: Array<GitHubCiContextNode | null>
 ): GitHubCiContextRecord[] {
   const contexts: GitHubCiContextRecord[] = [];
 
@@ -9143,8 +9182,13 @@ function extractGitHubCiContextRecords(
     if (node.__typename === 'CheckRun') {
       contexts.push({
         type: 'checkRun',
+        ...(typeof node.name === 'string' && node.name.trim()
+          ? { identity: `checkRun:${node.name.trim()}` }
+          : {}),
         status: node.status ?? undefined,
-        conclusion: node.conclusion ?? undefined
+        conclusion: node.conclusion ?? undefined,
+        startedAt: node.startedAt ?? undefined,
+        completedAt: node.completedAt ?? undefined
       });
       continue;
     }
@@ -9152,7 +9196,12 @@ function extractGitHubCiContextRecords(
     if (node.__typename === 'StatusContext') {
       contexts.push({
         type: 'statusContext',
-        state: node.state ?? undefined
+        ...(typeof node.context === 'string' && node.context.trim()
+          ? { identity: `statusContext:${node.context.trim()}` }
+          : {}),
+        state: node.state ?? undefined,
+        createdAt: node.createdAt ?? undefined,
+        updatedAt: node.updatedAt ?? undefined
       });
     }
   }
@@ -9318,18 +9367,7 @@ function tryBuildGitHubPullRequestStatusSnapshotFromBatchNode(node: {
   statusCheckRollup?: {
     contexts?: {
       pageInfo?: GitHubPageInfo | null;
-      nodes?: Array<
-        | {
-            __typename?: 'CheckRun';
-            status?: string | null;
-            conclusion?: string | null;
-          }
-        | {
-            __typename?: 'StatusContext';
-            state?: string | null;
-          }
-        | null
-      > | null;
+      nodes?: Array<GitHubCiContextNode | null> | null;
     } | null;
   } | null;
 }, repository: ParsedRepositoryReference): GitHubPullRequestStatusSnapshot | null {
@@ -9363,18 +9401,7 @@ function tryBuildGitHubPullRequestCiStateFromBatchNode(node: {
   statusCheckRollup?: {
     contexts?: {
       pageInfo?: GitHubPageInfo | null;
-      nodes?: Array<
-        | {
-            __typename?: 'CheckRun';
-            status?: string | null;
-            conclusion?: string | null;
-          }
-        | {
-            __typename?: 'StatusContext';
-            state?: string | null;
-          }
-        | null
-      > | null;
+      nodes?: Array<GitHubCiContextNode | null> | null;
     } | null;
   } | null;
 }): GitHubPullRequestCiState | null {
@@ -9482,28 +9509,7 @@ async function getGitHubPullRequestCiSnapshot(
     }
 
     const connection = response.repository?.pullRequest?.statusCheckRollup?.contexts;
-    const nodes = connection?.nodes ?? [];
-    for (const node of nodes) {
-      if (!node?.__typename) {
-        continue;
-      }
-
-      if (node.__typename === 'CheckRun') {
-        contexts.push({
-          type: 'checkRun',
-          status: node.status ?? undefined,
-          conclusion: node.conclusion ?? undefined
-        });
-        continue;
-      }
-
-      if (node.__typename === 'StatusContext') {
-        contexts.push({
-          type: 'statusContext',
-          state: node.state ?? undefined
-        });
-      }
-    }
+    contexts.push(...extractGitHubCiContextRecords(connection?.nodes ?? []));
 
     after = getPageCursor(connection?.pageInfo);
   } while (after);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1168,6 +1168,11 @@ type GitHubCiContextNode =
           id?: string | null;
           slug?: string | null;
         } | null;
+        workflowRun?: {
+          workflow?: {
+            id?: string | null;
+          } | null;
+        } | null;
       } | null;
     }
   | {
@@ -1626,6 +1631,11 @@ const GITHUB_PULL_REQUEST_CI_CONTEXTS_QUERY = `
                     id
                     slug
                   }
+                  workflowRun {
+                    workflow {
+                      id
+                    }
+                  }
                 }
               }
               ... on StatusContext {
@@ -1713,10 +1723,15 @@ const GITHUB_REPOSITORY_OPEN_PULL_REQUEST_STATUSES_QUERY = `
                   completedAt
                   checkSuite {
                     createdAt
-                    app {
+                  app {
+                    id
+                    slug
+                  }
+                  workflowRun {
+                    workflow {
                       id
-                      slug
                     }
+                  }
                   }
                 }
                 ... on StatusContext {
@@ -1822,10 +1837,15 @@ const GITHUB_PROJECT_PULL_REQUEST_INSIGHT_FIELDS = `
                   completedAt
                   checkSuite {
                     createdAt
-                    app {
+                  app {
+                    id
+                    slug
+                  }
+                  workflowRun {
+                    workflow {
                       id
-                      slug
                     }
+                  }
                   }
                 }
                 ... on StatusContext {
@@ -1892,10 +1912,15 @@ const GITHUB_PROJECT_PULL_REQUEST_METRICS_FIELDS = `
                   completedAt
                   checkSuite {
                     createdAt
-                    app {
+                  app {
+                    id
+                    slug
+                  }
+                  workflowRun {
+                    workflow {
                       id
-                      slug
                     }
+                  }
                   }
                 }
                 ... on StatusContext {
@@ -7814,7 +7839,7 @@ function getGitHubCiContextAttemptTimestamp(context: GitHubCiContextRecord): num
 
 function getEffectiveGitHubCiContexts(contexts: GitHubCiContextRecord[]): GitHubCiContextRecord[] {
   const ungroupedContexts: GitHubCiContextRecord[] = [];
-  const latestContexts = new Map<string, { context: GitHubCiContextRecord; timestamp: number }>();
+  const latestContexts = new Map<string, { contexts: GitHubCiContextRecord[]; timestamp: number }>();
 
   for (const context of contexts) {
     const timestamp = getGitHubCiContextAttemptTimestamp(context);
@@ -7827,23 +7852,24 @@ function getEffectiveGitHubCiContexts(contexts: GitHubCiContextRecord[]): GitHub
 
     const existing = latestContexts.get(context.identity);
     if (!existing) {
-      latestContexts.set(context.identity, { context, timestamp });
+      latestContexts.set(context.identity, { contexts: [context], timestamp });
       continue;
     }
 
     if (timestamp > existing.timestamp) {
-      latestContexts.set(context.identity, { context, timestamp });
+      latestContexts.set(context.identity, { contexts: [context], timestamp });
       continue;
     }
 
     if (timestamp === existing.timestamp) {
-      // GitHub can report separate checks with an equal timestamp. Keep both unless
-      // the API gives us enough ordering evidence to prove one supersedes the other.
-      ungroupedContexts.push(context);
+      // GitHub can report separate checks with an equal timestamp. They are all
+      // current attempts only when the tie is at the latest timestamp for this
+      // identity; older tied attempts were superseded and must not affect CI state.
+      existing.contexts.push(context);
     }
   }
 
-  return [...ungroupedContexts, ...[...latestContexts.values()].map(({ context }) => context)];
+  return [...ungroupedContexts, ...[...latestContexts.values()].flatMap(({ contexts: latest }) => latest)];
 }
 
 function classifyGitHubPullRequestCiState(contexts: GitHubCiContextRecord[]): GitHubPullRequestCiState {
@@ -9226,10 +9252,14 @@ function extractGitHubCiContextRecords(
           ? `appSlug:${appSlug}`
           : undefined;
 
+      const workflowId = node.checkSuite?.workflowRun?.workflow?.id?.trim();
       contexts.push({
         type: 'checkRun',
-        ...(typeof node.name === 'string' && node.name.trim() && producerIdentity
-          ? { identity: `checkRun:${producerIdentity}:${node.name.trim()}` }
+        // A rendered check name is stable only within its producer and workflow.
+        // If GitHub omits workflow provenance, retain the context instead of
+        // accidentally hiding a distinct required check with the same name.
+        ...(typeof node.name === 'string' && node.name.trim() && producerIdentity && workflowId
+          ? { identity: `checkRun:${producerIdentity}:${workflowId}:${node.name.trim()}` }
           : {}),
         status: node.status ?? undefined,
         conclusion: node.conclusion ?? undefined,

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -4647,7 +4647,7 @@ test('update_pull_request refreshes the AI footer when updating the pull request
         number: 7,
         title: 'Fix the importer',
         body: updatedBody,
-        html_url: `https://github.com/paperclipai/example-repo/pull/${pullRequestNumber}`,
+        html_url: 'https://github.com/paperclipai/example-repo/pull/7',
         state: 'open',
         draft: false,
         merged: false,
@@ -4920,7 +4920,7 @@ test('get_pull_request_checks returns CI jobs, status contexts, and workflow run
       return jsonResponse({
         number: pullRequestNumber,
         title: 'Fix the importer',
-        html_url: 'https://github.com/paperclipai/example-repo/pull/7',
+        html_url: `https://github.com/paperclipai/example-repo/pull/${pullRequestNumber}`,
         state: 'open',
         draft: false,
         merged: false,

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -4858,13 +4858,67 @@ test('tracked issue mutations attribute linked targets omitted from tool input',
 test('get_pull_request_checks returns CI jobs, status contexts, and workflow runs', async () => {
   const harness = await createGitHubAgentToolHarness();
   const originalFetch = globalThis.fetch;
+  const ciContextsByPullRequest = new Map<number, Array<Record<string, string | null>>>([[7, [
+    {
+      __typename: 'CheckRun',
+      name: 'Application generation UI',
+      status: 'COMPLETED',
+      conclusion: 'FAILURE',
+      startedAt: '2026-04-12T09:00:00Z',
+      completedAt: '2026-04-12T09:10:00Z'
+    },
+    {
+      __typename: 'CheckRun',
+      name: 'Application generation UI',
+      status: 'COMPLETED',
+      conclusion: 'FAILURE',
+      startedAt: '2026-04-12T10:00:00Z',
+      completedAt: '2026-04-12T10:10:00Z'
+    },
+    {
+      __typename: 'CheckRun',
+      name: 'Application generation UI',
+      status: 'COMPLETED',
+      conclusion: 'SUCCESS',
+      startedAt: '2026-04-12T11:00:00Z',
+      completedAt: '2026-04-12T11:10:00Z'
+    }
+  ]], [8, [
+    {
+      __typename: 'CheckRun', name: 'Application generation UI', status: 'COMPLETED', conclusion: 'SUCCESS',
+      startedAt: '2026-04-12T11:00:00Z', completedAt: '2026-04-12T11:10:00Z'
+    },
+    {
+      __typename: 'CheckRun', name: 'Application generation UI', status: 'COMPLETED', conclusion: 'FAILURE',
+      startedAt: '2026-04-12T12:00:00Z', completedAt: '2026-04-12T12:10:00Z'
+    }
+  ]], [9, [
+    {
+      __typename: 'CheckRun', name: 'Application generation UI', status: 'COMPLETED', conclusion: 'FAILURE',
+      startedAt: '2026-04-12T12:00:00Z', completedAt: '2026-04-12T12:10:00Z'
+    },
+    {
+      __typename: 'CheckRun', name: 'Application generation UI', status: 'IN_PROGRESS', conclusion: null,
+      startedAt: '2026-04-12T13:00:00Z', completedAt: null
+    }
+  ]], [10, [
+    {
+      __typename: 'CheckRun', name: 'test (ubuntu)', status: 'COMPLETED', conclusion: 'SUCCESS',
+      startedAt: '2026-04-12T14:00:00Z', completedAt: '2026-04-12T14:10:00Z'
+    },
+    {
+      __typename: 'CheckRun', name: 'test (windows)', status: 'COMPLETED', conclusion: 'FAILURE',
+      startedAt: '2026-04-12T14:00:00Z', completedAt: '2026-04-12T14:10:00Z'
+    }
+  ]]]);
 
   globalThis.fetch = async (input, init) => {
     const url = new URL(getRequestUrl(input));
 
-    if (url.pathname === '/repos/paperclipai/example-repo/pulls/7') {
+    const pullRequestNumber = Number(url.pathname.match(/\/pulls\/(\d+)$/)?.[1]);
+    if ([7, 8, 9, 10].includes(pullRequestNumber)) {
       return jsonResponse({
-        number: 7,
+        number: pullRequestNumber,
         title: 'Fix the importer',
         html_url: 'https://github.com/paperclipai/example-repo/pull/7',
         state: 'open',
@@ -4874,7 +4928,7 @@ test('get_pull_request_checks returns CI jobs, status contexts, and workflow run
         mergeable_state: 'clean',
         head: {
           ref: 'feature/fix-importer',
-          sha: 'abc123'
+          sha: `abc${pullRequestNumber}`
         },
         base: {
           ref: 'main'
@@ -4887,7 +4941,7 @@ test('get_pull_request_checks returns CI jobs, status contexts, and workflow run
       });
     }
 
-    if (url.pathname === '/repos/paperclipai/example-repo/commits/abc123/check-runs') {
+    if (/\/repos\/paperclipai\/example-repo\/commits\/abc(?:7|8|9|10)\/check-runs$/.test(url.pathname)) {
       return jsonResponse({
         total_count: 1,
         check_runs: [
@@ -4907,7 +4961,7 @@ test('get_pull_request_checks returns CI jobs, status contexts, and workflow run
       });
     }
 
-    if (url.pathname === '/repos/paperclipai/example-repo/commits/abc123/status') {
+    if (/\/repos\/paperclipai\/example-repo\/commits\/abc(?:7|8|9|10)\/status$/.test(url.pathname)) {
       return jsonResponse({
         state: 'failure',
         statuses: [
@@ -4924,7 +4978,7 @@ test('get_pull_request_checks returns CI jobs, status contexts, and workflow run
     }
 
     if (url.pathname === '/repos/paperclipai/example-repo/actions/runs') {
-      assert.equal(url.searchParams.get('head_sha'), 'abc123');
+      assert.match(url.searchParams.get('head_sha') ?? '', /^abc(?:7|8|9|10)$/);
       return jsonResponse({
         total_count: 1,
         workflow_runs: [
@@ -4944,7 +4998,7 @@ test('get_pull_request_checks returns CI jobs, status contexts, and workflow run
     }
 
     if (url.pathname === '/graphql') {
-      const { query } = getGraphqlRequest(init);
+      const { query, variables } = getGraphqlRequest(init);
       if (query.includes('query GitHubPullRequestReviewThreads')) {
         return graphqlResponse({
           repository: {
@@ -4987,13 +5041,7 @@ test('get_pull_request_checks returns CI jobs, status contexts, and workflow run
                     hasNextPage: false,
                     endCursor: null
                   },
-                  nodes: [
-                    {
-                      __typename: 'CheckRun',
-                      status: 'COMPLETED',
-                      conclusion: 'FAILURE'
-                    }
-                  ]
+                  nodes: ciContextsByPullRequest.get(variables.pullRequestNumber as number) ?? []
                 }
               }
             }
@@ -5021,11 +5069,26 @@ test('get_pull_request_checks returns CI jobs, status contexts, and workflow run
       statusContexts: Array<{ context: string }>;
       workflowRuns: Array<{ id: number }>;
     };
-    assert.equal(data.ciState, 'red');
+    assert.equal(data.ciState, 'green');
     assert.equal(data.hasUnresolvedReviewThreads, true);
     assert.equal(data.checkRuns[0]?.id, 301);
     assert.equal(data.statusContexts[0]?.context, 'lint');
     assert.equal(data.workflowRuns[0]?.id, 401);
+
+    const newerFailure = await harness.executeTool('get_pull_request_checks', { pullRequestNumber: 8 }, {
+      companyId: 'company-1', projectId: 'project-1'
+    });
+    assert.equal((newerFailure.data as { ciState: string }).ciState, 'red');
+
+    const newerPendingAttempt = await harness.executeTool('get_pull_request_checks', { pullRequestNumber: 9 }, {
+      companyId: 'company-1', projectId: 'project-1'
+    });
+    assert.equal((newerPendingAttempt.data as { ciState: string }).ciState, 'unfinished');
+
+    const distinctMatrixFailure = await harness.executeTool('get_pull_request_checks', { pullRequestNumber: 10 }, {
+      companyId: 'company-1', projectId: 'project-1'
+    });
+    assert.equal((distinctMatrixFailure.data as { ciState: string }).ciState, 'red');
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -9465,7 +9528,24 @@ test('sync.runNow leaves completed direct pull request reviews in an unassigned 
                       nodes: [
                         {
                           __typename: 'StatusContext',
-                          state: 'SUCCESS'
+                          context: 'deployment',
+                          state: 'FAILURE',
+                          createdAt: '2026-04-12T09:00:00Z',
+                          updatedAt: '2026-04-12T09:10:00Z'
+                        },
+                        {
+                          __typename: 'StatusContext',
+                          context: 'deployment',
+                          state: 'FAILURE',
+                          createdAt: '2026-04-12T10:00:00Z',
+                          updatedAt: '2026-04-12T10:10:00Z'
+                        },
+                        {
+                          __typename: 'StatusContext',
+                          context: 'deployment',
+                          state: 'SUCCESS',
+                          createdAt: '2026-04-12T11:00:00Z',
+                          updatedAt: '2026-04-12T11:10:00Z'
                         }
                       ]
                     }
@@ -9509,7 +9589,24 @@ test('sync.runNow leaves completed direct pull request reviews in an unassigned 
                   nodes: [
                     {
                       __typename: 'StatusContext',
-                      state: 'SUCCESS'
+                      context: 'deployment',
+                      state: 'FAILURE',
+                      createdAt: '2026-04-12T09:00:00Z',
+                      updatedAt: '2026-04-12T09:10:00Z'
+                    },
+                    {
+                      __typename: 'StatusContext',
+                      context: 'deployment',
+                      state: 'FAILURE',
+                      createdAt: '2026-04-12T10:00:00Z',
+                      updatedAt: '2026-04-12T10:10:00Z'
+                    },
+                    {
+                      __typename: 'StatusContext',
+                      context: 'deployment',
+                      state: 'SUCCESS',
+                      createdAt: '2026-04-12T11:00:00Z',
+                      updatedAt: '2026-04-12T11:10:00Z'
                     }
                   ]
                 }

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -4647,7 +4647,7 @@ test('update_pull_request refreshes the AI footer when updating the pull request
         number: 7,
         title: 'Fix the importer',
         body: updatedBody,
-        html_url: 'https://github.com/paperclipai/example-repo/pull/7',
+        html_url: `https://github.com/paperclipai/example-repo/pull/${pullRequestNumber}`,
         state: 'open',
         draft: false,
         merged: false,

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -4858,7 +4858,7 @@ test('tracked issue mutations attribute linked targets omitted from tool input',
 test('get_pull_request_checks returns CI jobs, status contexts, and workflow runs', async () => {
   const harness = await createGitHubAgentToolHarness();
   const originalFetch = globalThis.fetch;
-  const ciContextsByPullRequest = new Map<number, Array<Record<string, string | null>>>([[7, [
+  const ciContextsByPullRequest = new Map<number, Array<Record<string, unknown>>>([[7, [
     {
       __typename: 'CheckRun',
       name: 'Application generation UI',
@@ -4911,12 +4911,46 @@ test('get_pull_request_checks returns CI jobs, status contexts, and workflow run
       startedAt: '2026-04-12T14:00:00Z', completedAt: '2026-04-12T14:10:00Z'
     }
   ]]]);
+  for (const contexts of ciContextsByPullRequest.values()) {
+    for (const context of contexts) {
+      if (context.__typename === 'CheckRun') {
+        context.checkSuite = {
+          createdAt: context.startedAt,
+          app: { id: 'APP_actions', slug: 'github-actions' }
+        };
+      }
+    }
+  }
+  ciContextsByPullRequest.set(11, [
+    {
+      __typename: 'CheckRun', name: 'Application generation UI', status: 'COMPLETED', conclusion: 'FAILURE',
+      startedAt: '2026-04-12T10:00:00Z', completedAt: '2026-04-12T14:00:00Z',
+      checkSuite: { createdAt: '2026-04-12T09:59:00Z', app: { id: 'APP_actions', slug: 'github-actions' } }
+    },
+    {
+      __typename: 'CheckRun', name: 'Application generation UI', status: 'COMPLETED', conclusion: 'SUCCESS',
+      startedAt: '2026-04-12T12:00:00Z', completedAt: '2026-04-12T13:00:00Z',
+      checkSuite: { createdAt: '2026-04-12T11:59:00Z', app: { id: 'APP_actions', slug: 'github-actions' } }
+    }
+  ]);
+  ciContextsByPullRequest.set(12, [
+    {
+      __typename: 'CheckRun', name: 'build', status: 'COMPLETED', conclusion: 'SUCCESS',
+      startedAt: '2026-04-12T12:00:00Z', completedAt: '2026-04-12T12:10:00Z',
+      checkSuite: { createdAt: '2026-04-12T11:59:00Z', app: { id: 'APP_actions', slug: 'github-actions' } }
+    },
+    {
+      __typename: 'CheckRun', name: 'build', status: 'COMPLETED', conclusion: 'FAILURE',
+      startedAt: '2026-04-12T13:00:00Z', completedAt: '2026-04-12T13:10:00Z',
+      checkSuite: { createdAt: '2026-04-12T12:59:00Z', app: { id: 'APP_external_ci', slug: 'external-ci' } }
+    }
+  ]);
 
   globalThis.fetch = async (input, init) => {
     const url = new URL(getRequestUrl(input));
 
     const pullRequestNumber = Number(url.pathname.match(/\/pulls\/(\d+)$/)?.[1]);
-    if ([7, 8, 9, 10].includes(pullRequestNumber)) {
+    if ([7, 8, 9, 10, 11, 12].includes(pullRequestNumber)) {
       return jsonResponse({
         number: pullRequestNumber,
         title: 'Fix the importer',
@@ -4941,7 +4975,7 @@ test('get_pull_request_checks returns CI jobs, status contexts, and workflow run
       });
     }
 
-    if (/\/repos\/paperclipai\/example-repo\/commits\/abc(?:7|8|9|10)\/check-runs$/.test(url.pathname)) {
+    if (/\/repos\/paperclipai\/example-repo\/commits\/abc(?:7|8|9|10|11|12)\/check-runs$/.test(url.pathname)) {
       return jsonResponse({
         total_count: 1,
         check_runs: [
@@ -4961,7 +4995,7 @@ test('get_pull_request_checks returns CI jobs, status contexts, and workflow run
       });
     }
 
-    if (/\/repos\/paperclipai\/example-repo\/commits\/abc(?:7|8|9|10)\/status$/.test(url.pathname)) {
+    if (/\/repos\/paperclipai\/example-repo\/commits\/abc(?:7|8|9|10|11|12)\/status$/.test(url.pathname)) {
       return jsonResponse({
         state: 'failure',
         statuses: [
@@ -4978,7 +5012,7 @@ test('get_pull_request_checks returns CI jobs, status contexts, and workflow run
     }
 
     if (url.pathname === '/repos/paperclipai/example-repo/actions/runs') {
-      assert.match(url.searchParams.get('head_sha') ?? '', /^abc(?:7|8|9|10)$/);
+      assert.match(url.searchParams.get('head_sha') ?? '', /^abc(?:7|8|9|10|11|12)$/);
       return jsonResponse({
         total_count: 1,
         workflow_runs: [
@@ -5089,6 +5123,16 @@ test('get_pull_request_checks returns CI jobs, status contexts, and workflow run
       companyId: 'company-1', projectId: 'project-1'
     });
     assert.equal((distinctMatrixFailure.data as { ciState: string }).ciState, 'red');
+
+    const overlappingAttempts = await harness.executeTool('get_pull_request_checks', { pullRequestNumber: 11 }, {
+      companyId: 'company-1', projectId: 'project-1'
+    });
+    assert.equal((overlappingAttempts.data as { ciState: string }).ciState, 'green');
+
+    const sameNameDifferentProducer = await harness.executeTool('get_pull_request_checks', { pullRequestNumber: 12 }, {
+      companyId: 'company-1', projectId: 'project-1'
+    });
+    assert.equal((sameNameDifferentProducer.data as { ciState: string }).ciState, 'red');
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -4916,7 +4916,8 @@ test('get_pull_request_checks returns CI jobs, status contexts, and workflow run
       if (context.__typename === 'CheckRun') {
         context.checkSuite = {
           createdAt: context.startedAt,
-          app: { id: 'APP_actions', slug: 'github-actions' }
+          app: { id: 'APP_actions', slug: 'github-actions' },
+          workflowRun: { workflow: { id: 'WORKFLOW_CI' } }
         };
       }
     }
@@ -4925,24 +4926,80 @@ test('get_pull_request_checks returns CI jobs, status contexts, and workflow run
     {
       __typename: 'CheckRun', name: 'Application generation UI', status: 'COMPLETED', conclusion: 'FAILURE',
       startedAt: '2026-04-12T10:00:00Z', completedAt: '2026-04-12T14:00:00Z',
-      checkSuite: { createdAt: '2026-04-12T09:59:00Z', app: { id: 'APP_actions', slug: 'github-actions' } }
+      checkSuite: {
+        createdAt: '2026-04-12T09:59:00Z', app: { id: 'APP_actions', slug: 'github-actions' },
+        workflowRun: { workflow: { id: 'WORKFLOW_CI' } }
+      }
     },
     {
       __typename: 'CheckRun', name: 'Application generation UI', status: 'COMPLETED', conclusion: 'SUCCESS',
       startedAt: '2026-04-12T12:00:00Z', completedAt: '2026-04-12T13:00:00Z',
-      checkSuite: { createdAt: '2026-04-12T11:59:00Z', app: { id: 'APP_actions', slug: 'github-actions' } }
+      checkSuite: {
+        createdAt: '2026-04-12T11:59:00Z', app: { id: 'APP_actions', slug: 'github-actions' },
+        workflowRun: { workflow: { id: 'WORKFLOW_CI' } }
+      }
     }
   ]);
   ciContextsByPullRequest.set(12, [
     {
       __typename: 'CheckRun', name: 'build', status: 'COMPLETED', conclusion: 'SUCCESS',
       startedAt: '2026-04-12T12:00:00Z', completedAt: '2026-04-12T12:10:00Z',
-      checkSuite: { createdAt: '2026-04-12T11:59:00Z', app: { id: 'APP_actions', slug: 'github-actions' } }
+      checkSuite: {
+        createdAt: '2026-04-12T11:59:00Z', app: { id: 'APP_actions', slug: 'github-actions' },
+        workflowRun: { workflow: { id: 'WORKFLOW_CI' } }
+      }
     },
     {
       __typename: 'CheckRun', name: 'build', status: 'COMPLETED', conclusion: 'FAILURE',
       startedAt: '2026-04-12T13:00:00Z', completedAt: '2026-04-12T13:10:00Z',
-      checkSuite: { createdAt: '2026-04-12T12:59:00Z', app: { id: 'APP_external_ci', slug: 'external-ci' } }
+      checkSuite: {
+        createdAt: '2026-04-12T12:59:00Z', app: { id: 'APP_external_ci', slug: 'external-ci' },
+        workflowRun: { workflow: { id: 'WORKFLOW_CI' } }
+      }
+    }
+  ]);
+  ciContextsByPullRequest.set(13, [
+    {
+      __typename: 'CheckRun', name: 'verify', status: 'COMPLETED', conclusion: 'FAILURE',
+      startedAt: '2026-04-12T14:00:00Z', completedAt: '2026-04-12T14:10:00Z',
+      checkSuite: {
+        createdAt: '2026-04-12T13:59:00Z', app: { id: 'APP_actions', slug: 'github-actions' },
+        workflowRun: { workflow: { id: 'WORKFLOW_REQUIRED' } }
+      }
+    },
+    {
+      __typename: 'CheckRun', name: 'verify', status: 'COMPLETED', conclusion: 'SUCCESS',
+      startedAt: '2026-04-12T15:00:00Z', completedAt: '2026-04-12T15:10:00Z',
+      checkSuite: {
+        createdAt: '2026-04-12T14:59:00Z', app: { id: 'APP_actions', slug: 'github-actions' },
+        workflowRun: { workflow: { id: 'WORKFLOW_OPTIONAL' } }
+      }
+    }
+  ]);
+  ciContextsByPullRequest.set(14, [
+    {
+      __typename: 'CheckRun', name: 'verify', status: 'COMPLETED', conclusion: 'FAILURE',
+      startedAt: '2026-04-12T14:00:00Z', completedAt: '2026-04-12T14:10:00Z',
+      checkSuite: {
+        createdAt: '2026-04-12T13:59:00Z', app: { id: 'APP_actions', slug: 'github-actions' },
+        workflowRun: { workflow: { id: 'WORKFLOW_CI' } }
+      }
+    },
+    {
+      __typename: 'CheckRun', name: 'verify', status: 'COMPLETED', conclusion: 'FAILURE',
+      startedAt: '2026-04-12T14:00:00Z', completedAt: '2026-04-12T14:11:00Z',
+      checkSuite: {
+        createdAt: '2026-04-12T13:59:00Z', app: { id: 'APP_actions', slug: 'github-actions' },
+        workflowRun: { workflow: { id: 'WORKFLOW_CI' } }
+      }
+    },
+    {
+      __typename: 'CheckRun', name: 'verify', status: 'COMPLETED', conclusion: 'SUCCESS',
+      startedAt: '2026-04-12T15:00:00Z', completedAt: '2026-04-12T15:10:00Z',
+      checkSuite: {
+        createdAt: '2026-04-12T14:59:00Z', app: { id: 'APP_actions', slug: 'github-actions' },
+        workflowRun: { workflow: { id: 'WORKFLOW_CI' } }
+      }
     }
   ]);
 
@@ -4950,7 +5007,7 @@ test('get_pull_request_checks returns CI jobs, status contexts, and workflow run
     const url = new URL(getRequestUrl(input));
 
     const pullRequestNumber = Number(url.pathname.match(/\/pulls\/(\d+)$/)?.[1]);
-    if ([7, 8, 9, 10, 11, 12].includes(pullRequestNumber)) {
+    if ([7, 8, 9, 10, 11, 12, 13, 14].includes(pullRequestNumber)) {
       return jsonResponse({
         number: pullRequestNumber,
         title: 'Fix the importer',
@@ -4975,7 +5032,7 @@ test('get_pull_request_checks returns CI jobs, status contexts, and workflow run
       });
     }
 
-    if (/\/repos\/paperclipai\/example-repo\/commits\/abc(?:7|8|9|10|11|12)\/check-runs$/.test(url.pathname)) {
+    if (/\/repos\/paperclipai\/example-repo\/commits\/abc(?:7|8|9|10|11|12|13|14)\/check-runs$/.test(url.pathname)) {
       return jsonResponse({
         total_count: 1,
         check_runs: [
@@ -4995,7 +5052,7 @@ test('get_pull_request_checks returns CI jobs, status contexts, and workflow run
       });
     }
 
-    if (/\/repos\/paperclipai\/example-repo\/commits\/abc(?:7|8|9|10|11|12)\/status$/.test(url.pathname)) {
+    if (/\/repos\/paperclipai\/example-repo\/commits\/abc(?:7|8|9|10|11|12|13|14)\/status$/.test(url.pathname)) {
       return jsonResponse({
         state: 'failure',
         statuses: [
@@ -5012,7 +5069,7 @@ test('get_pull_request_checks returns CI jobs, status contexts, and workflow run
     }
 
     if (url.pathname === '/repos/paperclipai/example-repo/actions/runs') {
-      assert.match(url.searchParams.get('head_sha') ?? '', /^abc(?:7|8|9|10|11|12)$/);
+      assert.match(url.searchParams.get('head_sha') ?? '', /^abc(?:7|8|9|10|11|12|13|14)$/);
       return jsonResponse({
         total_count: 1,
         workflow_runs: [
@@ -5133,6 +5190,16 @@ test('get_pull_request_checks returns CI jobs, status contexts, and workflow run
       companyId: 'company-1', projectId: 'project-1'
     });
     assert.equal((sameNameDifferentProducer.data as { ciState: string }).ciState, 'red');
+
+    const requiredWorkflowFailure = await harness.executeTool('get_pull_request_checks', { pullRequestNumber: 13 }, {
+      companyId: 'company-1', projectId: 'project-1'
+    });
+    assert.equal((requiredWorkflowFailure.data as { ciState: string }).ciState, 'red');
+
+    const newerAttemptSuccess = await harness.executeTool('get_pull_request_checks', { pullRequestNumber: 14 }, {
+      companyId: 'company-1', projectId: 'project-1'
+    });
+    assert.equal((newerAttemptSuccess.data as { ciState: string }).ciState, 'green');
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
## Summary
- retain check/status identities and timestamps in CI rollup queries
- classify only the latest safely orderable attempt for each identity
- cover superseded failures, newer failures, pending attempts, and matrix checks

## Verification
- pnpm typecheck
- pnpm exec tsx --test --test-name-pattern="get_pull_request_checks returns CI jobs|leaves completed direct pull request reviews" tests/plugin.spec.ts
- pnpm build